### PR TITLE
#1872 Usage of correct price values for bundle products

### DIFF
--- a/src/app/component/ProductBundleItem/ProductBundleItem.container.js
+++ b/src/app/component/ProductBundleItem/ProductBundleItem.container.js
@@ -178,16 +178,16 @@ export class ProductBundleItemContainer extends ProductCustomizableOptionContain
     }
 
     getDropdownOptions(values) {
+        const { price_range: { minimum_price: { discount: { percent_off } } } } = this.props;
+
         return values.reduce((acc, {
             id,
             label,
             price_type,
             quantity,
             can_change_quantity,
-            product: { price_range: { minimum_price: { regular_price: { value } } } }
+            product: { price_range: { minimum_price: { final_price: { value } } } }
         }) => {
-            const { price_range: { minimum_price: { discount: { percent_off } } } } = this.props;
-
             // eslint-disable-next-line no-magic-numbers
             const finalPrice = value - (value * (percent_off / 100));
 

--- a/src/app/component/ProductBundleItems/ProductBundleItems.container.js
+++ b/src/app/component/ProductBundleItems/ProductBundleItems.container.js
@@ -82,7 +82,7 @@ export class ProductBundleItemsContainer extends ProductCustomizableOptionsConta
 
                 options.reduce((acc, { id: optionId, product }) => {
                     if (JSON.stringify(value) === JSON.stringify([optionId.toString()])) {
-                        const { price_range: { minimum_price: { regular_price: { value } } } } = product;
+                        const { price_range: { minimum_price: { final_price: { value } } } } = product;
                         price += (value * quantity);
                     }
 


### PR DESCRIPTION
Requires PR: https://github.com/scandipwa/catalog-graphql/pull/80

1. Moved property access outside loop
2. Changed from regular_price to final_price to include products discount.