### PR TITLE
Respect price tax diplay settings

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.style.scss
+++ b/packages/scandipwa/src/component/CartItem/CartItem.style.scss
@@ -399,4 +399,8 @@
         justify-content: space-between;
         align-items: baseline;
     }
+
+    .ProductPrice-SubPrice {
+        font-size: .7em;
+    }
 }

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
@@ -12,13 +12,14 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-import {
-    DISPLAY_CART_TAX_IN_SHIPPING_BOTH,
-    DISPLAY_CART_TAX_IN_SHIPPING_EXL_TAX
-} from 'Route/CartPage/CartPage.config';
 import { shippingMethodType } from 'Type/Checkout';
 import { TotalsType } from 'Type/MiniCart';
 import { formatPrice } from 'Util/Price';
+
+import {
+    DISPLAY_SHIPPING_PRICES_BOTH,
+    DISPLAY_SHIPPING_PRICES_EXCL_TAX
+} from './CheckoutDeliveryOption.config';
 
 import './CheckoutDeliveryOption.style';
 
@@ -28,7 +29,8 @@ export class CheckoutDeliveryOption extends PureComponent {
         option: shippingMethodType.isRequired,
         onClick: PropTypes.func.isRequired,
         isSelected: PropTypes.bool,
-        totals: TotalsType.isRequired
+        totals: TotalsType.isRequired,
+        displayTaxInPrice: PropTypes.string.isRequired
     };
 
     static defaultProps = {
@@ -51,14 +53,12 @@ export class CheckoutDeliveryOption extends PureComponent {
                 price_excl_tax
             },
             totals: {
-                cart_display_config: {
-                    display_tax_in_shipping_amount
-                } = {},
                 quote_currency_code
-            }
+            },
+            displayTaxInPrice
         } = this.props;
 
-        if (display_tax_in_shipping_amount === DISPLAY_CART_TAX_IN_SHIPPING_EXL_TAX) {
+        if (displayTaxInPrice === DISPLAY_SHIPPING_PRICES_EXCL_TAX) {
             return formatPrice(price_excl_tax, quote_currency_code);
         }
 
@@ -71,14 +71,12 @@ export class CheckoutDeliveryOption extends PureComponent {
                 price_excl_tax
             },
             totals: {
-                cart_display_config: {
-                    display_tax_in_shipping_amount
-                } = {},
                 quote_currency_code
-            }
+            },
+            displayTaxInPrice
         } = this.props;
 
