### PR TITLE
#1559 - 'Not found' page isn't rendered if a disabled CMS page is loaded

### DIFF
--- a/packages/scandipwa/src/route/CmsPage/CmsPage.component.js
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.component.js
@@ -14,6 +14,7 @@ import { PureComponent } from 'react';
 
 import Html from 'Component/Html';
 import TextPlaceholder from 'Component/TextPlaceholder';
+import NoMatch from 'Route/NoMatch';
 import { BlockListType } from 'Type/CMS';
 
 import './CmsPage.style';
@@ -23,7 +24,8 @@ export class CmsPage extends PureComponent {
     static propTypes = {
         isLoading: PropTypes.bool.isRequired,
         isBreadcrumbsActive: PropTypes.bool,
-        page: BlockListType.isRequired
+        page: BlockListType.isRequired,
+        isPageLoaded: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -68,8 +70,17 @@ export class CmsPage extends PureComponent {
     }
 
     render() {
-        const { page, isBreadcrumbsActive } = this.props;
+        const {
+            page,
+            isBreadcrumbsActive,
+            isLoading,
+            isPageLoaded
+        } = this.props;
         const { page_width } = page;
+
+        if (!isLoading && !isPageLoaded) {
+            return <NoMatch />;
+        }
 
         return (
             <main

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
@@ -78,7 +78,8 @@ export class CmsPageContainer extends DataContainer {
 
     state = {
         page: {},
-        isLoading: true
+        isLoading: true,
+        isPageLoaded: false
     };
 
     __construct(props) {
@@ -183,7 +184,7 @@ export class CmsPageContainer extends DataContainer {
             });
         }
 
-        this.setState({ page, isLoading: false });
+        this.setState({ page, isLoading: false, isPageLoaded: true });
     };
 
     getRequestQueryParams() {
@@ -221,7 +222,8 @@ export class CmsPageContainer extends DataContainer {
 
         this.fetchData(
             [CmsPageQuery.getQuery(params)],
-            this.onPageLoad
+            this.onPageLoad,
+            () => this.setState({ isLoading: false })
         );
     }
 

--- a/packages/scandipwa/src/route/NoMatch/NoMatch.container.js
+++ b/packages/scandipwa/src/route/NoMatch/NoMatch.container.js
@@ -18,6 +18,7 @@ import SharedTransitionContainer from 'Component/SharedTransition/SharedTransiti
 import { updateMeta } from 'Store/Meta/Meta.action';
 import { changeNavigationState } from 'Store/Navigation/Navigation.action';
 import { TOP_NAVIGATION_TYPE } from 'Store/Navigation/Navigation.reducer';
+import { updateNoMatch } from 'Store/NoMatch/NoMatch.action';
 
 import NoMatch from './NoMatch.component';
 
@@ -34,7 +35,8 @@ export const mapDispatchToProps = (dispatch) => ({
         );
     },
     updateMeta: (meta) => dispatch(updateMeta(meta)),
-    changeHeaderState: (state) => dispatch(changeNavigationState(TOP_NAVIGATION_TYPE, state))
+    changeHeaderState: (state) => dispatch(changeNavigationState(TOP_NAVIGATION_TYPE, state)),
+    updateNoMatch: (options) => dispatch(updateNoMatch(options))
 });
 
 /** @namespace Route/NoMatch/Container/mapStateToProps */
@@ -48,12 +50,14 @@ export class NoMatchContainer extends PureComponent {
     static propTypes = {
         changeHeaderState: PropTypes.func.isRequired,
         updateMeta: PropTypes.func.isRequired,
+        updateNoMatch: PropTypes.func.isRequired,
         urlRewrite: PropTypes.object.isRequired
     };
 
     componentDidMount() {
         this.updateHeaderState();
         this.updateMeta();
+        this.updateNoMatch();
     }
 
     updateHeaderState() {
@@ -70,6 +74,12 @@ export class NoMatchContainer extends PureComponent {
         const { updateMeta } = this.props;
 
         updateMeta({ title: __('Page not found'), status_code: '404' });
+    }
+
+    updateNoMatch() {
+        const { updateNoMatch } = this.props;
+
+        updateNoMatch(true);
     }
 
     render() {

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.js
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.js
@@ -36,8 +36,7 @@ export class UrlRewrites extends PureComponent {
     static propTypes = {
         isNotFound: PropTypes.bool,
         props: PropTypes.object,
-        type: PropTypes.string,
-        updateNoMatch: PropTypes.func.isRequired
+        type: PropTypes.string
     };
 
     static defaultProps = {
@@ -53,7 +52,7 @@ export class UrlRewrites extends PureComponent {
     }
 
     renderContent() {
-        const { props, type, updateNoMatch } = this.props;
+        const { props, type } = this.props;
 
         switch (type) {
         case TYPE_PRODUCT:
@@ -63,7 +62,6 @@ export class UrlRewrites extends PureComponent {
         case TYPE_CATEGORY:
             return <CategoryPage { ...props } />;
         case TYPE_NOTFOUND:
-            updateNoMatch({ noMatch: true });
             return <NoMatch { ...props } />;
         default:
             return this.renderDefaultPage();

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.js
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.js
@@ -46,11 +46,6 @@ export const mapDispatchToProps = (dispatch) => ({
         UrlRewritesDispatcher.then(
             ({ default: dispatcher }) => dispatcher.handleData(dispatch, { urlParam })
         );
-    },
-    updateNoMatch: (options) => {
-        NoMatchDispatcher.then(
-            ({ default: dispatcher }) => dispatcher.updateNoMatch(dispatch, options)
-        );
     }
 });
 
@@ -68,8 +63,7 @@ export class UrlRewritesContainer extends PureComponent {
             type: PropTypes.string,
             sku: PropTypes.string,
             notFound: PropTypes.bool
-        }).isRequired,
-        updateNoMatch: PropTypes.func.isRequired
+        }).isRequired
     };
 
     static defaultProps = {
@@ -124,15 +118,10 @@ export class UrlRewritesContainer extends PureComponent {
         }
     }
 
-    containerProps = () => {
-        const { updateNoMatch } = this.props;
-
-        return {
-            type: this.getType(),
-            props: this.getProps(),
-            updateNoMatch
-        };
-    };
+    containerProps = () => ({
+        type: this.getType(),
+        props: this.getProps()
+    });
 
     getTypeSpecificProps() {
         const {


### PR DESCRIPTION
Fixes issue #1559 

- Added logic that renders a 404 page in cases when the CMS page is disabled and not fetched
- Moved the no match reducer update from UrlRewrites to NoMatch component

I remember that in previous versions of SWPWA we were able to render the 404 page just by setting the `noMatch: true` in the NoMatch reducer but for some reason, it doesn't work anymore - why so? I noticed that in the ContactPage component the NoMatch component is rendered directly so I ended up doing the same.