### PR TITLE
Firefox(Win): Frame (right side) of small photos is missing on the left side of product page #1672

### DIFF
--- a/packages/scandipwa/src/component/CarouselScroll/CarouselScroll.style.scss
+++ b/packages/scandipwa/src/component/CarouselScroll/CarouselScroll.style.scss
@@ -16,5 +16,6 @@
         height: 100%;
         transform: translateY(var(--translateY));
         transition: transform var(--animation-speed);
+        padding-right: 1px;
     }
 }


### PR DESCRIPTION
- So as observed in firefox the right side of the frame is being hidden by the slider image and just a little 1px padding from the right made it appear in every resolution, also tried to add right property but then left side starts to disappear in chrome, so in overall this padding works in chrome as well as in firefox.