### PR TITLE
[QA FIX] #2162 wrong border color in ProductCustomizableOption text field

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.container.js
+++ b/packages/scandipwa/src/component/Field/Field.container.js
@@ -57,6 +57,7 @@ export class FieldContainer extends PureComponent {
         max: PropTypes.number,
         validation: PropTypes.arrayOf(PropTypes.string),
         message: PropTypes.string,
+        customValidationStatus: PropTypes.bool,
         id: PropTypes.string,
         formRef: PropTypes.oneOfType([
             PropTypes.func,
@@ -79,6 +80,7 @@ export class FieldContainer extends PureComponent {
         isControlled: false,
         validation: [],
         message: '',
+        customValidationStatus: null,
         id: '',
         formRefMap: {}
     };
@@ -152,7 +154,8 @@ export class FieldContainer extends PureComponent {
 
     containerProps = () => {
         const {
-            checked: propsChecked
+            checked: propsChecked,
+            customValidationStatus
         } = this.props;
 
         const {
@@ -166,7 +169,7 @@ export class FieldContainer extends PureComponent {
         return {
             checked: type === CHECKBOX_TYPE ? propsChecked : checked,
             value,
-            validationStatus,
+            validationStatus: customValidationStatus ?? validationStatus,
             message: validationMessage
         };
     };
@@ -310,9 +313,11 @@ export class FieldContainer extends PureComponent {
     }
 
     render() {
+        const { customValidationStatus, ...otherProps } = this.props;
+
         return (
             <Field
-              { ...this.props }
+              { ...otherProps }
               { ...this.containerProps() }
               { ...this.containerFunctions }
             />

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
@@ -27,11 +27,16 @@ export class ProductCustomizableOption extends PureComponent {
         getSelectedCheckboxValue: PropTypes.func.isRequired,
         renderOptionLabel: PropTypes.func.isRequired,
         updateTextFieldValue: PropTypes.func.isRequired,
+        textFieldValid: PropTypes.bool,
         setDropdownValue: PropTypes.func.isRequired,
         selectedDropdownValue: PropTypes.number.isRequired,
         optionType: PropTypes.string.isRequired,
         getDropdownOptions: PropTypes.func.isRequired,
         requiredSelected: PropTypes.bool.isRequired
+    };
+
+    static defaultProps = {
+        textFieldValid: null
     };
 
     renderMap = {
@@ -181,7 +186,8 @@ export class ProductCustomizableOption extends PureComponent {
             },
             updateTextFieldValue,
             textValue,
-            optionType
+            optionType,
+            textFieldValid
         } = this.props;
         const { max_characters } = data;
         const fieldType = optionType === 'field' ? 'text' : 'textarea';
@@ -195,6 +201,7 @@ export class ProductCustomizableOption extends PureComponent {
                   maxLength={ max_characters > 0 ? max_characters : null }
                   value={ textValue }
                   onChange={ updateTextFieldValue }
+                  customValidationStatus={ textFieldValid }
                 />
                 { this.renderRequired(required) }
                 { this.renderMaxCharacters(max_characters) }

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.container.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.container.js
@@ -28,7 +28,8 @@ export class ProductCustomizableOptionContainer extends PureComponent {
 
     state = {
         textValue: '',
-        selectedDropdownValue: 0
+        selectedDropdownValue: 0,
+        textFieldValid: null
     };
 
     containerFunctions = {
@@ -111,10 +112,13 @@ export class ProductCustomizableOptionContainer extends PureComponent {
 
     updateTextFieldValue(value) {
         const { option, setCustomizableOptionTextFieldValue } = this.props;
-        const { option_id } = option;
+        const { option_id, required } = option;
 
         setCustomizableOptionTextFieldValue(option_id, value);
-        this.setState({ fieldValue: value });
+        this.setState({
+            fieldValue: value,
+            textFieldValid: required ? value.length > 0 : true
+        });
     }
 
     setDropdownValue(value) {


### PR DESCRIPTION
Bug: https://github.com/scandipwa/scandipwa/issues/2162

**Root cause of the issue:**
Method `validateField` of Field component is able to work only with fields that are part of a form.
https://github.com/scandipwa/scandipwa/blob/master/packages/scandipwa/src/component/Field/Field.container.js#L174
As ProductCustomizableOption text field is not part of any form, current implementation always returns validationStatus equal to `true` => field will always have green borders once you start typing.

Even if you modify `validateField` to work with single fields + add validation rule `not empty` to `ProductCustomizableOption` component, you encounter the problem that error messages are duplicated:
![image](https://user-images.githubusercontent.com/79456428/108827235-6a315080-75d6-11eb-95d5-c16a72529e8b.png)
The reason for this is that ProductCustomizableOption already has customized error messages, apart from those triggered by validation rules.

**Solution:**
Explanation above means that we need a mechanism to control color of the field border without adding validation rules, which is why I came to a solution of adding `customValidationStatus` property and passing its value straight to Field component as props.