### PR TITLE
bugfix #2287 - city and state autofill

### DIFF
--- a/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
+++ b/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
@@ -101,28 +101,25 @@ export class CheckoutAddressForm extends MyAccountAddressForm {
         });
     }
 
-    onZipcodeChange = (e) => {
+    onZipcodeChange = async (e) => {
         const { value } = e.currentTarget;
         const { countryId, availableRegions } = this.state;
 
-        getCityAndRegionFromZipcode(countryId, value).then(
-            ([city, regionCode]) => {
-                if (city) {
-                    this.setState({
-                        city
-                    });
-                }
+        const [city, regionCode] = await getCityAndRegionFromZipcode(countryId, value);
+        if (city) {
+            this.setState({
+                city
+            });
+        }
 
-                if (availableRegions.length > 0 && regionCode) {
-                    const { id: regionId } = availableRegions
-                        .find((r) => r.code.toUpperCase() === regionCode.toUpperCase());
+        if (availableRegions.length > 0 && regionCode) {
+            const { id: regionId } = availableRegions
+                .find((r) => r.code.toUpperCase() === regionCode.toUpperCase());
 
-                    if (regionId) {
-                        this.setState({ regionId });
-                    }
-                }
+            if (regionId) {
+                this.setState({ regionId });
             }
-        );
+        }
     };
 
     get fieldMap() {

--- a/packages/scandipwa/src/component/Field/Field.container.js
+++ b/packages/scandipwa/src/component/Field/Field.container.js
@@ -122,6 +122,7 @@ export class FieldContainer extends PureComponent {
             this.setState({ checked: currChecked });
         }
 
+        this.updateValidationStatus();
         this.setValidationMessage(prevProps);
     }
 
@@ -206,6 +207,15 @@ export class FieldContainer extends PureComponent {
         return validationConfig[rule] || {};
     }
 
+    updateValidationStatus() {
+        const validationRule = this.validateField();
+
+        this.setState({
+            validationStatus: !validationRule.validate,
+            validationMessage: validationRule.message
+        });
+    }
+
     onChange(event) {
         if (typeof event === 'string' || typeof event === 'number') {
             return this.handleChange(event);
@@ -217,12 +227,7 @@ export class FieldContainer extends PureComponent {
             });
         }
 
-        const validationRule = this.validateField();
-
-        this.setState({
-            validationStatus: !validationRule.validate,
-            validationMessage: validationRule.message
-        });
+        this.updateValidationStatus();
 
         return this.handleChange(event.target.value);
     }

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import FieldForm from 'Component/FieldForm';
 import { addressType } from 'Type/Account';
 import { countriesType } from 'Type/Config';
-import { getCityFromZipcode, setAddressesInFormObject } from 'Util/Address';
+import { getCityAndRegionFromZipcode, setAddressesInFormObject } from 'Util/Address';
 
 /** @namespace Component/MyAccountAddressForm/Component */
 export class MyAccountAddressForm extends FieldForm {
@@ -116,15 +116,26 @@ export class MyAccountAddressForm extends FieldForm {
 
     onZipcodeChange = (e) => {
         const { value } = e.currentTarget;
-        const { countryId } = this.state;
+        const { countryId, availableRegions } = this.state;
 
-        const city = getCityFromZipcode(countryId, value);
+        getCityAndRegionFromZipcode(countryId, value).then(
+            ([city, regionCode]) => {
+                if (city) {
+                    this.setState({
+                        city
+                    });
+                }
 
-        if (city) {
-            this.setState({
-                city
-            });
-        }
+                if (availableRegions.length > 0 && regionCode) {
+                    const { id: regionId } = availableRegions
+                        .find((r) => r.code.toUpperCase() === regionCode.toUpperCase());
+
+                    if (regionId) {
+                        this.setState({ regionId });
+                    }
+                }
+            }
+        );
     };
 
     getStreetFields(label, index) {

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
@@ -114,28 +114,25 @@ export class MyAccountAddressForm extends FieldForm {
         });
     };
 
-    onZipcodeChange = (e) => {
+    onZipcodeChange = async (e) => {
         const { value } = e.currentTarget;
         const { countryId, availableRegions } = this.state;
 
-        getCityAndRegionFromZipcode(countryId, value).then(
-            ([city, regionCode]) => {
-                if (city) {
-                    this.setState({
-                        city
-                    });
-                }
+        const [city, regionCode] = await getCityAndRegionFromZipcode(countryId, value);
+        if (city) {
+            this.setState({
+                city
+            });
+        }
 
-                if (availableRegions.length > 0 && regionCode) {
-                    const { id: regionId } = availableRegions
-                        .find((r) => r.code.toUpperCase() === regionCode.toUpperCase());
+        if (availableRegions.length > 0 && regionCode) {
+            const { id: regionId } = availableRegions
+                .find((r) => r.code.toUpperCase() === regionCode.toUpperCase());
 
-                    if (regionId) {
-                        this.setState({ regionId });
-                    }
-                }
+            if (regionId) {
+                this.setState({ regionId });
             }
-        );
+        }
     };
 
     getStreetFields(label, index) {

--- a/packages/scandipwa/src/util/Address/index.js
+++ b/packages/scandipwa/src/util/Address/index.js
@@ -88,15 +88,22 @@ export const getFormFields = (fields, addressLinesQty) => {
     return setAddressesInFormObject(fields, addressLinesQty);
 };
 
-/** @namespace Util/Address/getCityFromZipcode */
-export const getCityFromZipcode = (countryId, value) => {
-    fetch(`http://api.zippopotam.us/${countryId}/${value}`)
-        /** @namespace Util/Address/getCityFromZipcode/response */
-        .then(
-            (response) => response.json()
+/** @namespace Util/Address/getCityAndRegionFromZipcode */
+export const getCityAndRegionFromZipcode = (countryId, value) => fetch(
+    `https://api.zippopotam.us/${countryId}/${value.split(' ')[0]}`
+)
+/** @namespace Util/Address/getCityAndRegionFromZipcode/response */
+    .then(
+        (response) => response.json()
+    )
+/** @namespace Util/Address/getCityAndRegionFromZipcode/then */
+    .then(
+        (data) => (
+            data && Object.entries(data).length > 0
+                ? [
+                    data.places[0]['place name'],
+                    data.places[0]['state abbreviation']
+                ]
+                : [null, null]
         )
-        /** @namespace Util/Address/getCityFromZipcode/then */
-        .then(
-            (data) => (data && Object.entries(data).length > 0 ? data.places[0].['place name'] : null)
-        );
-};
+    );

--- a/packages/scandipwa/src/util/Address/index.js
+++ b/packages/scandipwa/src/util/Address/index.js
@@ -89,21 +89,13 @@ export const getFormFields = (fields, addressLinesQty) => {
 };
 
 /** @namespace Util/Address/getCityAndRegionFromZipcode */
-export const getCityAndRegionFromZipcode = (countryId, value) => fetch(
-    `https://api.zippopotam.us/${countryId}/${value.split(' ')[0]}`
-)
-/** @namespace Util/Address/getCityAndRegionFromZipcode/response */
-    .then(
-        (response) => response.json()
-    )
-/** @namespace Util/Address/getCityAndRegionFromZipcode/then */
-    .then(
-        (data) => (
-            data && Object.entries(data).length > 0
-                ? [
-                    data.places[0]['place name'],
-                    data.places[0]['state abbreviation']
-                ]
-                : [null, null]
-        )
-    );
+export const getCityAndRegionFromZipcode = async (countryId, value) => {
+    const response = await fetch(`https://api.zippopotam.us/${countryId}/${value.split(' ')[0]}`);
+    const data = await response.json();
+    return data && Object.entries(data).length > 0
+        ? [
+            data.places[0]['place name'],
+            data.places[0]['state abbreviation']
+        ]
+        : [null, null];
+};


### PR DESCRIPTION
### ISSUES: https://github.com/scandipwa/scandipwa/issues/2287, https://github.com/scandipwa/scandipwa/pull/2152

Fix for https://github.com/scandipwa/scandipwa/pull/2152, which actually turned out to be not working at all, not just http vs https issue. Changes made:
- changed HTTP to HTTPS
- fixed error with city not being set at all (nothing was returned from method `getCityFromZipcode`)
- added autofill for state (as it looks dull, when the city is being autocomplete and the state (= region) is not)
- added autofill to Shipping and Billing steps, not just Address book
- validation status update for `city` field (`onChange` is not triggered in such a case) 