### PR TITLE
#1690 Fix for unable to change payment after klarna selection

### DIFF
--- a/packages/scandipwa/src/component/Klarna/Klarna.component.js
+++ b/packages/scandipwa/src/component/Klarna/Klarna.component.js
@@ -49,6 +49,11 @@ export class Klarna extends PureComponent {
 
         if (paymentIsShown) {
             document.getElementById(KLARNA_PAYMENTS_DEVICE_RECOGNITION_ID).remove();
+            const klarnaDOM = document.getElementById(KLARNA_PAYMENTS_DEVICE_RECOGNITION_ID);
+
+            if (klarnaDOM) {
+                klarnaDOM.remove();
+            }
         }
     }
 

--- a/packages/scandipwa/src/component/Klarna/Klarna.component.js
+++ b/packages/scandipwa/src/component/Klarna/Klarna.component.js
@@ -48,7 +48,6 @@ export class Klarna extends PureComponent {
         const { paymentIsShown } = this.state;
 
         if (paymentIsShown) {
-            document.getElementById(KLARNA_PAYMENTS_DEVICE_RECOGNITION_ID).remove();
             const klarnaDOM = document.getElementById(KLARNA_PAYMENTS_DEVICE_RECOGNITION_ID);
 
             if (klarnaDOM) {


### PR DESCRIPTION
### In this PR:
Issue was, that when Klarna failed to load, it also did not create DOM element... so when trying to delete it when switching to different payment method js error was outputted and crashed the system... added value check to prevent this from happening.