### PR TITLE
Get back default_description for meta

### DIFF
--- a/packages/scandipwa/src/query/Config.query.js
+++ b/packages/scandipwa/src/query/Config.query.js
@@ -90,6 +90,7 @@ export class ConfigQuery {
             'default_display_currency_code',
             'default_keywords',
             'default_title',
+            'default_description',
             'default_country',
             'secure_base_media_url',
             // 'paypal_sandbox_flag',

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
@@ -158,7 +158,8 @@ export class CmsPageContainer extends DataContainer {
             content_heading,
             meta_title,
             title,
-            meta_description
+            meta_description,
+            meta_keywords
         } = page;
 
         debounce(this.setOfflineNoticeSize, LOADING_TIME)();
@@ -167,6 +168,7 @@ export class CmsPageContainer extends DataContainer {
         updateMeta({
             title: meta_title || title,
             description: meta_description,
+            keywords: meta_keywords,
             canonical_url: window.location.href
         });
 


### PR DESCRIPTION
fixes #1554 
fixes #1553 

Get default_description in query.
Also add meta_keywords for cms pages.