### PR TITLE
#2270 Downloadable my-account fixes

### DIFF
--- a/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.component.js
+++ b/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.component.js
@@ -14,6 +14,7 @@ import { PureComponent } from 'react';
 
 import Loader from 'Component/Loader';
 import MyAccountDownloadableTableRow from 'Component/MyAccountDownloadableTableRow';
+import MyAccountOrderPopup from 'Component/MyAccountOrderPopup';
 import { downloadableType } from 'Type/Account';
 import { DeviceType } from 'Type/Device';
 
@@ -24,6 +25,10 @@ export class MyAccountDownloadableComponent extends PureComponent {
         isLoading: PropTypes.bool.isRequired,
         device: DeviceType.isRequired
     };
+
+    renderPopup() {
+        return <MyAccountOrderPopup />;
+    }
 
     renderNoOrders() {
         const { device } = this.props;
@@ -102,6 +107,7 @@ export class MyAccountDownloadableComponent extends PureComponent {
             <div block="MyAccountMyOrders">
                 <Loader isLoading={ isLoading } />
                 { this.renderTable() }
+                { this.renderPopup() }
             </div>
         );
     }

--- a/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.container.js
+++ b/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.container.js
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
+import { OrderDispatcher } from 'Component/MyAccountMyOrders/MyAccountMyOrders.container';
 import OrderQuery from 'Query/Order.query';
 import { showNotification } from 'Store/Notification/Notification.action';
 import { DeviceType } from 'Type/Device';
