### PR TITLE
bugfix #2250 - invalid filter area height

### DIFF
--- a/packages/scandipwa/src/component/ExpandableContentShowMore/ExpandableContentShowMore.component.js
+++ b/packages/scandipwa/src/component/ExpandableContentShowMore/ExpandableContentShowMore.component.js
@@ -36,7 +36,6 @@ export class ExpandableContentShowMore extends PureComponent {
         const { showElemCount, children: { length } } = this.props;
 
         this.expandableRef = createRef();
-        this.expandableContentHeight = 'auto';
 
         this.state = {
             isOpen: length > showElemCount,
@@ -48,9 +47,6 @@ export class ExpandableContentShowMore extends PureComponent {
         const { isOpen } = this.state;
 
         if (isOpen) {
-            if (this.expandableRef.current) {
-                this.expandableContentHeight = this.expandableRef.current.getBoundingClientRect().height;
-            }
             this.setState({ isOpen: false });
         }
     }
@@ -86,11 +82,7 @@ export class ExpandableContentShowMore extends PureComponent {
             return;
         }
 
-        this.expandableContentHeight = 'auto';
         this.setState({ isOpen: true }, () => {
-            if (this.expandableRef.current) {
-                this.expandableContentHeight = this.expandableRef.current.getBoundingClientRect().height;
-            }
             this.setState({ isOpen: false });
         });
     }
@@ -132,16 +124,12 @@ export class ExpandableContentShowMore extends PureComponent {
         const { children, showElemCount } = this.props;
 
         const child = (isOpen || isExpanding) ? children.slice(showElemCount) : null;
-        const style = {
-            height: isOpen ? this.expandableContentHeight : 0
-        };
 
         return (
             <div
               ref={ this.expandableRef }
               block="ExpandableContentShowMore"
               elem="ExpandableChildren"
-              style={ style }
             >
                 { child }
             </div>


### PR DESCRIPTION
Removed explicitly setting filter area height.
Tested in Chrome, FF and even Safari 10 after removal - found no difference in behaviour other than the bug is gone. 