### PR TITLE
Add To Cart Button In Compare Page

### DIFF
--- a/packages/scandipwa/src/component/AddToCart/AddToCart.container.js
+++ b/packages/scandipwa/src/component/AddToCart/AddToCart.container.js
@@ -64,7 +64,8 @@ export class AddToCartContainer extends PureComponent {
         removeFromWishlist: PropTypes.func.isRequired,
         wishlistItems: PropTypes.objectOf(ProductType).isRequired,
         onProductValidationError: PropTypes.func,
-        productOptionsData: PropTypes.object.isRequired
+        productOptionsData: PropTypes.object.isRequired,
+        disableHandler: PropTypes.bool
     };
 
     static defaultProps = {
@@ -72,7 +73,8 @@ export class AddToCartContainer extends PureComponent {
         configurableVariantIndex: 0,
         setQuantityToDefault: () => {},
         onProductValidationError: () => {},
-        isLoading: false
+        isLoading: false,
+        disableHandler: false
     };
 
     state = { isLoading: false };
@@ -309,9 +311,14 @@ export class AddToCartContainer extends PureComponent {
 
     buttonClick() {
         const {
-            product: { type_id },
-            onProductValidationError
+            product: { type_id } = {},
+            onProductValidationError,
+            disableHandler
         } = this.props;
+
+        if (disableHandler) {
+            return;
+        }
 
         if (!this.validateAddToCart()) {
             onProductValidationError(type_id);

--- a/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.component.js
+++ b/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.component.js
@@ -19,7 +19,6 @@ import Loader from 'Component/Loader';
 import ProductPrice from 'Component/ProductPrice';
 import { DeviceType } from 'Type/Device';
 import { ProductType } from 'Type/ProductList';
-import { CONFIGURABLE } from 'Util/Product';
 
 import {
     PRODUCT_ADD_TO_CART_DEFAULT_QUANTITY,
@@ -37,22 +36,32 @@ export class ProductCompareItem extends PureComponent {
         getGroupedProductQuantity: PropTypes.func.isRequired,
         getProductOptionsData: PropTypes.func.isRequired,
         device: DeviceType.isRequired,
-        imgUrl: PropTypes.string.isRequired
+        imgUrl: PropTypes.string.isRequired,
+        overrideAddToCartBtnBehavior: PropTypes.bool.isRequired,
+        linkTo: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.shape({})
+        ]),
+        overriddenAddToCartBtnHandler: PropTypes.func.isRequired
+    };
+
+    static defaultProps = {
+        linkTo: {}
     };
 
     renderProductImage() {
         const {
             product: {
                 id,
-                name,
-                url
+                name
             },
-            imgUrl
+            imgUrl,
+            linkTo
         } = this.props;
 
         return (
             <figure block="ProductCompareItem" elem="Figure">
-                <Link block="ProductCompareItem" elem="ImageLink" to={ url }>
+                <Link block="ProductCompareItem" elem="ImageLink" to={ linkTo }>
                     <Image
                       ratio="custom"
                       src={ imgUrl }
@@ -65,20 +74,20 @@ export class ProductCompareItem extends PureComponent {
     }
 
     renderTitle() {
-        const { product: { name, url } } = this.props;
+        const { product: { name }, linkTo } = this.props;
 
         return (
             <Link
               block="ProductCompareItem"
               elem="Title"
-              to={ url }
+              to={ linkTo }
             >
                 { name }
             </Link>
         );
     }
 
-    renderAddToCartBtn() {
+    renderAddToCartBtnEnabled() {
         const {
             product,
             getGroupedProductQuantity,
@@ -97,20 +106,34 @@ export class ProductCompareItem extends PureComponent {
         );
     }
 
-    renderAddToCartBtnWrapper() {
-        const {
-            product: { type_id, url }
-        } = this.props;
-
-        if (type_id !== CONFIGURABLE) {
-            return this.renderAddToCartBtn();
-        }
-
+    renderAddToCartBtnDisabled() {
+        const { linkTo, overriddenAddToCartBtnHandler } = this.props;
         return (
-            <Link to={ url }>
-                { this.renderAddToCartBtn() }
+            <Link
+              to={ linkTo }
+              onClick={ overriddenAddToCartBtnHandler }
+              block="ProductCompareItem"
+              elem="AddToCartBtnWrapper"
+            >
+                <AddToCart
+                  product={ {} }
+                  groupedProductQuantity={ {} }
+                  productOptionsData={ {} }
+                  disableHandler
+                  mix={ { block: 'ProductCompareItem', elem: 'AddToCartBtn' } }
+                />
             </Link>
         );
+    }
+
+    renderAddToCartBtn() {
+        const { overrideAddToCartBtnBehavior } = this.props;
+
+        if (!overrideAddToCartBtnBehavior) {
+            return this.renderAddToCartBtnEnabled();
+        }
+
+        return this.renderAddToCartBtnDisabled();
     }
 
     renderPrice() {
@@ -131,7 +154,7 @@ export class ProductCompareItem extends PureComponent {
             <div block="ProductCompareItem" elem="Details">
                 { this.renderPrice() }
                 { this.renderTitle() }
-                { this.renderAddToCartBtnWrapper() }
+                { this.renderAddToCartBtn() }
             </div>
         );
     }

--- a/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.container.js
+++ b/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.container.js
@@ -13,8 +13,10 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
+import { showNotification } from 'Store/Notification/Notification.action';
 import { DeviceType } from 'Type/Device';
 import { ProductType } from 'Type/ProductList';
+import { BUNDLE, CONFIGURABLE } from 'Util/Product';
 
 import ProductCompareItem from './ProductCompareItem.component';
 
@@ -32,7 +34,8 @@ export const mapStateToProps = (state) => ({
 export const mapDispatchToProps = (dispatch) => ({
     removeComparedProduct: (productId) => ProductCompareDispatcher.then(
         ({ default: dispatcher }) => dispatcher.removeComparedProduct(productId, dispatch)
-    )
+    ),
+    showNotification: (type, message) => dispatch(showNotification(type, message))
 });
 
 /** @namespace Component/ProductCompareItem/Container */
@@ -40,7 +43,8 @@ export class ProductCompareItemContainer extends PureComponent {
     static propTypes = {
         product: ProductType.isRequired,
         removeComparedProduct: PropTypes.func.isRequired,
-        device: DeviceType.isRequired
+        device: DeviceType.isRequired,
+        showNotification: PropTypes.func.isRequired
     };
 
     state = {
@@ -50,11 +54,14 @@ export class ProductCompareItemContainer extends PureComponent {
     containerFunctions = {
         removeComparedProduct: this.removeComparedProduct.bind(this),
         getGroupedProductQuantity: this.getGroupedProductQuantity.bind(this),
-        getProductOptionsData: this.getProductOptionsData.bind(this)
+        getProductOptionsData: this.getProductOptionsData.bind(this),
+        overriddenAddToCartBtnHandler: this.overriddenAddToCartBtnHandler.bind(this)
     };
 
     containerProps = {
-        imgUrl: this.getProductImage()
+        imgUrl: this.getProductImage(),
+        overrideAddToCartBtnBehavior: this.getOverrideAddToCartBtnBehavior(),
+        linkTo: this.getLinkTo()
     };
 
     async removeComparedProduct() {
@@ -111,6 +118,27 @@ export class ProductCompareItemContainer extends PureComponent {
         }
 
         return thumbnail.url;
+    }
+
+    getLinkTo() {
+        const { product: { url }, product } = this.props;
+
+        return {
+            pathname: url,
+            state: { product }
+        };
+    }
+
+    getOverrideAddToCartBtnBehavior() {
+        const { product: { type_id, options } } = this.props;
+        const types = [BUNDLE, CONFIGURABLE];
+
+        return !!(types.indexOf(type_id) !== -1 || options?.length);
+    }
+
+    overriddenAddToCartBtnHandler() {
+        const { showNotification } = this.props;
+        showNotification('info', __('Please select required option!'));
     }
 
     render() {


### PR DESCRIPTION
Fixes #2062 
Fixed add to cart button behavior for bundled, configurable and customizable products.
Fixed product redirect to 404 before loading product page.

Related PR
scandipwa/compare-graphql/pull/6