### PR TITLE
Added the lower stack order to the background placeholder

### DIFF
--- a/packages/scandipwa/src/component/Image/Image.style.scss
+++ b/packages/scandipwa/src/component/Image/Image.style.scss
@@ -79,6 +79,7 @@
         &::after {
             content: '';
             position: absolute;
+            z-index: -1;
             top: 0;
             left: 0;
             width: 100%;


### PR DESCRIPTION
This PR fixes the following home page image placeholder behavior:
<img width="1429" alt="before" src="https://user-images.githubusercontent.com/43637240/110548446-3bb88700-8139-11eb-9ad1-4c47b15a8dd3.png">
