### PR TITLE
#1881 Slider adjustments + placeholder

### DIFF
--- a/src/app/component/Slider/Slider.style.scss
+++ b/src/app/component/Slider/Slider.style.scss
@@ -31,6 +31,15 @@
 
     transition: height var(--height-transition-speed);
 
+    @include before-desktop {
+        width: 100vw;
+        max-width: 100vw;
+
+        position: relative;
+        margin-left: -50vw;
+        left: 50%;
+    }
+
     &-Wrapper {
         display: flex;
         align-items: flex-start;
@@ -80,7 +89,7 @@
         bottom: 1.2rem;
 
         @include mobile {
-            bottom: 1.4rem;
+            display: none;
         }
     }
 


### PR DESCRIPTION
In this PR:
* Removed pagination in mobile
* Made Slider full-screen in mobile & tablet

Placeholder
* Placeholder for slider is showing, but due to slow internet images that are displayed may be outputted after widget is loaded.