### PR TITLE
Bugfix/1674/virtual product shipping

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -429,5 +429,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://scandipwapmrev.indvp.com/"
+    "proxy": "https://40kskudemo.scandipwa.com/"
 }

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -429,5 +429,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://40kskudemo.scandipwa.com/"
+    "proxy": "https://scandipwapmrev.indvp.com/"
 }

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -278,11 +278,6 @@ export class CheckoutContainer extends PureComponent {
         const { checkoutStep } = this.state;
 
         if (checkoutStep === BILLING_STEP) {
-            this.setState({
-                isLoading: false,
-                checkoutStep: SHIPPING_STEP
-            });
-
             BrowserDatabase.deleteItem(PAYMENT_TOTALS);
         }
 

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -278,6 +278,9 @@ export class CheckoutContainer extends PureComponent {
         const { checkoutStep } = this.state;
 
         if (checkoutStep === BILLING_STEP) {
+            this.setState({
+                isLoading: false
+            });
             BrowserDatabase.deleteItem(PAYMENT_TOTALS);
         }
 


### PR DESCRIPTION
The reason why the issue is typical to Mobile version is that click on Go Back button (which is not displayed in desktop version) is handled without taking into account difference between checkout steps for virtual and real products.

![image](https://user-images.githubusercontent.com/79456428/109045122-40664f80-76e4-11eb-8084-6d2938fbc5d6.png)

This behavior is wrong for virtual products, as we need to go back directly to cart:
```
 if (checkoutStep === BILLING_STEP) {
     this.setState({
         checkoutStep: SHIPPING_STEP
     });
  }
```

In fact we don't need to explicitly set CHECKOUT_STEP equal to SHIPPING_STEP. `history.goBack()` does the required work. As Shipping step was skipped when going from Cart to Billing, it is skipped as well when going in the opposite direction. 