-        if (display_tax_in_shipping_amount === DISPLAY_CART_TAX_IN_SHIPPING_BOTH) {
+        if (displayTaxInPrice === DISPLAY_SHIPPING_PRICES_BOTH) {
             return (
                 <span block="CheckoutDeliveryOption" elem="SubPrice">
                     { __('Excl. tax: ') }

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.config.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.config.js
@@ -1,0 +1,16 @@
+/* eslint-disable import/prefer-default-export */
+
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export const DISPLAY_SHIPPING_PRICES_INCL_TAX = 'DISPLAY_SHIPPING_PRICES_INCL_TAX';
+export const DISPLAY_SHIPPING_PRICES_EXCL_TAX = 'DISPLAY_SHIPPING_PRICES_EXCL_TAX';
+export const DISPLAY_SHIPPING_PRICES_BOTH = 'DISPLAY_SHIPPING_PRICES_BOTH';

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.container.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.container.js
@@ -15,7 +15,8 @@ import CheckoutDeliveryOption from './CheckoutDeliveryOption.component';
 
 /** @namespace Component/CheckoutDeliveryOption/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
-    totals: state.CartReducer.cartTotals
+    totals: state.CartReducer.cartTotals,
+    displayTaxInPrice: state.ConfigReducer.priceTaxDisplay.shipping_price_display_type
 });
 
 /** @namespace Component/CheckoutDeliveryOption/Container/mapDispatchToProps */

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *
@@ -30,6 +31,7 @@ export class ProductPrice extends PureComponent {
         priceCurrency: PropTypes.string,
         discountPercentage: PropTypes.number,
         formattedFinalPrice: PropTypes.string,
+        formattedSubPrice: PropTypes.string,
         variantsCount: PropTypes.number,
         price: PriceType,
         mix: MixType
@@ -41,6 +43,7 @@ export class ProductPrice extends PureComponent {
         priceCurrency: 'USD',
         discountPercentage: 0,
         formattedFinalPrice: '0',
+        formattedSubPrice: null,
         variantsCount: 0,
         mix: {},
         price: {}
@@ -88,6 +91,24 @@ export class ProductPrice extends PureComponent {
             <PriceSemanticElementName>
                 <span { ...priceSchema }>{ formattedFinalPrice }</span>
             </PriceSemanticElementName>
+        );
+    }
+
+    renderSubPrice() {
+        const { formattedSubPrice } = this.props;
+
+        if (!formattedSubPrice) {
+            return null;
+        }
+
+        return (
+            <span
+              aria-label={ __('Current product price excl. tax') }
+              block="ProductPrice"
+              elem="SubPrice"
+            >
+                { `${ __('Excl. tax:') } ${ formattedSubPrice }` }
+            </span>
         );
     }
 
@@ -153,6 +174,7 @@ export class ProductPrice extends PureComponent {
               aria-label={ `Product price: ${formattedFinalPrice}` }
             >
                 { this.renderCurrentPrice() }
+                { this.renderSubPrice() }
                 { this.renderOldPrice() }
                 { this.renderSchema() }
             </p>

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *
@@ -174,8 +173,8 @@ export class ProductPrice extends PureComponent {
               aria-label={ `Product price: ${formattedFinalPrice}` }
             >
                 { this.renderCurrentPrice() }
-                { this.renderSubPrice() }
                 { this.renderOldPrice() }
+                { this.renderSubPrice() }
                 { this.renderSchema() }
             </p>
         );

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.config.js
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.config.js
@@ -1,0 +1,14 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export const DISPLAY_PRODUCT_PRICES_IN_CATALOG_INCL_TAX = 'DISPLAY_PRODUCT_PRICES_IN_CATALOG_INCL_TAX';
+export const DISPLAY_PRODUCT_PRICES_IN_CATALOG_EXCL_TAX = 'DISPLAY_PRODUCT_PRICES_IN_CATALOG_EXCL_TAX';
+export const DISPLAY_PRODUCT_PRICES_IN_CATALOG_BOTH = 'DISPLAY_PRODUCT_PRICES_IN_CATALOG_BOTH';

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.container.js
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.container.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *
@@ -20,7 +21,21 @@ import {
     roundPrice
 } from 'Util/Price';
 
+import {
+    DISPLAY_PRODUCT_PRICES_IN_CATALOG_BOTH,
+    DISPLAY_PRODUCT_PRICES_IN_CATALOG_EXCL_TAX
+} from './ProductPrice.config';
+
 import ProductPrice from './ProductPrice.component';
+
+/** @namespace Component/ProductPrice/Container/mapStateToProps */
+export const mapStateToProps = (state) => ({
+    displayTaxInPrice: state.ConfigReducer.priceTaxDisplay.product_price_display_type
+});
+
+/** @namespace Component/ProductPrice/Container/mapDispatchToProps */
+// eslint-disable-next-line no-unused-vars
+export const mapDispatchToProps = (dispatch) => ({});
 
 /**
  * Product price
@@ -62,17 +77,80 @@ export class ProductPriceContainer extends PureComponent {
             return {};
         }
 
-        const roundedRegularPrice = roundPrice(regularPriceValue);
-        const finalPrice = calculateFinalPrice(discountPercentage, minimalPriceValue, regularPriceValue);
-        const formattedFinalPrice = formatPrice(finalPrice, priceCurrency);
+        const roundedRegularPrice = this.getRoundedRegularPrice();
+        const formattedFinalPrice = this.getFormattedFinalPrice();
+        const formattedSubPrice = this.getFormattedSubPrice();
 
         return {
             roundedRegularPrice,
             priceCurrency,
             discountPercentage,
-            formattedFinalPrice
+            formattedFinalPrice,
+            formattedSubPrice
         };
     };
+
+    getRoundedRegularPrice() {
+        const {
+            price: {
+                minimum_price: {
+                    regular_price: {
+                        value: regularPriceValue
+                    } = {}
+                } = {}
+            } = {},
+            displayTaxInPrice
+        } = this.props;
+
+        // TODO
+        if (displayTaxInPrice === DISPLAY_PRODUCT_PRICES_IN_CATALOG_EXCL_TAX) {
+            return null;
+        }
+
+        return roundPrice(regularPriceValue)
+    }
+
+    getFormattedFinalPrice() {
+        const {
+            price: {
+                minimum_price: {
+                    discount: {
+                        percent_off: discountPercentage
+                    } = {},
+                    final_price: {
+                        value: minimalPriceValue,
+                        currency: priceCurrency
+                    } = {},
+                    regular_price: {
+                        value: regularPriceValue
+                    } = {}
+                } = {}
+            } = {},
+            displayTaxInPrice
+        } = this.props;
+
+        // TODO
+        if (displayTaxInPrice === DISPLAY_PRODUCT_PRICES_IN_CATALOG_EXCL_TAX) {
+            return null;
+        }
+
+        const finalPrice = calculateFinalPrice(discountPercentage, minimalPriceValue, regularPriceValue);
+
+        return formatPrice(finalPrice, priceCurrency);
+    }
+
+    getFormattedSubPrice() {
+        const {
+            displayTaxInPrice
+        } = this.props;
+
+        // TODO
+        if (displayTaxInPrice === DISPLAY_PRODUCT_PRICES_IN_CATALOG_BOTH) {
+            return null;
+        }
+
+        return null;
+    }
 
     render() {
         return (

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.container.js
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.container.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *
@@ -12,6 +11,7 @@
 
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
+import { connect } from 'react-redux';
 
 import { MixType } from 'Type/Common';
 import { PriceType } from 'Type/ProductList';
@@ -21,12 +21,12 @@ import {
     roundPrice
 } from 'Util/Price';
 
+import ProductPrice from './ProductPrice.component';
 import {
     DISPLAY_PRODUCT_PRICES_IN_CATALOG_BOTH,
-    DISPLAY_PRODUCT_PRICES_IN_CATALOG_EXCL_TAX
+    DISPLAY_PRODUCT_PRICES_IN_CATALOG_EXCL_TAX,
+    DISPLAY_PRODUCT_PRICES_IN_CATALOG_INCL_TAX
 } from './ProductPrice.config';
-
-import ProductPrice from './ProductPrice.component';
 
 /** @namespace Component/ProductPrice/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
@@ -46,11 +46,13 @@ export class ProductPriceContainer extends PureComponent {
     static propTypes = {
         isSchemaRequired: PropTypes.bool,
         price: PriceType,
-        mix: MixType
+        mix: MixType,
+        displayTaxInPrice: PropTypes.string
     };
 
     static defaultProps = {
         isSchemaRequired: false,
+        displayTaxInPrice: DISPLAY_PRODUCT_PRICES_IN_CATALOG_INCL_TAX,
         mix: {},
         price: {}
     };
@@ -96,18 +98,20 @@ export class ProductPriceContainer extends PureComponent {
                 minimum_price: {
                     regular_price: {
                         value: regularPriceValue
+                    } = {},
+                    regular_price_excl_tax: {
+                        value: regularPriceExclTaxValue
                     } = {}
                 } = {}
             } = {},
             displayTaxInPrice
         } = this.props;
 
-        // TODO
         if (displayTaxInPrice === DISPLAY_PRODUCT_PRICES_IN_CATALOG_EXCL_TAX) {
-            return null;
+            return roundPrice(regularPriceExclTaxValue);
         }
 
-        return roundPrice(regularPriceValue)
+        return roundPrice(regularPriceValue);
     }
 
     getFormattedFinalPrice() {
@@ -121,17 +125,28 @@ export class ProductPriceContainer extends PureComponent {
                         value: minimalPriceValue,
                         currency: priceCurrency
                     } = {},
+                    final_price_excl_tax: {
+                        value: minimalPriceExclTaxValue
+                    } = {},
                     regular_price: {
                         value: regularPriceValue
+                    } = {},
+                    regular_price_excl_tax: {
+                        value: regularPriceExclTaxValue
                     } = {}
                 } = {}
             } = {},
             displayTaxInPrice
         } = this.props;
 
-        // TODO
         if (displayTaxInPrice === DISPLAY_PRODUCT_PRICES_IN_CATALOG_EXCL_TAX) {
-            return null;
+            const finalPrice = calculateFinalPrice(
+                discountPercentage,
+                minimalPriceExclTaxValue,
+                regularPriceExclTaxValue
+            );
+
+            return formatPrice(finalPrice, priceCurrency);
         }
 
         const finalPrice = calculateFinalPrice(discountPercentage, minimalPriceValue, regularPriceValue);
@@ -141,12 +156,31 @@ export class ProductPriceContainer extends PureComponent {
 
     getFormattedSubPrice() {
         const {
+            price: {
+                minimum_price: {
+                    discount: {
+                        percent_off: discountPercentage
+                    } = {},
+                    final_price_excl_tax: {
+                        value: minimalPriceExclTaxValue,
+                        currency: priceCurrency
+                    } = {},
+                    regular_price_excl_tax: {
+                        value: regularPriceExclTaxValue
+                    } = {}
+                } = {}
+            } = {},
             displayTaxInPrice
         } = this.props;
 
-        // TODO
         if (displayTaxInPrice === DISPLAY_PRODUCT_PRICES_IN_CATALOG_BOTH) {
-            return null;
+            const finalPrice = calculateFinalPrice(
+                discountPercentage,
+                minimalPriceExclTaxValue,
+                regularPriceExclTaxValue
+            );
+
+            return formatPrice(finalPrice, priceCurrency);
         }
 
         return null;
@@ -162,4 +196,4 @@ export class ProductPriceContainer extends PureComponent {
     }
 }
 
-export default ProductPriceContainer;
+export default connect(mapStateToProps, mapDispatchToProps)(ProductPriceContainer);

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
@@ -54,6 +54,6 @@
     &-SubPrice {
         display: block;
         font-weight: 500;
-        font-size: .7em;
+        font-size: .5em;
     }
 }

--- a/packages/scandipwa/src/query/Config.query.js
+++ b/packages/scandipwa/src/query/Config.query.js
@@ -40,6 +40,14 @@ export class ConfigQuery {
             ]);
     }
 
+    getPriceDisplayTypeField() {
+        return new Field('priceTaxDisplay')
+            .addFieldList([
+                'product_price_display_type',
+                'shipping_price_display_type'
+            ]);
+    }
+
     getSaveSelectedCurrencyMutation(newCurrency) {
         return new Field('saveSelectedCurrency')
             .addArgument('currency', 'String', newCurrency)
@@ -113,7 +121,8 @@ export class ConfigQuery {
             'is_email_confirmation_required',
             'base_link_url',
             'show_vat_number_on_storefront',
-            'show_tax_vat_number'
+            'show_tax_vat_number',
+            this.getPriceDisplayTypeField()
         ];
     }
 }

--- a/packages/scandipwa/src/query/ProductList.query.js
+++ b/packages/scandipwa/src/query/ProductList.query.js
@@ -383,7 +383,9 @@ export class ProductListQuery {
         return [
             this._getDiscountField(),
             this._getFinalPriceField(),
-            this._getRegularPriceField()
+            this._getFinalPriceExclTaxField(),
+            this._getRegularPriceField(),
+            this._getRegularPriceExclTaxField()
         ];
     }
 
@@ -817,8 +819,20 @@ export class ProductListQuery {
             .addField('value');
     }
 
+    _getFinalPriceExclTaxField() {
+        return new Field('final_price_excl_tax')
+            .addField('currency')
+            .addField('value');
+    }
+
     _getRegularPriceField() {
         return new Field('regular_price')
+            .addField('currency')
+            .addField('value');
+    }
+
+    _getRegularPriceExclTaxField() {
+        return new Field('regular_price_excl_tax')
             .addField('currency')
             .addField('value');
     }


### PR DESCRIPTION
fixes #1508
fixes #1625 

Related PR :
https://github.com/scandipwa/store-graphql/pull/9
https://github.com/scandipwa/catalog-graphql/pull/85

Adds check if price in catalog and shipping price should excl/incl tax or should be displayed both. 
Atm magento 2 is not providing excl tax price in graphql, so while it is not supported added excl tax price in price range response.
