### PR TITLE
Free Shipping Coupon Fixes

### DIFF
--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.container.js
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.container.js
@@ -35,11 +35,13 @@ export class CartCouponContainer extends PureComponent {
     static propTypes = {
         couponCode: PropTypes.string,
         applyCouponToCart: PropTypes.func.isRequired,
-        removeCouponFromCart: PropTypes.func.isRequired
+        removeCouponFromCart: PropTypes.func.isRequired,
+        onCouponCodeUpdate: PropTypes.func
     };
 
     static defaultProps = {
-        couponCode: ''
+        couponCode: '',
+        onCouponCodeUpdate: () => {}
     };
 
     containerFunctions = {
@@ -50,23 +52,29 @@ export class CartCouponContainer extends PureComponent {
     state = { isLoading: false };
 
     handleApplyCouponToCart(couponCode) {
-        const { applyCouponToCart } = this.props;
+        const { applyCouponToCart, onCouponCodeUpdate } = this.props;
 
         this.setState({ isLoading: true });
 
         applyCouponToCart(couponCode).then(
             /** @namespace Component/CartCoupon/Container/applyCouponToCartThen */
+            () => onCouponCodeUpdate()
+        ).finally(
+            /** @namespace Component/CartCoupon/Container/applyCouponToCartFinally */
             () => this.setState({ isLoading: false })
         );
     }
 
     handleRemoveCouponFromCart() {
-        const { removeCouponFromCart } = this.props;
+        const { removeCouponFromCart, onCouponCodeUpdate } = this.props;
 
         this.setState({ isLoading: true });
 
         removeCouponFromCart().then(
             /** @namespace Component/CartCoupon/Container/removeCouponFromCartThen */
+            () => onCouponCodeUpdate()
+        ).finally(
+            /** @namespace Component/CartCoupon/Container/removeCouponFromCartFinally */
             () => this.setState({ isLoading: false })
         );
     }

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -16,7 +16,7 @@ import CartCoupon from 'Component/CartCoupon';
 import CartItem from 'Component/CartItem';
 import CheckoutOrderSummaryPriceLine from 'Component/CheckoutOrderSummaryPriceLine';
 import ExpandableContent from 'Component/ExpandableContent';
-import { BILLING_STEP } from 'Route/Checkout/Checkout.config';
+import { BILLING_STEP, SHIPPING_STEP } from 'Route/Checkout/Checkout.config';
 import { TotalsType } from 'Type/MiniCart';
 
 import './CheckoutOrderSummary.style';
@@ -37,7 +37,8 @@ export class CheckoutOrderSummary extends PureComponent {
         cartSubtotalSubPrice: PropTypes.number,
         cartShippingPrice: PropTypes.number,
         cartShippingSubPrice: PropTypes.number,
-        cartTotalSubPrice: PropTypes.number
+        cartTotalSubPrice: PropTypes.number,
+        onCouponCodeUpdate: PropTypes.func
     };
 
     static defaultProps = {
@@ -49,7 +50,8 @@ export class CheckoutOrderSummary extends PureComponent {
         cartSubtotalSubPrice: null,
         cartShippingPrice: 0,
         cartShippingSubPrice: null,
-        cartTotalSubPrice: null
+        cartTotalSubPrice: null,
+        onCouponCodeUpdate: () => {}
     };
 
     renderPriceLine(price, title, mods) {
@@ -292,13 +294,18 @@ export class CheckoutOrderSummary extends PureComponent {
     }
 
     renderCoupon() {
-        const { couponCode } = this.props;
+        const { couponCode, onCouponCodeUpdate, checkoutStep } = this.props;
+
+        if (checkoutStep === SHIPPING_STEP) {
+            return null;
+        }
 
         return (
             <CartCoupon
               couponCode={ couponCode }
               mix={ { block: 'CheckoutOrderSummary', elem: 'Coupon' } }
               title={ __('Have a discount code?') }
+              onCouponCodeUpdate={ onCouponCodeUpdate }
             />
         );
     }

--- a/packages/scandipwa/src/component/CheckoutOrderSummaryPriceLine/CheckoutOrderSummaryPriceLine.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummaryPriceLine/CheckoutOrderSummaryPriceLine.component.js
@@ -18,7 +18,7 @@ import { formatPrice } from 'Util/Price';
 /** @namespace Component/CheckoutOrderSummaryPriceLine/Component */
 export class CheckoutOrderSummaryPriceLine extends PureComponent {
     static propTypes = {
-        price: PropTypes.number.isRequired,
+        price: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
         currency: PropTypes.string.isRequired,
         title: PropTypes.string.isRequired,
         mods: PropTypes.object,

--- a/packages/scandipwa/src/component/Field/Field.component.js
+++ b/packages/scandipwa/src/component/Field/Field.component.js
@@ -54,7 +54,7 @@ export class Field extends PureComponent {
             PropTypes.bool
         ]),
         validation: PropTypes.arrayOf(PropTypes.string).isRequired,
-        validationStatus: PropTypes.string,
+        validationStatus: PropTypes.bool,
         checked: PropTypes.oneOfType([
             PropTypes.bool,
             PropTypes.string

--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -68,7 +68,8 @@ export class Checkout extends PureComponent {
         isGuestEmailSaved: PropTypes.bool.isRequired,
         goBack: PropTypes.func.isRequired,
         totals: TotalsType.isRequired,
-        isMobile: PropTypes.bool.isRequired
+        isMobile: PropTypes.bool.isRequired,
+        onCouponCodeUpdate: PropTypes.func.isRequired
     };
 
     static defaultProps = {
@@ -246,7 +247,8 @@ export class Checkout extends PureComponent {
             checkoutStep,
             paymentTotals,
             isMobile,
-            totals: { coupon_code }
+            totals: { coupon_code },
+            onCouponCodeUpdate
         } = this.props;
         const { areTotalsVisible } = this.stepMap[checkoutStep];
 
@@ -263,6 +265,7 @@ export class Checkout extends PureComponent {
               couponCode={ coupon_code }
               // eslint-disable-next-line react/jsx-no-bind
               renderCmsBlock={ () => this.renderPromo(true) }
+              onCouponCodeUpdate={ onCouponCodeUpdate }
             />
         );
     }
@@ -281,10 +284,12 @@ export class Checkout extends PureComponent {
     renderCartCoupon() {
         const {
             totals: { coupon_code },
-            isMobile
+            isMobile,
+            onCouponCodeUpdate,
+            checkoutStep
         } = this.props;
 
-        if (isMobile) {
+        if (isMobile || checkoutStep === SHIPPING_STEP) {
             return null;
         }
 
@@ -293,7 +298,10 @@ export class Checkout extends PureComponent {
               heading={ __('Have a discount code?') }
               mix={ { block: 'Checkout', elem: 'Coupon' } }
             >
-                <CartCoupon couponCode={ coupon_code } />
+                <CartCoupon
+                  couponCode={ coupon_code }
+                  onCouponCodeUpdate={ onCouponCodeUpdate }
+                />
             </ExpandableContent>
         );
     }

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -138,6 +138,7 @@ export class CheckoutContainer extends PureComponent {
         onEmailChange: this.onEmailChange.bind(this),
         onCreateUserChange: this.onCreateUserChange.bind(this),
         onPasswordChange: this.onPasswordChange.bind(this),
+        onCouponCodeUpdate: this.onCouponCodeUpdate.bind(this),
         goBack: this.goBack.bind(this)
     };
 
@@ -170,7 +171,8 @@ export class CheckoutContainer extends PureComponent {
             paymentTotals: BrowserDatabase.getItem(PAYMENT_TOTALS) || {},
             email: '',
             isGuestEmailSaved: false,
-            isCreateUser: false
+            isCreateUser: false,
+            estimateAddress: {}
         };
 
         if (is_virtual) {
@@ -253,7 +255,8 @@ export class CheckoutContainer extends PureComponent {
 
         this.setState({
             isDeliveryOptionsLoading: true,
-            requestsSent: requestsSent + 1
+            requestsSent: requestsSent + 1,
+            estimateAddress: address
         });
 
         fetchMutation(CheckoutQuery.getEstimateShippingCosts(
@@ -272,6 +275,17 @@ export class CheckoutContainer extends PureComponent {
             },
             this._handleError
         );
+    }
+
+    onCouponCodeUpdate() {
+        const { estimateAddress, checkoutStep } = this.state;
+
+        // update delivery methods on coupon change
+        // in order ot fetch new available delivery methods
+        // if any could be applied by coupon
+        if (checkoutStep === SHIPPING_STEP) {
+            this.onShippingEstimationFieldsChange(estimateAddress);
+        }
     }
 
     goBack() {


### PR DESCRIPTION
Fixes #2081

There are two ways how coupon is affecting shipping.
1. When coupon is applied, free shipping delivery method is displayed on the checkout shipping page.
https://docs.magento.com/user-guide/marketing/price-rules-cart-free-shipping.html
2. Selected shipping method gets discount.
https://community.magento.com/t5/Magento-2-x-Admin-Configuration/50-Off-Shipping-Rule/m-p/126798/highlight/true#M3861

We are not calculating cart totals.
Thus for the second case cart totals are updated according to magento cart logic.

We don't update the shipping price / grand total on delivery method change.
And since we don't have ability to select a delivery method on the cart page, we still see same estimated shipping price after coupon is applied.

So i've added ability to reload delivery method list on coupon changes on the checkout shipping step.
Then i've talked to @lianastaskevica and we decided to remove coupon component from the shipping page, since it't not present on the magento luma's shipping page too.

In addition i've fixed some component prop related warnings from the console.