### PR TITLE
#1748 - Mobile: Wishlist title stays on my account page

### DIFF
--- a/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
@@ -163,12 +163,14 @@ export class MyAccountContainer extends PureComponent {
     componentDidUpdate(prevProps, prevState) {
         const { wishlistItems: prevWishlistItems } = prevProps;
         const { wishlistItems, isSignedIn } = this.props;
-        const { prevActiveTab } = prevState;
+        const { activeTab: prevActiveTab } = prevState;
         const { activeTab } = this.state;
 
         this.redirectIfNotSignedIn();
+
         if (prevActiveTab !== activeTab) {
             this.updateBreadcrumbs();
+            this.changeHeaderState();
         }
 
         if (Object.keys(wishlistItems).length !== Object.keys(prevWishlistItems).length) {


### PR DESCRIPTION
Fixes issue #1748.

Fixed as well updateBreadcrumbs as previously this method was triggered always when component did update because prevActiveTab was incorrectly destructed.