### PR TITLE
Adding slash to store regexp, to properly strip language prefixes

### DIFF
--- a/packages/m2-theme/public/index.php
+++ b/packages/m2-theme/public/index.php
@@ -31,7 +31,7 @@
 
             // Multistore
             window.storeList = JSON.parse(`<?= $this->getStoreListJson() ?>`);
-            window.storeRegexText = `/(${window.storeList.join('|')})?`;
+            window.storeRegexText = `/(${window.storeList.join('|')})/?`;
         </script>
 
         <!-- Preload i18n chunk for the store -->

--- a/packages/scandipwa/public/index.html
+++ b/packages/scandipwa/public/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
-    
+
     <!-- Muli font import from Abode -->
     <link rel="stylesheet" href="https://use.typekit.net/gbk7rfi.css">
 
@@ -11,12 +11,12 @@
     <title>ScandiPWA</title>
     <meta name="theme-color" content="#ffffff" />
     <meta name="description" content="Web site created using create-scandipwa-app" />
-    
+
     <!-- Default content-configurations -->
     <script>
         window.contentConfiguration = {};
         window.storeList = ['default'];
-        window.storeRegexText = `/(${window.storeList.join('|')})?`;
+        window.storeRegexText = `/(${window.storeList.join('|')})/?`;
     </script>
 </head>
 <body>


### PR DESCRIPTION
This fixes 404 error on multi store sites with language code (store code) in the url. Without it produt urls on locale sites start with `/` and result in 404