### PR TITLE
@scandipwa/webpack-i18n-runtime update

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -11,7 +11,7 @@
         "@scandipwa/m2-theme": "^0.1.3",
         "@scandipwa/scandipwa-scripts": "^2.2.4",
         "@scandipwa/service-worker": "^0.0.4",
-        "@scandipwa/webpack-i18n-runtime": "^0.0.8",
+        "@scandipwa/webpack-i18n-runtime": "0.0.9",
         "braintree-web-drop-in": "^1.23.0",
         "history": "^4.9.0",
         "html-react-parser": "^0.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,10 +2542,10 @@
   dependencies:
     "@scandipwa/scandipwa-dev-utils" "0.0.20"
 
-"@scandipwa/webpack-i18n-runtime@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@scandipwa/webpack-i18n-runtime/-/webpack-i18n-runtime-0.0.8.tgz#9b4362ed08ee2184b1a5a23ff2ee135cbc502e68"
-  integrity sha512-7qqDEETI/CqMf5A3NnOfohzW8k0A/Y8Ehf1STqAu92CiHoZ1MPDzDdgMXKD8tMvPTtBmV1enbx8+pyvI+Eg67w==
+"@scandipwa/webpack-i18n-runtime@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@scandipwa/webpack-i18n-runtime/-/webpack-i18n-runtime-0.0.9.tgz#fcbd68603c0ac35b1274891594962c6732ea7fb5"
+  integrity sha512-wxT+ynMKHDHXAw/VDjWV8WiD5NzmhyguKw4hnA31QtaTHLVv15TMDU+HhZzx3hX1uS3qNisyQFwy6BzopgfL+g==
   dependencies:
     "@scandipwa/scandipwa-dev-utils" "0.0.20"
     "@scandipwa/webpack-after-emit-logger" "0.0.3"


### PR DESCRIPTION
There were an issue in CRA repo, that crashed project startup on Windows.
scandipwa/create-scandipwa-app#11

But after merge `@scandipwa/webpack-i18n-runtime` package version didn't updated in this repo.
Thus fresh installs still fetched old package with the bug.

Updated `@scandipwa/webpack-i18n-runtime` package version in order to fix installs.