### PR TITLE
#1444 - Reset qty when navigating from PDP to PDP via click on related products

### DIFF
--- a/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
@@ -84,6 +84,15 @@ export class ProductActions extends PureComponent {
 
     groupedProductsRef = createRef();
 
+    componentDidUpdate(prevProps) {
+        const { product: { id: prevId } } = prevProps;
+        const { product: { id }, minQuantity, setQuantity } = this.props;
+
+        if (id !== prevId) {
+            setQuantity(minQuantity);
+        }
+    }
+
     renderStock(stockStatus) {
         if (stockStatus === 'OUT_OF_STOCK') {
             return __('Out of stock');

--- a/packages/scandipwa/src/util/CSS/CSS.js
+++ b/packages/scandipwa/src/util/CSS/CSS.js
@@ -25,7 +25,7 @@ export class CSS {
      * @memberof CSS
      */
     static setVariable(ref, name, value) {
-        if (ref.current) {
+        if (ref && ref.current) {
             ref.current.style.setProperty(`--${name}`, value);
         }
     }


### PR DESCRIPTION
Fixes issue #1444 

Also, resolves an issue where we get `Cannot read property 'current' of undefined` when clicking on a related product.