### PR TITLE
SWPWA - 1520 - Fix linked products double-quoting + slider issue

### DIFF
--- a/src/app/component/ProductGallery/ProductGallery.component.js
+++ b/src/app/component/ProductGallery/ProductGallery.component.js
@@ -95,7 +95,7 @@ export class ProductGallery extends PureComponent {
             this.updateSharedDestinationElement();
         }
 
-        if (sliderRef && pathname !== prevPathname) {
+        if (sliderRef.current.draggableRef && pathname !== prevPathname) {
             CSS.setVariable(
                 sliderRef.current.draggableRef,
                 'animation-speed',

--- a/src/app/store/LinkedProducts/LinkedProducts.dispatcher.js
+++ b/src/app/store/LinkedProducts/LinkedProducts.dispatcher.js
@@ -74,7 +74,7 @@ export class LinkedProductsDispatcher extends QueryDispatcher {
     prepareRequest(product_links) {
         const relatedSKUs = product_links.reduce((links, link) => {
             const { linked_product_sku } = link;
-            return [...links, `"${ linked_product_sku.replace(/ /g, '%20') }"`];
+            return [...links, `${ linked_product_sku.replace(/ /g, '%20') }`];
         }, []);
 
         return [


### PR DESCRIPTION
Fix double wrapping of linked product sku. 
That is, was sending request with each sku quotes double wrapped like : 
filter_1={"sku":{"in":[""n31350783""]}
now : filter_1={"sku":{"in":["n31350783"]}

Also noticed that if try to visit linked product from PDP than error appears: "Cannot read property "current" of undefined"
So just clarify if logic in productGallery.component 