### PR TITLE
Fix product card default attribute_options value

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -172,7 +172,7 @@ export class ProductCardContainer extends PureComponent {
             return [];
         }
 
-        const { attribute_options } = Object.values(configurable_options)[0];
+        const { attribute_options = {} } = Object.values(configurable_options)[0];
 
         return Object.values(attribute_options).reduce(
             (acc, option) => {


### PR DESCRIPTION
Fixes #1996 

Issue appears if attribute_option is empty and shots error that can't make object out of undefined/null.