### PR TITLE
EDU407-21: Safari: Shipping step opens if user buys virtual product and taps back on billing step #1674

### DIFF
--- a/src/app/route/Checkout/Checkout.container.js
+++ b/src/app/route/Checkout/Checkout.container.js
@@ -276,14 +276,11 @@ export class CheckoutContainer extends PureComponent {
         const { checkoutStep } = this.state;
 
         if (checkoutStep === BILLING_STEP) {
-            this.setState({
-                isLoading: false,
-                checkoutStep: SHIPPING_STEP
-            });
-
             BrowserDatabase.deleteItem(PAYMENT_TOTALS);
-        }
+            history.push('/default/cart');
 
+            return;
+        }
         history.goBack();
     }
 


### PR DESCRIPTION
Fix for https://github.com/scandipwa/scandipwa/issues/1674
-  fixed by adding history.push call

With the current fix, we got inconsistent behavior on the back button in mobile and desktop view.
Mobile back leads to the cart page, desktop to the shipping page.
Is it expected behavior?