@@ -29,7 +30,10 @@ export const mapStateToProps = (state) => ({
 /** @namespace Component/MyAccountDownloadable/Container/mapDispatchToProps */
 export const mapDispatchToProps = (dispatch) => ({
     showErrorNotification: (message) => dispatch(showNotification('error', message)),
-    showSuccessNotification: (message) => dispatch(showNotification('success', message))
+    showSuccessNotification: (message) => dispatch(showNotification('success', message)),
+    getOrderList: () => OrderDispatcher.then(
+        ({ default: dispatcher }) => dispatcher.requestOrders(dispatch)
+    )
 });
 
 /** @namespace Component/MyAccountDownloadable/Container */
@@ -37,7 +41,8 @@ export class MyAccountDownloadableContainer extends PureComponent {
     static propTypes = {
         device: DeviceType.isRequired,
         showErrorNotification: PropTypes.func.isRequired,
-        showSuccessNotification: PropTypes.func.isRequired
+        showSuccessNotification: PropTypes.func.isRequired,
+        getOrderList: PropTypes.func.isRequired
     };
 
     state = {
@@ -46,6 +51,9 @@ export class MyAccountDownloadableContainer extends PureComponent {
     };
 
     componentDidMount() {
+        const { getOrderList } = this.props;
+
+        getOrderList();
         this.requestDownloadable();
     }
 

--- a/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.container.js
+++ b/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.container.js
@@ -13,13 +13,17 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
-import { OrderDispatcher } from 'Component/MyAccountMyOrders/MyAccountMyOrders.container';
 import OrderQuery from 'Query/Order.query';
 import { showNotification } from 'Store/Notification/Notification.action';
 import { DeviceType } from 'Type/Device';
 import { fetchQuery } from 'Util/Request';
 
 import MyAccountDownloadable from './MyAccountDownloadable.component';
+
+export const OrderDispatcher = import(
+    /* webpackMode: "lazy", webpackChunkName: "dispatchers" */
+    'Store/Order/Order.dispatcher'
+);
 
 /** @namespace Component/MyAccountDownloadable/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({

--- a/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.component.js
+++ b/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.component.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *
@@ -9,8 +10,10 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
+import Link from 'Component/Link';
 import { downloadableType } from 'Type/Account';
 import { DeviceType } from 'Type/Device';
 
@@ -20,19 +23,56 @@ import './MyAccountDownloadableTableRow.style';
 export class MyAccountDownloadableTableRowComponent extends PureComponent {
     static propTypes = {
         order: downloadableType.isRequired,
+        onOrderIdClick: PropTypes.func.isRequired,
         device: DeviceType.isRequired
     };
+
+    renderOrderId() {
+        const {
+            order: {
+                order_id
+            },
+            onOrderIdClick
+        } = this.props;
+
+        return (
+            <div onClick={ onOrderIdClick } block="MyAccountDownloadTableRow" elem="OrderId">
+                #
+                { order_id }
+            </div>
+        );
+    }
+
+    renderTitle() {
+        const {
+            order: {
+                download_url,
+                link_title,
+                title,
+                downloads
+            }
+        } = this.props;
+
+        if (!download_url || !downloads) {
+            return title;
+        }
+
+        return (
+            <>
+                { title }
+                <Link to={ download_url } block="MyAccountDownloadTableRow" elem="Link">
+                    { link_title }
+                </Link>
+            </>
+        );
+    }
 
     render() {
         const {
             order: {
-                order_id,
                 downloads,
-                download_url,
                 created_at,
-                title,
-                status,
-                link_title
+                status_label
             } = {},
             device: { isMobile } = {}
         } = this.props;
@@ -42,21 +82,11 @@ export class MyAccountDownloadableTableRowComponent extends PureComponent {
             : <td>{ downloads }</td>;
 
         return (
-            <tr block="MyAccountOrderTableRow">
-                <td>{ order_id }</td>
+            <tr block="MyAccountDownloadTableRow">
+                <td>{ this.renderOrderId() }</td>
                 <td>{ created_at }</td>
-                <td>
-                    { title }
-                    <a
-                      href={ download_url }
-                      download
-                      block="MyAccountOrderTableRow"
-                      elem="DownloadLink"
-                    >
-                        { link_title }
-                    </a>
-                </td>
-                <td>{ status }</td>
+                <td>{ this.renderTitle() }</td>
+                <td block="MyAccountDownloadTableRow" elem="Status">{ status_label }</td>
                 { remainingDownloads }
             </tr>
         );

--- a/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.container.js
+++ b/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.container.js
@@ -9,9 +9,12 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
+import { ORDER_POPUP_ID } from 'Component/MyAccountOrderPopup/MyAccountOrderPopup.config';
+import { showPopup } from 'Store/Popup/Popup.action';
 import { downloadableType } from 'Type/Account';
 import { DeviceType } from 'Type/Device';
 
@@ -19,18 +22,47 @@ import MyAccountDownloadableTableRow from './MyAccountDownloadableTableRow.compo
 
 /** @namespace Component/MyAccountDownloadableTableRow/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
-    device: state.ConfigReducer.device
+    device: state.ConfigReducer.device,
+    orderList: state.OrderReducer.orderList
 });
 
 /** @namespace Component/MyAccountDownloadableTableRow/Container/mapDispatchToProps */
-export const mapDispatchToProps = () => ({});
+export const mapDispatchToProps = (dispatch) => ({
+    showPopup: (payload) => dispatch(showPopup(ORDER_POPUP_ID, payload))
+});
 
 /** @namespace Component/MyAccountDownloadableTableRow/Container */
 export class MyAccountDownloadableTableRowContainer extends PureComponent {
     static propTypes = {
+        showPopup: PropTypes.func.isRequired,
+        orderList: PropTypes.array.isRequired,
         order: downloadableType.isRequired,
         device: DeviceType.isRequired
     };
+
+    containerFunctions = {
+        onOrderIdClick: this.onOrderIdClick.bind(this)
+    };
+
+    onOrderIdClick() {
+        const { showPopup, orderList, order: { order_id } } = this.props;
+
+        const order = orderList.find((order) => {
+            const {
+                base_order_info: {
+                    increment_id
+                }
+            } = order;
+
+            return increment_id === order_id;
+        });
+
+        showPopup({
+            title: __('Order #%s', order_id),
+            increment_id: order_id,
+            order
+        });
+    }
 
     containerProps() {
         const { device, order } = this.props;
@@ -45,6 +77,7 @@ export class MyAccountDownloadableTableRowContainer extends PureComponent {
         return (
             <MyAccountDownloadableTableRow
               { ...this.containerProps() }
+              { ...this.containerFunctions }
             />
         );
     }

--- a/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.style.scss
+++ b/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.style.scss
@@ -1,8 +1,10 @@
 :root {
     --my-account-order-table-row-hover-background: var(--secondary-base-color);
+    --link-color: var(--primary-base-color);
+    --link-hover: var(--primary-dark-color);
 }
 
-.MyAccountOrderTableRow {
+.MyAccountDownloadTableRow {
     height: 36px;
 
     td,
@@ -12,12 +14,19 @@
         }
     }
 
-    &:hover {
-        background-color: var(--my-account-order-table-row-hover-background);
-        cursor: pointer;
+    &-Link {
+        display: block;
     }
 
-    &-DownloadLink {
-        display: block;
+    &-Status {
+        text-transform: capitalize;
+    }
+
+    &-OrderId {
+        color: var(--link-color);
+        &:hover {
+            cursor: pointer;
+            color: var(--link-hover);
+        }
     }
 }


### PR DESCRIPTION
Requires PR: https://github.com/scandipwa/customer-downloadable-graphql/pull/1
Original issue: #2270 

In this PR:
* Shows order popup on order id click
* Shows status
* Renders title without link if not provided
* DOM class fix - from 'MyAccountOrderTableRow' to 'MyAccountDownloadTableRow'