### PR TITLE
#2181 ClickOutside with overlay

### DIFF
--- a/packages/scandipwa/src/component/ClickOutside/ClickOutside.component.js
+++ b/packages/scandipwa/src/component/ClickOutside/ClickOutside.component.js
@@ -54,7 +54,10 @@ export class ClickOutside extends PureComponent {
         const { onClick } = this.props;
 
         if (this.childrenRefs.every(
-            ({ current }) => !current.contains(target)
+            (ref) => {
+                const elementRef = ref.current?.overlayRef?.current || ref.current;
+                return !elementRef.contains(target);
+            }
         )) {
             onClick();
         }

--- a/packages/scandipwa/src/component/Overlay/Overlay.container.js
+++ b/packages/scandipwa/src/component/Overlay/Overlay.container.js
@@ -24,4 +24,5 @@ export const mapStateToProps = (state) => ({
 // eslint-disable-next-line no-unused-vars
 export const mapDispatchToProps = (dispatch) => ({});
 
-export default connect(mapStateToProps, mapDispatchToProps)(OverlayComponent);
+// eslint-disable-next-line @scandipwa/scandipwa-guidelines/always-both-mappings
+export default connect(mapStateToProps, mapDispatchToProps, null, { forwardRef: true })(OverlayComponent);


### PR DESCRIPTION
Fix the error with null refs when using <Overlay> component as direct child of <ClickOutside>.

Reason for the issue is that Overlay is not a DOM element, refs need to be forwarded for "handle click outside target" logic to work correctly.