### PR TITLE
Mobile: Page leads to Ooops page if user deleted product with swipe delete from the Wishlist and then deleted product in edit mode

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
@@ -66,7 +66,7 @@ export class WishlistItemContainer extends PureComponent {
 
     containerFunctions = {
         addToCart: this.addItemToCart.bind(this),
-        removeItem: this.removeItem.bind(this, false)
+        removeItem: this.removeItem.bind(this, false, true)
     };
 
     state = {


### PR DESCRIPTION
Fixes swipe delete. Correction for https://github.com/scandipwa/scandipwa/issues/1918