### PR TITLE
Taxes in Minicart

### DIFF
--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -85,7 +85,13 @@ export class CartOverlay extends PureComponent {
     }
 
     renderTotals() {
-        const { totals: { subtotal_incl_tax = 0 } } = this.props;
+        const {
+            totals: {
+                subtotal_incl_tax = 0,
+                shipping_tax_amount = 0
+            } = {}
+        } = this.props;
+        const result = subtotal_incl_tax - shipping_tax_amount;
 
         return (
             <dl
@@ -93,13 +99,19 @@ export class CartOverlay extends PureComponent {
               elem="Total"
             >
                 <dt>{ __('Order total:') }</dt>
-                <dd>{ this.renderPriceLine(subtotal_incl_tax) }</dd>
+                <dd>{ this.renderPriceLine(result) }</dd>
             </dl>
         );
     }
 
     renderTax() {
-        const { totals: { tax_amount = 0 } } = this.props;
+        const {
+            totals: {
+                tax_amount = 0,
+                shipping_tax_amount = 0
+            } = {}
+        } = this.props;
+        const result = tax_amount - shipping_tax_amount;
 
         return (
             <dl
@@ -107,7 +119,7 @@ export class CartOverlay extends PureComponent {
               elem="Tax"
             >
                 <dt>{ __('Tax total:') }</dt>
-                <dd>{ this.renderPriceLine(tax_amount || 0) }</dd>
+                <dd>{ this.renderPriceLine(result) }</dd>
             </dl>
         );
     }

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -84,6 +84,29 @@ export class CartOverlay extends PureComponent {
         );
     }
 
+    renderOrderTotalExlTax() {
+        const {
+            totals: {
+                cart_display_config: {
+                    include_tax_in_order_total
+                } = {},
+                subtotal_incl_tax = 0,
+                tax_amount = 0
+            }
+        } = this.props;
+        const result = subtotal_incl_tax - tax_amount;
+
+        if (!include_tax_in_order_total) {
+            return null;
+        }
+
+        return (
+            <span>
+                { `${ __('Excl. tax:') } ${ this.renderPriceLine(result) }` }
+            </span>
+        );
+    }
+
     renderTotals() {
         const {
             totals: {
@@ -99,7 +122,10 @@ export class CartOverlay extends PureComponent {
               elem="Total"
             >
                 <dt>{ __('Order total:') }</dt>
-                <dd>{ this.renderPriceLine(result) }</dd>
+                <dd>
+                    { this.renderPriceLine(result) }
+                    { this.renderOrderTotalExlTax() }
+                </dd>
             </dl>
         );
     }

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.style.scss
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.style.scss
@@ -162,6 +162,7 @@
     &-Total {
         font-weight: bold;
         padding: .6rem 1.2rem 1.2rem;
+        align-items: flex-start;
 
         @include mobile {
             padding: .7rem 1.4rem 1.4rem;
@@ -169,6 +170,16 @@
 
         @include after-mobile {
             border-bottom: 1px solid var(--cart-item-divider-color);
+        }
+
+        dd {
+            text-align: right;
+
+            span {
+                display: block;
+                font-size: .6em;
+                font-weight: 300;
+            }
         }
     }
 

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -140,8 +140,9 @@ export class CheckoutOrderSummary extends PureComponent {
     renderSubTotal() {
         const {
             totals: {
-                subtotal,
-                subtotal_incl_tax,
+                subtotal = 0,
+                subtotal_incl_tax = 0,
+                shipping_tax_amount = 0,
                 quote_currency_code,
                 cart_display_config: {
                     display_tax_in_subtotal
@@ -153,7 +154,7 @@ export class CheckoutOrderSummary extends PureComponent {
         if (display_tax_in_subtotal === DISPLAY_CART_TAX_IN_SUBTOTAL_BOTH) {
             return (
                 <CheckoutOrderSummaryPriceLine
-                  price={ subtotal_incl_tax }
+                  price={ subtotal_incl_tax - shipping_tax_amount }
                   currency={ quote_currency_code }
                   title={ title }
                   subPrice={ subtotal }
@@ -162,7 +163,7 @@ export class CheckoutOrderSummary extends PureComponent {
         }
 
         if (display_tax_in_subtotal === DISPLAY_CART_TAX_IN_SUBTOTAL_INCL_TAX) {
-            return this.renderPriceLine(subtotal_incl_tax, title);
+            return this.renderPriceLine(subtotal_incl_tax - shipping_tax_amount, title);
         }
 
         return this.renderPriceLine(subtotal, title);
@@ -230,19 +231,22 @@ export class CheckoutOrderSummary extends PureComponent {
         const {
             totals: {
                 tax_amount,
+                shipping_tax_amount,
                 quote_currency_code,
                 cart_display_config: {
                     include_tax_in_order_total
                 } = {}
-            }
+            },
+            checkoutStep
         } = this.props;
         const title = __('Order total');
         const orderTotal = this.getOrderTotal();
+        const shippingTax = checkoutStep === SHIPPING_STEP ? shipping_tax_amount : 0;
 
         if (include_tax_in_order_total) {
             return (
                 <CheckoutOrderSummaryPriceLine
-                  price={ orderTotal }
+                  price={ orderTotal - shippingTax }
                   currency={ quote_currency_code }
                   title={ title }
                   subPrice={ orderTotal - tax_amount }
@@ -281,6 +285,7 @@ export class CheckoutOrderSummary extends PureComponent {
         const {
             totals: {
                 tax_amount = 0,
+                shipping_tax_amount = 0,
                 quote_currency_code,
                 cart_display_config: {
                     display_full_tax_summary,
@@ -288,14 +293,15 @@ export class CheckoutOrderSummary extends PureComponent {
                 } = {}
             }
         } = this.props;
+        const tax = tax_amount - shipping_tax_amount;
 
-        if (!tax_amount && !display_zero_tax_subtotal) {
+        if (!tax && !display_zero_tax_subtotal) {
             return null;
         }
 
         return (
             <CheckoutOrderSummaryPriceLine
-              price={ tax_amount }
+              price={ tax }
               currency={ quote_currency_code }
               title={ __('Tax') }
               mods={ { withAppendedContent: display_full_tax_summary } }

--- a/packages/scandipwa/src/query/Cart.query.js
+++ b/packages/scandipwa/src/query/Cart.query.js
@@ -103,6 +103,7 @@ export class CartQuery {
             'coupon_code',
             'shipping_amount',
             'shipping_incl_tax',
+            'shipping_tax_amount',
             'is_virtual',
             'applied_rule_ids',
             this._getCartItemsField(),

--- a/packages/scandipwa/src/route/CartPage/CartPage.component.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.component.js
@@ -147,13 +147,15 @@ export class CartPage extends PureComponent {
         const {
             totals: {
                 tax_amount = 0,
+                shipping_tax_amount = 0,
                 cart_display_config: {
                     display_zero_tax_subtotal
                 } = {}
             }
         } = this.props;
+        const tax = tax_amount - shipping_tax_amount;
 
-        if (!tax_amount && !display_zero_tax_subtotal) {
+        if (!tax && !display_zero_tax_subtotal) {
             return null;
         }
 
@@ -163,7 +165,7 @@ export class CartPage extends PureComponent {
                     { __('Tax:') }
                     { this.renderTaxFullSummary() }
                 </dt>
-                <dd>{ this.renderPriceLine(tax_amount) }</dd>
+                <dd>{ this.renderPriceLine(tax) }</dd>
             </>
         );
     }
@@ -201,15 +203,17 @@ export class CartPage extends PureComponent {
         const {
             totals: {
                 subtotal_with_discount = 0,
-                tax_amount = 0
+                tax_amount = 0,
+                shipping_tax_amount = 0
             }
         } = this.props;
+        const result = subtotal_with_discount + tax_amount - shipping_tax_amount;
 
         return (
             <dl block="CartPage" elem="Total" aria-label="Complete order total">
                 <dt>{ __('Order total:') }</dt>
                 <dd>
-                    { this.renderPriceLine(subtotal_with_discount + tax_amount) }
+                    { this.renderPriceLine(result) }
                     { this.renderOrderTotalExlTax() }
                 </dd>
             </dl>

--- a/packages/scandipwa/src/route/CartPage/CartPage.container.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.container.js
@@ -145,7 +145,8 @@ export class CartPageContainer extends PureComponent {
                     display_tax_in_subtotal
                 } = {},
                 subtotal,
-                subtotal_incl_tax
+                subtotal_incl_tax,
+                shipping_tax_amount = 0
             }
         } = this.props;
 
@@ -153,7 +154,7 @@ export class CartPageContainer extends PureComponent {
             return subtotal;
         }
 
-        return subtotal_incl_tax;
+        return subtotal_incl_tax - shipping_tax_amount;
     }
 
     getCartSubTotalExclTax() {


### PR DESCRIPTION
Fixes #1795
Fixed display of order total value without tax in minicart.

In order to prevent conflicts, i had to merge scandipwa/pull/1945 in this branch, since i was editing the same method in both tasks.