### PR TITLE
issue-2063 - Add support for require country state/province

### DIFF
--- a/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
+++ b/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
@@ -155,7 +155,13 @@ export class CheckoutAddressForm extends MyAccountAddressForm {
     }
 
     getRegionFields() {
+        const { regionDisplayAll } = this.props;
         const regionFieldData = super.getRegionFields();
+
+        if (!regionDisplayAll && !regionFieldData) {
+            return null;
+        }
+
         const { region_string } = regionFieldData;
 
         if (region_string) {

--- a/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.container.js
+++ b/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.container.js
@@ -19,7 +19,8 @@ export const mapStateToProps = (state) => ({
     default_country: state.ConfigReducer.default_country,
     addressLinesQty: state.ConfigReducer.address_lines_quantity,
     shippingFields: state.CheckoutReducer.shippingFields,
-    showVatNumber: state.ConfigReducer.show_vat_number_on_storefront
+    showVatNumber: state.ConfigReducer.show_vat_number_on_storefront,
+    regionDisplayAll: state.ConfigReducer.region_display_all
 });
 
 /** @namespace Component/CheckoutAddressForm/Container/mapDispatchToProps */

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
@@ -18,7 +18,8 @@ export const mapStateToProps = (state) => ({
     countries: state.ConfigReducer.countries,
     default_country: state.ConfigReducer.default_country,
     addressLinesQty: state.ConfigReducer.address_lines_quantity,
-    showVatNumber: state.ConfigReducer.show_vat_number_on_storefront
+    showVatNumber: state.ConfigReducer.show_vat_number_on_storefront,
+    regionDisplayAll: state.ConfigReducer.region_display_all
 });
 
 /** @namespace Component/MyAccountAddressForm/Container/mapDispatchToProps */

--- a/packages/scandipwa/src/query/Config.query.js
+++ b/packages/scandipwa/src/query/Config.query.js
@@ -124,6 +124,7 @@ export class ConfigQuery {
             'show_vat_number_on_storefront',
             'show_tax_vat_number',
             'cookie_lifetime',
+            'region_display_all',
             this.getPriceDisplayTypeField()
         ];
     }

--- a/packages/scandipwa/src/query/Region.query.js
+++ b/packages/scandipwa/src/query/Region.query.js
@@ -25,6 +25,7 @@ export class RegionQuery {
     _getCountryFields() {
         return [
             'id',
+            'is_state_required',
             this._getAvailableRegionsField(),
             new Field('full_name_locale').setAlias('label')
         ];


### PR DESCRIPTION
Fixes #2063 

Goes together with:
[directory-graphql/pull/1](https://github.com/scandipwa/directory-graphql/pull/1)
[store-graphql/pull/16](https://github.com/scandipwa/store-graphql/pull/16)

Support setting 'Allow to Choose State if It is Optional for Country', in this case if yes, then for all countries state/province can be added. In case if no, then state/province field is not present if only country is not requiring it from setting above.