### PR TITLE
issue #1783 Mozzila arrow by sort appears at middle

### DIFF
--- a/src/app/component/CategorySort/CategorySort.style.scss
+++ b/src/app/component/CategorySort/CategorySort.style.scss
@@ -46,7 +46,7 @@
         &::after {
             @include before-desktop {
                 left: 55px;
-                bottom: 22px;
+                top: -22px;
             }
         }
 


### PR DESCRIPTION
#https://github.com/scandipwa/scandipwa/issues/1783

On mozzila arrow by "sort by" now appears at middle