### PR TITLE
#1761 Fix for ooops on purchase page when changing currency

### DIFF
--- a/packages/scandipwa/src/store/Config/Config.reducer.js
+++ b/packages/scandipwa/src/store/Config/Config.reducer.js
@@ -35,7 +35,10 @@ export const {
 export const getIndexedRatings = (reviewRatings) => ((reviewRatings) ? reviewRatings.items || [] : []);
 
 /** @namespace Store/Config/Reducer/getCurrencyData */
-export const getCurrencyData = (base, state) => ((base) || state.currencyData || {});
+export const getCurrencyData = (base, state) => (base || state.currencyData || {});
+
+/** @namespace Store/Config/Reducer/getCountryData */
+export const getCountryData = (base, state) => (base || state.countries || {});
 
 /** @namespace Store/Config/Reducer/getInitialState */
 export const getInitialState = () => ({
@@ -81,7 +84,7 @@ export const ConfigReducer = (
 
         return {
             ...state,
-            countries,
+            countries: getCountryData(countries, state),
             reviewRatings: getIndexedRatings(reviewRatings),
             checkoutAgreements,
             currencyData: getCurrencyData(currencyData, state),

--- a/packages/scandipwa/src/store/Config/Config.reducer.js
+++ b/packages/scandipwa/src/store/Config/Config.reducer.js
@@ -40,6 +40,9 @@ export const getCurrencyData = (base, state) => (base || state.currencyData || {
 /** @namespace Store/Config/Reducer/getCountryData */
 export const getCountryData = (base, state) => (base || state.countries || {});
 
+/** @namespace Store/Config/Reducer/getCheckoutAgreementData */
+export const getCheckoutAgreementData = (base, state) => (base || state.checkoutAgreements || {});
+
 /** @namespace Store/Config/Reducer/getInitialState */
 export const getInitialState = () => ({
     ...filterStoreConfig(storeConfig),
@@ -86,7 +89,7 @@ export const ConfigReducer = (
             ...state,
             countries: getCountryData(countries, state),
             reviewRatings: getIndexedRatings(reviewRatings),
-            checkoutAgreements,
+            checkoutAgreements: getCheckoutAgreementData(checkoutAgreements, state),
             currencyData: getCurrencyData(currencyData, state),
             ...filteredStoreConfig,
             // Should be updated manually as filteredStoreConfig does not contain header_logo_src when it is null


### PR DESCRIPTION
In this PR:
- Using cached countries when performing page reload, otherwise they are `null`, that causes many dependent components to crash website with message "ooops", as they have `.required` prop type.