### PR TITLE
#1881 Placeholder + popping up slider fix

### DIFF
--- a/src/app/component/Slider/Slider.component.js
+++ b/src/app/component/Slider/Slider.component.js
@@ -97,6 +97,7 @@ export class Slider extends PureComponent {
         const sliderRef = this.getSliderRef();
         const sliderHeight = `${ sliderChildren[0].getBoundingClientRect().height }px`;
 
+        CSS.setVariable(sliderRef, 'slider-height', sliderHeight);
         CSS.setVariable(sliderRef, 'slide-height', sliderHeight);
         sliderChildren[0].onload = () => {
             CSS.setVariable(sliderRef, 'slider-height', sliderHeight);

--- a/src/app/component/SliderWidget/SliderWidget.component.js
+++ b/src/app/component/SliderWidget/SliderWidget.component.js
@@ -40,12 +40,14 @@ export class SliderWidget extends PureComponent {
             )
         }),
         device: DeviceType.isRequired,
-        isVertical: PropTypes.bool
+        isVertical: PropTypes.bool,
+        isLoaded: PropTypes.bool
     };
 
     static defaultProps = {
         slider: [{}],
-        isVertical: false
+        isVertical: false,
+        isLoaded: false
     };
 
     state = {
@@ -135,7 +137,17 @@ export class SliderWidget extends PureComponent {
         );
     };
 
+    renderPlaceholder() {
+        return <div block="WidgetFactory" elem="SliderPlaceholder" />;
+    }
+
     render() {
+        const { isLoaded } = this.state;
+        
+        if (!isLoaded) {
+            return this.renderPlaceholder();
+        }
+
         const { activeSlide } = this.state;
         const { slider: { slides, title: block }, isVertical } = this.props;
 

--- a/src/app/component/SliderWidget/SliderWidget.component.js
+++ b/src/app/component/SliderWidget/SliderWidget.component.js
@@ -142,8 +142,8 @@ export class SliderWidget extends PureComponent {
     }
 
     render() {
-        const { isLoaded } = this.state;
-        
+        const { isLoaded } = this.props;
+
         if (!isLoaded) {
             return this.renderPlaceholder();
         }

--- a/src/app/component/SliderWidget/SliderWidget.container.js
+++ b/src/app/component/SliderWidget/SliderWidget.container.js
@@ -72,12 +72,6 @@ export class SliderWidgetContainer extends DataContainer {
     }
 
     render() {
-        const { isLoaded } = this.state;
-
-        if (!isLoaded) {
-            return null;
-        }
-
         return (
             <SliderWidget
               { ...this.props }


### PR DESCRIPTION
Original issue: #1881 

### In this PR:
* **Slider.component.js** - added slider-height definition on mount to remove slider from changing size when visible... meaning that after load its height is 0 and after some time its height is set to correct height (_popping up effect_).

* **SliderWidget** - added `renderPlaceholder()` instead of return `null`, because `WidgetFactory` & `RenderWhenVisible` does not respond to `null` type returns, instead they are using different criteria to determine if  widget has finished loading, so returning `null` will just make an empty object.