### PR TITLE
#1745 Remove currency option and fix styles

### DIFF
--- a/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.component.js
+++ b/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.component.js
@@ -62,7 +62,6 @@ export class CurrencySwitcher extends PureComponent {
                       id="CurrencySwitcherList"
                       name="CurrencySwitcherList"
                       type="select"
-                      placeholder={ __('Select currency') }
                       selectOptions={ availableCurrencies }
                       value={ this.getCurrencyValue() }
                       onChange={ handleCurrencySelect }

--- a/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.style.scss
+++ b/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.style.scss
@@ -19,6 +19,7 @@
 
     @include desktop {
         display: inline-block;
+        margin-right: 28px;
 
         .Field {
             margin: .5rem;
@@ -36,6 +37,7 @@
                 transition: transform 200ms ease-in-out;
                 transform: rotate(180deg);
                 will-change: transform;
+                right: -17px;
             }
 
             &[aria-expanded='true'] {
@@ -55,11 +57,12 @@
                 overflow-y: auto;
                 text-align: center;
                 margin-top: 1rem;
+                width: min-content;
             }
 
             &-Option {
-                padding: 0;
                 line-height: 2.8rem;
+                padding: 6px 12px;
                 font-size: 1.2rem;
             }
         }

--- a/packages/scandipwa/src/component/StoreSwitcher/StoreSwitcher.style.scss
+++ b/packages/scandipwa/src/component/StoreSwitcher/StoreSwitcher.style.scss
@@ -20,14 +20,12 @@
     }
 
     @include before-desktop {
-        --input-padding: 1.2rem;
         border-bottom: 1px solid var(--primary-divider-color);
         order: 1;
         margin-bottom: 1.2rem;
     }
 
     @include mobile {
-        --input-padding: 1.4rem;
         margin-bottom: 1.4rem;
     }
 


### PR DESCRIPTION
Select currency option was removed from Android devices.

### Before:
![image](https://user-images.githubusercontent.com/79456428/108961460-70800500-7688-11eb-8a79-f1fad6b25eea.png)

### After:
![image](https://user-images.githubusercontent.com/79456428/108961486-7a096d00-7688-11eb-8918-b47cc27b2a6f.png)

Removing the option broke select layout, which is why style modifications very required.

Also fixed alignment of the 2 dropdowns (currency and country) on mobile version.

### Before:
![image](https://user-images.githubusercontent.com/79456428/108961155-fea7bb80-7687-11eb-9b34-73950e4a8a82.png)

### After:
![image](https://user-images.githubusercontent.com/79456428/108961185-06fff680-7688-11eb-8acd-bdb50db79a73.png)
 