### PR TITLE
Changed node v10.x to v12.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: '12.x'
       - name: Install Dependencies
         run: yarn
       - name: Lint JS


### PR DESCRIPTION
Improving the ESLint runner node version, based on:  `error @scandipwa/scandipwa-scripts@2.2.0: The engine "node" is incompatible with this module. Expected version ">=12.0.0". Got "10.23.1"`