### PR TITLE
Some minor minicart and delivery method list fixes

### DIFF
--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -38,7 +38,8 @@ export class CartOverlay extends PureComponent {
         hasOutOfStockProductsInCart: PropTypes.bool,
         cartTotalSubPrice: PropTypes.number,
         cartShippingPrice: PropTypes.number,
-        cartShippingSubPrice: PropTypes.number
+        cartShippingSubPrice: PropTypes.number,
+        cartDisplaySettings: PropTypes.object.isRequired
     };
 
     static defaultProps = {
@@ -125,8 +126,15 @@ export class CartOverlay extends PureComponent {
         const {
             totals: {
                 tax_amount = 0
+            } = {},
+            cartDisplaySettings: {
+                display_zero_tax_subtotal
             } = {}
         } = this.props;
+
+        if (!tax_amount && !display_zero_tax_subtotal) {
+            return null;
+        }
 
         return (
             <dl

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.container.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.container.js
@@ -47,7 +47,8 @@ export const mapStateToProps = (state) => ({
     activeOverlay: state.OverlayReducer.activeOverlay,
     cartTotalSubPrice: getCartTotalSubPrice(state),
     cartShippingPrice: getCartShippingPrice(state),
-    cartShippingSubPrice: getCartShippingSubPrice(state)
+    cartShippingSubPrice: getCartShippingSubPrice(state),
+    cartDisplaySettings: state.ConfigReducer.cartDisplaySettings
 });
 
 /** @namespace Component/CartOverlay/Container/mapDispatchToProps */

--- a/packages/scandipwa/src/util/Cart/Cart.js
+++ b/packages/scandipwa/src/util/Cart/Cart.js
@@ -11,6 +11,10 @@
  */
 
 import { PRODUCT_OUT_OF_STOCK } from 'Component/CartItem/CartItem.config';
+import {
+    DISPLAY_SHIPPING_PRICES_BOTH,
+    DISPLAY_SHIPPING_PRICES_EXCL_TAX
+} from 'Component/CheckoutDeliveryOption/CheckoutDeliveryOption.config';
 
 export const DISPLAY_CART_TAX_IN_SUBTOTAL_INCL_TAX = 'DISPLAY_CART_TAX_IN_SUBTOTAL_INCL_TAX';
 export const DISPLAY_CART_TAX_IN_SUBTOTAL_EXL_TAX = 'DISPLAY_CART_TAX_IN_SUBTOTAL_EXL_TAX';
@@ -202,8 +206,8 @@ export const getCartShippingSubPrice = (state) => {
 export const getCartShippingItemPrice = (state) => (props) => {
     const {
         ConfigReducer: {
-            cartDisplayConfig: {
-                display_tax_in_shipping_amount
+            priceTaxDisplay: {
+                shipping_price_display_type
             } = {}
         } = {}
     } = state;
@@ -213,7 +217,7 @@ export const getCartShippingItemPrice = (state) => (props) => {
         price_excl_tax = 0
     } = props;
 
-    if (display_tax_in_shipping_amount === DISPLAY_CART_TAX_IN_SHIPPING_EXL_TAX) {
+    if (shipping_price_display_type === DISPLAY_SHIPPING_PRICES_EXCL_TAX) {
         return price_excl_tax;
     }
 
@@ -224,8 +228,8 @@ export const getCartShippingItemPrice = (state) => (props) => {
 export const getCartShippingItemSubPrice = (state) => (props) => {
     const {
         ConfigReducer: {
-            cartDisplayConfig: {
-                display_tax_in_shipping_amount
+            priceTaxDisplay: {
+                shipping_price_display_type
             } = {}
         } = {}
     } = state;
@@ -234,7 +238,7 @@ export const getCartShippingItemSubPrice = (state) => (props) => {
         price_excl_tax = 0
     } = props;
 
-    if (display_tax_in_shipping_amount === DISPLAY_CART_TAX_IN_SHIPPING_BOTH) {
+    if (shipping_price_display_type === DISPLAY_SHIPPING_PRICES_BOTH) {
         return price_excl_tax;
     }
 


### PR DESCRIPTION
Fixed the setting that configures what to display as price in the delivery method list (see #1982).
Fixed zero tax display in minicart.