### PR TITLE
bugfix #1884 write review header blinking

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -519,7 +519,7 @@
         &_isVisible {
             @include before-desktop {
                 opacity: 1;
-                max-width: calc(100% - 180px);
+                max-width: calc(100% - 100px);
             }
         }
     }

--- a/packages/scandipwa/src/component/Popup/Popup.style.scss
+++ b/packages/scandipwa/src/component/Popup/Popup.style.scss
@@ -32,7 +32,7 @@
     position: fixed;
     background-color: var(--popup-background);
     left: 0;
-    bottom: 0;
+    top: var(--header-total-height);
 
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Actually header behaviour is correct. The problem is that write review form stays in place when the address bar appears and viewport size updates. Write review form should move down when it happens.