### PR TITLE
#1874 - Remove titles from product tabs on desktop + tabs font-size increase

### DIFF
--- a/src/app/component/ProductAttributes/ProductAttributes.style.scss
+++ b/src/app/component/ProductAttributes/ProductAttributes.style.scss
@@ -23,10 +23,9 @@
         }
     }
 
-    &-ExpandableContentHeading {
-        @include desktop {
-            font-size: 2rem;
-            text-transform: uppercase;
+    &-ExpandableContentButton {
+        @include after-mobile {
+            display: none;
         }
     }
 

--- a/src/app/component/ProductInformation/ProductInformation.style.scss
+++ b/src/app/component/ProductInformation/ProductInformation.style.scss
@@ -23,10 +23,9 @@
         }
     }
 
-    &-ExpandableContentHeading {
-        @include desktop {
-            font-size: 2rem;
-            text-transform: uppercase;
+    &-ExpandableContentButton {
+        @include after-mobile {
+            display: none;
         }
     }
 

--- a/src/app/component/ProductReviews/ProductReviews.component.js
+++ b/src/app/component/ProductReviews/ProductReviews.component.js
@@ -140,9 +140,6 @@ export class ProductReviews extends PureComponent {
               elem="Summary"
               { ...reviewSchemaObject }
             >
-                <h3 block="ProductReviews" elem="Title">
-                    { __('Customer reviews') }
-                </h3>
                 { this.renderRatingData() }
                 { this.renderButton() }
             </div>

--- a/src/app/component/ProductReviews/ProductReviews.style.scss
+++ b/src/app/component/ProductReviews/ProductReviews.style.scss
@@ -14,20 +14,6 @@
         z-index: 1;
     }
 
-    &-Title {
-        margin: 0 0 .6rem;
-        font-size: 2.4rem;
-
-        @include mobile {
-            margin: 0 0 .7rem;
-            font-size: 2.8rem;
-        }
-
-        @include before-desktop {
-            display: none;
-        }
-    }
-
     &-Wrapper {
         padding: 0;
 

--- a/src/app/component/ProductTab/ProductTab.style.scss
+++ b/src/app/component/ProductTab/ProductTab.style.scss
@@ -32,6 +32,7 @@
         margin: 0;
         padding: 0;
         padding: 1.2rem 2rem;
+        font-size: 1.8rem;
         font-weight: bold;
     }
 }

--- a/src/app/component/ProductTabs/index.js
+++ b/src/app/component/ProductTabs/index.js
@@ -1,1 +1,12 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
 export { default } from './ProductTabs.component';


### PR DESCRIPTION
Hide product expandable titles in product tabs for desktop/tablet. Increase font-size of tabs to 18px (PM request). Fix eslint (add license commit into ProductTabs/index.js).