### PR TITLE
#1531 - Trim baseurl from image path for category

### DIFF
--- a/src/app/component/CategoryDetails/CategoryDetails.component.js
+++ b/src/app/component/CategoryDetails/CategoryDetails.component.js
@@ -86,10 +86,12 @@ export class CategoryDetails extends PureComponent {
             return null;
         }
 
+        const trimmedImagePath = image.substring(image.indexOf('/media'));
+
         return (
             <Image
               mix={ { block: 'CategoryDetails', elem: 'Picture' } }
-              src={ image || '' }
+              src={ trimmedImagePath || '' }
               ratio="custom"
               objectFit="cover"
             />


### PR DESCRIPTION
Setting path for image without baseUrl like : /media/catalog/category...
This fixes broken images if using multistore.