### PR TITLE
#1772 Display order total with discount in cart overlay

### DIFF
--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -85,7 +85,12 @@ export class CartOverlay extends PureComponent {
     }
 
     renderTotals() {
-        const { totals: { subtotal_incl_tax = 0 } } = this.props;
+        const {
+            totals: {
+                subtotal_with_discount = 0,
+                tax_amount = 0
+            }
+        } = this.props;
 
         return (
             <dl
@@ -93,7 +98,7 @@ export class CartOverlay extends PureComponent {
               elem="Total"
             >
                 <dt>{ __('Order total:') }</dt>
-                <dd>{ this.renderPriceLine(subtotal_incl_tax) }</dd>
+                <dd>{ this.renderPriceLine(subtotal_with_discount + tax_amount) }</dd>
             </dl>
         );
     }


### PR DESCRIPTION
### In this PR:
Moved to same logic as in cart summary -> instead of using `subtotal_incl_tax` witch outputs order total without discount, component now is using sum of two variables `subtotal_with_discount` & `tax_amount` to get real final price (_same as cart summary_).