### PR TITLE
Fix issue with swatch_data selection for product cards

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -26,7 +26,7 @@ import { DeviceType } from 'Type/Device';
 import { ProductType } from 'Type/ProductList';
 import { BUNDLE, CONFIGURABLE } from 'Util/Product';
 
-import { OPTION_TYPE_COLOR, validOptionTypes } from './ProductCard.config';
+import { OPTION_TYPE_COLOR, OPTION_TYPE_IMAGE } from './ProductCard.config';
 
 import './ProductCard.style';
 /**
@@ -206,7 +206,23 @@ export class ProductCard extends PureComponent {
         );
     }
 
-    renderVisualOption({ value, label, type }, i) {
+    renderImageVisualOption(label, value, i) {
+        return (
+          <img
+            key={ i }
+            block="ProductCard"
+            elem="Image"
+            src={ `/media/attribute/swatch/swatch_thumb/110x90${value}` }
+            alt={ label }
+          />
+        );
+    }
+
+    renderVisualOption = ({ label, value, type }, i) => {
+        if (type === OPTION_TYPE_IMAGE) {
+            return this.renderImageVisualOption(label, value, i);
+        }
+
         const isColor = type === OPTION_TYPE_COLOR;
 
         return (
@@ -221,7 +237,16 @@ export class ProductCard extends PureComponent {
                 { isColor ? '' : value }
             </span>
         );
-    }
+    };
+
+    renderVisualOptions = (options) => (
+        <div
+          block="ProductCard"
+          elem="ConfigurableOption"
+        >
+            { options.map(this.renderVisualOption) }
+        </div>
+    );
 
     renderVisualConfigurableOptions() {
         const {
@@ -235,17 +260,13 @@ export class ProductCard extends PureComponent {
             return <div block="ProductCard" elem="ConfigurableOptions" />;
         }
 
-        if (!validOptionTypes.includes(availableVisualOptions[0].type)) {
-            return <div block="ProductCard" elem="ConfigurableOptions" />;
-        }
-
         if (!siblingsHaveConfigurableOptions) {
             setSiblingsHaveConfigurableOptions();
         }
 
         return (
             <div block="ProductCard" elem="ConfigurableOptions">
-                { availableVisualOptions.map(this.renderVisualOption) }
+                { availableVisualOptions.map(this.renderVisualOptions) }
             </div>
         );
     }

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -243,15 +243,6 @@ export class ProductCard extends PureComponent {
         );
     };
 
-    renderVisualOptions = (options) => (
-        <div
-          block="ProductCard"
-          elem="ConfigurableOption"
-        >
-            { options.map(this.renderVisualOption) }
-        </div>
-    );
-
     renderVisualConfigurableOptions() {
         const {
             siblingsHaveConfigurableOptions,

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -26,7 +26,11 @@ import { DeviceType } from 'Type/Device';
 import { ProductType } from 'Type/ProductList';
 import { BUNDLE, CONFIGURABLE } from 'Util/Product';
 
-import { OPTION_TYPE_COLOR, OPTION_TYPE_IMAGE } from './ProductCard.config';
+import {
+    OPTION_TYPE_COLOR,
+    OPTION_TYPE_IMAGE,
+    validOptionTypes
+} from './ProductCard.config';
 
 import './ProductCard.style';
 /**
@@ -260,13 +264,17 @@ export class ProductCard extends PureComponent {
             return <div block="ProductCard" elem="ConfigurableOptions" />;
         }
 
+        if (!validOptionTypes.includes(availableVisualOptions[0].type)) {
+            return <div block="ProductCard" elem="ConfigurableOptions" />;
+        }
+
         if (!siblingsHaveConfigurableOptions) {
             setSiblingsHaveConfigurableOptions();
         }
 
         return (
             <div block="ProductCard" elem="ConfigurableOptions">
-                { availableVisualOptions.map(this.renderVisualOptions) }
+                { availableVisualOptions.map(this.renderVisualOption) }
             </div>
         );
     }

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.config.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.config.js
@@ -11,6 +11,7 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+export const OPTION_TYPE_IMAGE = '2';
 export const OPTION_TYPE_COLOR = '1';
 export const OPTION_TYPE_TEXT = '0';
 export const validOptionTypes = [OPTION_TYPE_TEXT, OPTION_TYPE_COLOR];

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.config.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.config.js
@@ -14,6 +14,6 @@
 export const OPTION_TYPE_IMAGE = '2';
 export const OPTION_TYPE_COLOR = '1';
 export const OPTION_TYPE_TEXT = '0';
-export const validOptionTypes = [OPTION_TYPE_TEXT, OPTION_TYPE_COLOR];
+export const validOptionTypes = [OPTION_TYPE_TEXT, OPTION_TYPE_COLOR, OPTION_TYPE_IMAGE];
 
 export const IN_STOCK = 'IN_STOCK';

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -173,13 +173,13 @@ export class ProductCardContainer extends PureComponent {
         }
 
         // Find first option that has swatch_data in attribute_options property
-        const OptionWithSwatchData = Object.values(configurable_options).find((option) => {
+        const optionWithSwatchData = Object.values(configurable_options).find((option) => {
             const { attribute_options = {} } = option;
 
-            return Object.values(attribute_options).find(({ swatch_data }) => swatch_data);
+            return Object.values(attribute_options).some(({ swatch_data }) => swatch_data);
         });
 
-        const { attribute_options = {} } = OptionWithSwatchData || {};
+        const { attribute_options = {} } = optionWithSwatchData || {};
 
         return Object.values(attribute_options).reduce(
             (acc, option) => {

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -172,10 +172,10 @@ export class ProductCardContainer extends PureComponent {
             return [];
         }
 
-        const { attribute_options } = Object.values(configurable_options)[0];
+        return Object.values(configurable_options).reduce((acc, option) => {
+            const { attribute_options = {} } = option;
 
-        return Object.values(attribute_options).reduce(
-            (acc, option) => {
+            const attributes = Object.values(attribute_options).reduce((acc, option) => {
                 const {
                     swatch_data,
                     label
@@ -188,9 +188,14 @@ export class ProductCardContainer extends PureComponent {
                 }
 
                 return acc;
-            },
-            []
-        );
+            }, []);
+
+            if (attributes.length !== 0) {
+                acc.push(attributes);
+            }
+
+            return acc;
+        }, []);
     }
 
     isConfigurableProductOutOfStock() {

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -174,12 +174,12 @@ export class ProductCardContainer extends PureComponent {
 
         // Find first option that has swatch_data in attribute_options property
         const OptionWithSwatchData = Object.values(configurable_options).find((option) => {
-            const { attribute_options } = option;
+            const { attribute_options = {} } = option;
 
             return Object.values(attribute_options).find(({ swatch_data }) => swatch_data);
         });
 
-        const { attribute_options = {} } = OptionWithSwatchData;
+        const { attribute_options = {} } = OptionWithSwatchData || {};
 
         return Object.values(attribute_options).reduce(
             (acc, option) => {

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -172,10 +172,17 @@ export class ProductCardContainer extends PureComponent {
             return [];
         }
 
-        return Object.values(configurable_options).reduce((acc, option) => {
-            const { attribute_options = {} } = option;
+        // Find first option that has swatch_data in attribute_options property
+        const OptionWithSwatchData = Object.values(configurable_options).find((option) => {
+            const { attribute_options } = option;
 
-            const attributes = Object.values(attribute_options).reduce((acc, option) => {
+            return Object.values(attribute_options).find(({ swatch_data }) => swatch_data);
+        });
+
+        const { attribute_options = {} } = OptionWithSwatchData;
+
+        return Object.values(attribute_options).reduce(
+            (acc, option) => {
                 const {
                     swatch_data,
                     label
@@ -188,14 +195,9 @@ export class ProductCardContainer extends PureComponent {
                 }
 
                 return acc;
-            }, []);
-
-            if (attributes.length !== 0) {
-                acc.push(attributes);
-            }
-
-            return acc;
-        }, []);
+            },
+            []
+        );
     }
 
     isConfigurableProductOutOfStock() {

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
@@ -46,7 +46,6 @@
     &-Content {
         padding: 10px 0 15px;
         display: flex;
-        flex-grow: 1;
         flex-direction: column;
     }
 
@@ -135,13 +134,20 @@
 
     &-ConfigurableOptions {
         display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+    }
+
+    &-ConfigurableOption {
+        display: flex;
         justify-content: flex-start;
         align-items: center;
         flex-wrap: wrap;
         min-height: calc(var(--product-card-color-size) + 5px);
     }
 
-    &-Color {
+    &-Color,
+    &-Image {
         display: inline-block;
         width: var(--product-card-color-size);
         height: var(--product-card-color-size);

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
@@ -46,6 +46,7 @@
     &-Content {
         padding: 10px 0 15px;
         display: flex;
+        flex-grow: 1;
         flex-direction: column;
     }
 
@@ -133,12 +134,6 @@
     }
 
     &-ConfigurableOptions {
-        display: flex;
-        flex-direction: column;
-        justify-content: flex-start;
-    }
-
-    &-ConfigurableOption {
         display: flex;
         justify-content: flex-start;
         align-items: center;


### PR DESCRIPTION
Fixes #2041 
Fixes #1996

Previously for product cards it was getting first element from configurable_options property and if it was not containing swatch data then product card was without visual attributes. 
Example:
```
configurable_options: {
  { label: size, swatch_data: null, type null }
  { label: color_images, swatch_data: {....}, type: 2 }
}
```
It was getting only size attribute and since there is no swatch_data: result is empty for product card.

Also implemented support for images type.