### PR TITLE
bugfix #2197 configurable wishlist item without required options

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
@@ -167,6 +167,13 @@ export class WishlistItem extends PureComponent {
 
         const wishedVariant = product.variants.find(({ sku }) => sku === product.wishlist.sku);
 
+        if (!wishedVariant) {
+            return {
+                ...product,
+                url
+            };
+        }
+
         return {
             ...wishedVariant,
             url

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
@@ -142,7 +142,7 @@ export class WishlistItemContainer extends PureComponent {
             if (!configurableVariantIndex) {
                 history.push({ pathname: appendWithStoreCode(item.url) });
                 showNotification('info', __('Please select product options!'));
-                return;
+                return Promise.resolve();
             }
 
             item.configurableVariantIndex = configurableVariantIndex;
@@ -150,7 +150,7 @@ export class WishlistItemContainer extends PureComponent {
 
         this.setState({ isLoading: true });
 
-        addProductToCart({ product: item, quantity })
+        return addProductToCart({ product: item, quantity })
             .then(
                 /** @namespace Component/WishlistItem/Container/addItemToCartAddProductToCartThen */
                 () => this.removeItem(id),

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
@@ -18,7 +18,9 @@ import { changeNavigationState } from 'Store/Navigation/Navigation.action';
 import { TOP_NAVIGATION_TYPE } from 'Store/Navigation/Navigation.reducer';
 import { showNotification } from 'Store/Notification/Notification.action';
 import { ProductType } from 'Type/ProductList';
+import history from 'Util/History';
 import { debounce } from 'Util/Request';
+import { appendWithStoreCode } from 'Util/Url';
 
 import WishlistItem from './WishlistItem.component';
 import { UPDATE_WISHLIST_FREQUENCY } from './WishlistItem.config';
@@ -134,14 +136,21 @@ export class WishlistItemContainer extends PureComponent {
             }
         } = item;
 
-        const configurableVariantIndex = this.getConfigurableVariantIndex(sku, variants);
-        const product = type_id === 'configurable'
-            ? { ...item, configurableVariantIndex }
-            : item;
+        if (type_id === 'configurable') {
+            const configurableVariantIndex = this.getConfigurableVariantIndex(sku, variants);
+
+            if (!configurableVariantIndex) {
+                history.push({ pathname: appendWithStoreCode(item.url) });
+                showNotification('info', __('Please select product options!'));
+                return;
+            }
+
+            item.configurableVariantIndex = configurableVariantIndex;
+        }
 
         this.setState({ isLoading: true });
 
-        return addProductToCart({ product, quantity })
+        addProductToCart({ product: item, quantity })
             .then(
                 /** @namespace Component/WishlistItem/Container/addItemToCartAddProductToCartThen */
                 () => this.removeItem(id),


### PR DESCRIPTION
FE fix to load product tile correctly in wishlist, if for some reason (rare case, but possible) configurable product is added to wishlist without required options. The following logic is implemented:
- Thumbnail and price of base product are loaded and displayed
- On click on Add to cart button user is redirected to product page with info message "Please select required option"

Also includes fix for BE (previously backend threw an error when fetching withlist and no items were displayed to user in wishlist)