### PR TITLE
issue-2179 - Fix bundle products

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.config.js
+++ b/packages/scandipwa/src/component/Field/Field.config.js
@@ -18,5 +18,6 @@ export const CHECKBOX_TYPE = 'checkbox';
 export const TEXTAREA_TYPE = 'textarea';
 export const PASSWORD_TYPE = 'password';
 export const SELECT_TYPE = 'select';
+export const MULTI_TYPE = 'multi';
 
 export const ENTER_KEY_CODE = 13;

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
@@ -182,7 +182,12 @@ export class ProductActions extends PureComponent {
 
     renderBundleItems() {
         const {
-            product: { items, type_id, price_range },
+            product: {
+                items,
+                type_id,
+                price_range,
+                sku
+            },
             maxQuantity,
             getSelectedCustomizableOptions,
             productOptionsData,
@@ -206,6 +211,7 @@ export class ProductActions extends PureComponent {
                   productOptionsData={ productOptionsData }
                   setBundlePrice={ setBundlePrice }
                   price_range={ price_range }
+                  sku={ sku }
                 />
             </section>
         );

--- a/packages/scandipwa/src/component/ProductBundleItem/ProductBundleItem.container.js
+++ b/packages/scandipwa/src/component/ProductBundleItem/ProductBundleItem.container.js
@@ -11,6 +11,10 @@
 
 import PropTypes from 'prop-types';
 
+import {
+    RADIO_TYPE,
+    SELECT_TYPE
+} from 'Component/Field/Field.config';
 import ProductCustomizableOptionContainer
     from 'Component/ProductCustomizableOption/ProductCustomizableOption.container';
 
@@ -21,7 +25,8 @@ export class ProductBundleItemContainer extends ProductCustomizableOptionContain
     static propTypes = {
         ...ProductCustomizableOptionContainer.propTypes,
         setCustomizableOptionTextFieldValue: PropTypes.func,
-        updateQuantity: PropTypes.func.isRequired
+        updateQuantity: PropTypes.func.isRequired,
+        sku: PropTypes.string.isRequired
     };
 
     static defaultProps = {
@@ -35,52 +40,33 @@ export class ProductBundleItemContainer extends ProductCustomizableOptionContain
     };
 
     componentDidMount() {
-        this.getDefaultValues();
+        const { option: { type } } = this.props;
+
+        if (type === SELECT_TYPE || type === RADIO_TYPE) {
+            this.setDefaultDropdownValue();
+        }
     }
 
-    getDefaultValues() {
-        const { optionType } = this.containerProps();
+    componentDidUpdate(prevProps) {
+        const { sku, option: { type } } = this.props;
+        const { sku: prevSku } = prevProps;
 
-        switch (optionType) {
-        case 'select':
-        case 'radio': // handle radio as select
+        if (sku !== prevSku && (type === SELECT_TYPE || type === RADIO_TYPE)) {
             this.setDefaultDropdownValue();
-            break;
-        case 'checkbox':
-        case 'multi': // handle multi-select as checkbox
-            this.setDefaultCheckboxValue();
-            break;
-        default:
-            return null;
         }
-
-        return null;
     }
 
     setDefaultDropdownValue() {
-        const {
-            setSelectedDropdownValue,
-            option: { option_id, options }
-        } = this.props;
+        const { option: { options } } = this.props;
+        const { selectedDropdownValue } = this.state;
 
-        return options.reduce((acc, { is_default, id, quantity }) => {
+        if (selectedDropdownValue) {
+            this.setState({ selectedDropdownValue: 0 });
+        }
+
+        return options.reduce((acc, { is_default, id }) => {
             if (is_default) {
-                const value = id.toString();
-                setSelectedDropdownValue(option_id, { value, quantity });
                 this.setState({ selectedDropdownValue: id });
-            }
-
-            return acc;
-        }, []);
-    }
-
-    setDefaultCheckboxValue() {
-        const { option: { option_id, options }, setSelectedCheckboxValues } = this.props;
-
-        return options.reduce((acc, { is_default, id, quantity }) => {
-            if (is_default) {
-                const value = id.toString();
-                setSelectedCheckboxValues(option_id, { value, quantity });
             }
 
             return acc;

--- a/packages/scandipwa/src/component/ProductBundleItems/ProductBundleItems.component.js
+++ b/packages/scandipwa/src/component/ProductBundleItems/ProductBundleItems.component.js
@@ -21,7 +21,8 @@ export class ProductBundleItems extends ProductCustomizableOptions {
         ...ProductCustomizableOptions.propTypes,
         items: PropTypes.array,
         maxQuantity: PropTypes.number.isRequired,
-        updateQuantity: PropTypes.func.isRequired
+        updateQuantity: PropTypes.func.isRequired,
+        sku: PropTypes.string.isRequired
     };
 
     static defaultProps = {
@@ -36,7 +37,8 @@ export class ProductBundleItems extends ProductCustomizableOptions {
             maxQuantity,
             updateQuantity,
             productOptionsData,
-            price_range
+            price_range,
+            sku
         } = this.props;
 
         return items.map((item, key) => (
@@ -50,6 +52,7 @@ export class ProductBundleItems extends ProductCustomizableOptions {
               maxQuantity={ maxQuantity }
               updateQuantity={ updateQuantity }
               productOptionsData={ productOptionsData }
+              sku={ sku }
             />
         ));
     }

--- a/packages/scandipwa/src/component/ProductBundleItems/ProductBundleItems.container.js
+++ b/packages/scandipwa/src/component/ProductBundleItems/ProductBundleItems.container.js
@@ -12,6 +12,12 @@
 
 import PropTypes from 'prop-types';
 
+import {
+    CHECKBOX_TYPE,
+    MULTI_TYPE,
+    RADIO_TYPE,
+    SELECT_TYPE
+} from 'Component/Field/Field.config';
 import ProductCustomizableOptionsContainer
     from 'Component/ProductCustomizableOptions/ProductCustomizableOptions.container';
 import { ProductItemsType } from 'Type/ProductList';
@@ -23,7 +29,8 @@ export class ProductBundleItemsContainer extends ProductCustomizableOptionsConta
     static propTypes = {
         ...ProductCustomizableOptionsContainer.propTypes,
         items: ProductItemsType,
-        setBundlePrice: PropTypes.func.isRequired
+        setBundlePrice: PropTypes.func.isRequired,
+        sku: PropTypes.string.isRequired
     };
 
     static defaultProps = {
@@ -41,10 +48,13 @@ export class ProductBundleItemsContainer extends ProductCustomizableOptionsConta
         if (items) {
             this.stopLoading();
         }
+
+        this.setDefaultSelectedOptions();
     }
 
-    componentDidUpdate(_, prevState) {
+    componentDidUpdate(prevProps, prevState) {
         const { items } = this.props;
+        const { items: prevItems } = prevProps;
         const {
             selectedCheckboxValues,
             selectedDropdownOptions,
@@ -55,6 +65,10 @@ export class ProductBundleItemsContainer extends ProductCustomizableOptionsConta
             selectedCheckboxValues: prevSelectedCheckboxValues,
             selectedDropdownOptions: prevSelectedDropdownOptions
         } = prevState;
+
+        if (items !== prevItems) {
+            this.resetDefaultSelectOptions();
+        }
 
         if (items && isLoading) {
             this.stopLoading();
@@ -135,6 +149,62 @@ export class ProductBundleItemsContainer extends ProductCustomizableOptionsConta
             );
     }
 
+    resetDefaultSelectOptions() {
+        this.setState({
+            selectedCheckboxValues: [],
+            selectedDropdownOptions: []
+        }, () => this.setDefaultSelectedOptions());
+    }
+
+    setDefaultSelectedOptions() {
+        const { items } = this.props;
+
+        return items.reduce((acc, item) => {
+            const { type } = item;
+
+            switch (type) {
+            case SELECT_TYPE:
+            case RADIO_TYPE: // handle radio as select
+                this.setDefaultDropdownValue(item);
+                break;
+            case CHECKBOX_TYPE:
+            case MULTI_TYPE: // handle multi-select as checkbox
+                this.setDefaultCheckboxValue(item);
+                break;
+            default:
+                return acc;
+            }
+
+            return acc;
+        }, []);
+    }
+
+    setDefaultCheckboxValue(item) {
+        const { option_id, options } = item;
+
+        return options.reduce((acc, { is_default, id, quantity }) => {
+            if (is_default) {
+                const value = id.toString();
+                this.setSelectedCheckboxValues(option_id, { value, quantity });
+            }
+
+            return acc;
+        }, []);
+    }
+
+    setDefaultDropdownValue(item) {
+        const { option_id, options } = item;
+
+        return options.reduce((acc, { is_default, id, quantity }) => {
+            if (is_default) {
+                const value = id.toString();
+                this.setSelectedDropdownValue(option_id, { value, quantity });
+            }
+
+            return acc;
+        }, []);
+    }
+
     updateSelectedOptions() {
         const { getSelectedCustomizableOptions, setBundlePrice } = this.props;
         const { selectedDropdownOptions, selectedCheckboxValues } = this.state;
@@ -154,9 +224,10 @@ export class ProductBundleItemsContainer extends ProductCustomizableOptionsConta
     setSelectedDropdownValue(id, option) {
         const { selectedDropdownOptions } = this.state;
         const { value, quantity, option_id } = option;
-
+        console.log(id);
         if (!id) {
             const filteredOptions = selectedDropdownOptions.filter((item) => item.id !== option_id);
+            console.log(filteredOptions);
             this.setState({ selectedDropdownOptions: filteredOptions });
 
             return;

--- a/packages/scandipwa/src/component/ProductBundleItems/ProductBundleItems.container.js
+++ b/packages/scandipwa/src/component/ProductBundleItems/ProductBundleItems.container.js
@@ -224,10 +224,9 @@ export class ProductBundleItemsContainer extends ProductCustomizableOptionsConta
     setSelectedDropdownValue(id, option) {
         const { selectedDropdownOptions } = this.state;
         const { value, quantity, option_id } = option;
-        console.log(id);
+
         if (!id) {
             const filteredOptions = selectedDropdownOptions.filter((item) => item.id !== option_id);
-            console.log(filteredOptions);
             this.setState({ selectedDropdownOptions: filteredOptions });
 
             return;


### PR DESCRIPTION
Fixes #2179

Issue appears when we go from bundle to bundle from search. Component is not mounts again and not setting new default values + old one are still present so price is calculated from old selections. There was a problem with react tree structure for bundleitems component so it was  updating parent only after child is setting default values. So for this reason I moved default selection set from child container into parent. Now child is only checking default dropdown value (for checkbox it is already checked default);  And if product is changed then shot update to reset default selections.