### PR TITLE
bugfix #2057 missing required options validation after product revisit  

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -428,5 +428,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://40kskudemo.scandipwa.com/"
+    "proxy": "http://scandipwapmrev.indvp.com/"
 }

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -428,5 +428,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "http://scandipwapmrev.indvp.com/"
+    "proxy": "https://40kskudemo.scandipwa.com/"
 }

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -130,7 +130,9 @@ export class ProductPageContainer extends PureComponent {
             product: {
                 sku,
                 variants,
-                configurable_options
+                configurable_options,
+                options,
+                productOptionsData
             },
             location: { search }
         } = props;
@@ -167,10 +169,23 @@ export class ProductPageContainer extends PureComponent {
 
         const configurableVariantIndex = getVariantIndex(variants, parameters);
 
+        const newOptionsData = options.reduce((acc, { option_id, required }) => {
+            if (required) {
+                acc.push(option_id);
+            }
+
+            return acc;
+        }, []);
+
+        const prevOptions = productOptionsData?.requiredOptions || [];
+        const requiredOptions = [...prevOptions, ...newOptionsData];
+
         return {
             parameters,
             currentProductSKU,
-            configurableVariantIndex
+            configurableVariantIndex,
+            productOptionsData:
+                { ...productOptionsData, requiredOptions }
         };
     }
 
@@ -382,7 +397,6 @@ export class ProductPageContainer extends PureComponent {
         if (!options) {
             return [];
         }
-
         const requiredOptions = options.reduce((acc, { option_id, required }) => {
             if (required) {
                 acc.push(option_id);


### PR DESCRIPTION
The reason for the issue is that after getting back to product (via breadcrumbs, not pure page reload) `productOptionsData` props in `ProductActions` component is empty, while it should contain the list of required options.  As a result client side validation doesn't work => adding to cart fails with a different error message due to server side validation.

Root cause of the issue is in `ProductPage` container. It has logic that compares `prevProps` to  `currentProps` in order to minimize data requests and rerenders (https://github.com/scandipwa/scandipwa/blob/master/packages/scandipwa/src/route/ProductPage/ProductPage.container.js#L199). The steps described in the bug lead to product data being dispatched from `ProductReducer` instead of reloading all product data from the server (the product has not changed => we can reply on previous data). Yet the problem is that `productOptionsData` previously stored in state (and only in state) is now lost. In order to restore it we need to update `productOptionsData` in state using `options` from props. 