### PR TITLE
bugfix #2265 - Revert proxy and browserlist percentage

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -69,7 +69,7 @@
     },
     "browserslist": {
         "production": [
-            ">0.02%",
+            ">0.2%",
             "not dead",
             "not op_mini all"
         ],
@@ -430,5 +430,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://scandipwapmrev.indvp.com/"
+    "proxy": "https://40kskudemo.scandipwa.com/"
 }


### PR DESCRIPTION
Reverted proxy host and % of browsers in the browserlist query