### PR TITLE
#1760 Currency convertion in layerd navigation

### DIFF
--- a/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
+++ b/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
@@ -19,8 +19,8 @@ import { formatPrice } from 'Util/Price';
 export class CategoryConfigurableAttributes extends ProductConfigurableAttributes {
     getPriceLabel(option) {
         const { currency_code } = this.props;
-        const { value_string } = option;
-        const [from, to] = value_string.split('_');
+        const { label } = option;
+        const [from, to] = label.split('~');
         const priceFrom = formatPrice(from, currency_code);
         const priceTo = formatPrice(to, currency_code);
 

--- a/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.container.js
+++ b/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.container.js
@@ -18,7 +18,7 @@ import CategoryConfigurableAttributes from './CategoryConfigurableAttributes.com
 
 /** @namespace Component/CategoryConfigurableAttributes/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
-    currency_code: state.ConfigReducer.default_display_currency_code
+    currency_code: state.ConfigReducer.currencyData.current_currency_code
 });
 
 /** @namespace Component/CategoryConfigurableAttributes/Container */


### PR DESCRIPTION
### Required PR
* https://github.com/scandipwa/catalog-graphql/pull/82

### In this PR
* Switched from `state.ConfigReducer.default_display_currency_code` to `state.ConfigReducer.currencyData.current_currency_code` as old implementation shows default store currency not current
* Updated price calculations, by multiplying `price` with `currency_rate` _(check catalog-grapql pull request)_