### PR TITLE
#1747 Correct order totals in shipping & billing

### DIFF
--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
@@ -46,6 +46,7 @@ export class CheckoutBilling extends PureComponent {
         showPopup: PropTypes.func.isRequired,
         paymentMethods: paymentMethodsType.isRequired,
         totals: TotalsType.isRequired,
+        paymentTotals: TotalsType.isRequired,
         shippingAddress: addressType.isRequired,
         termsAndConditions: PropTypes.arrayOf(PropTypes.shape({
             checkbox_text: PropTypes.string
@@ -132,9 +133,17 @@ export class CheckoutBilling extends PureComponent {
     }
 
     renderOrderTotal() {
-        const { totals: { grand_total, quote_currency_code } } = this.props;
+        const {
+            totals: {
+                grand_total,
+                quote_currency_code
+            },
+            paymentTotals: {
+                grand_total: payment_grand_total
+            }
+        } = this.props;
 
-        const orderTotal = formatPrice(grand_total, quote_currency_code);
+        const orderTotal = formatPrice(payment_grand_total || grand_total, quote_currency_code);
 
         return (
             <div block="Checkout" elem="OrderTotal">

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -51,6 +51,7 @@ export class CheckoutBillingContainer extends PureComponent {
         shippingAddress: addressType.isRequired,
         customer: customerType.isRequired,
         totals: TotalsType.isRequired,
+        paymentTotals: TotalsType,
         addressLinesQty: PropTypes.number.isRequired,
         termsAndConditions: PropTypes.arrayOf(PropTypes.shape({
             checkbox_text: PropTypes.string,
@@ -58,6 +59,10 @@ export class CheckoutBillingContainer extends PureComponent {
             name: PropTypes.string
         })).isRequired
     };
+
+    static defaultProps = {
+        paymentTotals: {}
+    }
 
     static getDerivedStateFromProps(props, state) {
         const { paymentMethod, prevPaymentMethods } = state;

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -62,7 +62,7 @@ export class CheckoutBillingContainer extends PureComponent {
 
     static defaultProps = {
         paymentTotals: {}
-    }
+    };
 
     static getDerivedStateFromProps(props, state) {
         const { paymentMethod, prevPaymentMethods } = state;

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.component.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.component.js
@@ -42,12 +42,13 @@ export class CheckoutShipping extends PureComponent {
     renderOrderTotal() {
         const {
             totals: {
-                grand_total,
+                subtotal_with_discount,
+                tax_amount,
                 quote_currency_code
             }
         } = this.props;
 
-        const orderTotal = formatPrice(grand_total, quote_currency_code);
+        const orderTotal = formatPrice(subtotal_with_discount + tax_amount, quote_currency_code);
 
         return (
             <div block="Checkout" elem="OrderTotal">

--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -197,6 +197,7 @@ export class Checkout extends PureComponent {
 
     renderBillingStep() {
         const {
+            paymentTotals,
             setLoading,
             setDetailsStep,
             shippingAddress,
@@ -211,6 +212,7 @@ export class Checkout extends PureComponent {
               setDetailsStep={ setDetailsStep }
               shippingAddress={ shippingAddress }
               savePaymentInformation={ savePaymentInformation }
+              paymentTotals={ paymentTotals }
             />
         );
     }


### PR DESCRIPTION
### In this PR:
- Showing same order amount in summary and order_totals between shipping and billing step.
- Instead of depend  on different variables between summary & order_totals - moved them to same logic implementation, so that outputted information is the same.