### PR TITLE
Refactored product tabs render logic

### DIFF
--- a/packages/scandipwa/src/component/ProductTabs/ProductTabs.component.js
+++ b/packages/scandipwa/src/component/ProductTabs/ProductTabs.component.js
@@ -38,7 +38,7 @@ export class ProductTabs extends PureComponent {
         const { defaultTab } = this.props;
 
         this.state = {
-            activeTab: defaultTab || 0
+            activeTab: defaultTab
         };
     }
 

--- a/packages/scandipwa/src/component/ProductTabs/ProductTabs.component.js
+++ b/packages/scandipwa/src/component/ProductTabs/ProductTabs.component.js
@@ -16,81 +16,81 @@ import ContentWrapper from 'Component/ContentWrapper';
 import ProductTab from 'Component/ProductTab';
 import { isMobile } from 'Util/Mobile';
 
+// import { isMobile } from 'Util/Mobile';
 import './ProductTabs.style';
 
 /** @namespace Component/ProductTabs/Component */
 export class ProductTabs extends PureComponent {
     static propTypes = {
-        tabNames: PropTypes.arrayOf(PropTypes.string).isRequired,
-        children: PropTypes.node,
-        defaultTab: PropTypes.string
+        tabs: PropTypes.arrayOf(PropTypes.shape({
+            name: PropTypes.string.isRequired,
+            render: PropTypes.func.isRequired
+        })).isRequired,
+        defaultTab: PropTypes.number
     };
 
     static defaultProps = {
-        children: null,
-        defaultTab: null
+        defaultTab: 0
     };
 
     __construct(props) {
         super.__construct(props);
 
-        const { defaultTab, tabNames } = this.props;
+        const { defaultTab } = this.props;
 
         this.state = {
-            activeTab: defaultTab || tabNames[0]
+            activeTab: defaultTab || 0
         };
     }
 
-    onTabClick = (activeTab) => {
-        this.setState({
-            activeTab
-        });
+    onTabClick = (tab) => {
+        const { tabs } = this.props;
+        const { activeTab } = this.state;
+
+        const currentTab = tabs.findIndex(({ name }) => name === tab);
+
+        if (activeTab !== currentTab) {
+            this.setState({
+                activeTab: currentTab
+            });
+        }
     };
 
-    renderActiveTab(activeTab, childrenArray) {
-        const { tabNames } = this.props;
+    renderActiveTab() {
+        const { tabs } = this.props;
+        const { activeTab } = this.state;
 
-        return childrenArray.map((item, i) => {
-            if (tabNames[i].toLowerCase() === activeTab.toLowerCase()) {
-                return item;
-            }
-
-            return false;
-        });
+        return tabs[activeTab].render();
     }
 
-    renderAllTabs(childrenArray) {
-        return childrenArray.map((item) => item);
+    renderAllTabs() {
+        const { tabs } = this.props;
+
+        return tabs.map(({ render }) => render());
     }
 
-    renderTab = (_, i) => {
-        const { tabNames } = this.props;
+    renderTab = (item, i) => {
         const { activeTab } = this.state;
 
         return (
             <ProductTab
-              tabName={ tabNames[i] }
-              key={ tabNames[i] }
+              tabName={ item.name }
+              key={ i }
               onClick={ this.onTabClick }
-              isActive={ tabNames[i].toLowerCase() === activeTab.toLowerCase() }
+              isActive={ i === activeTab }
             />
         );
     };
 
     renderTabs() {
-        const { children } = this.props;
-        const { activeTab } = this.state;
+        const { tabs } = this.props;
 
         return (
             <>
-                <ul
-                  block="ProductTabs"
-                >
-                    { children.map(this.renderTab) }
+                <ul block="ProductTabs">
+                    { tabs.map(this.renderTab) }
                 </ul>
-                { isMobile.any()
-                    ? this.renderAllTabs(children)
-                    : this.renderActiveTab(activeTab, children) }
+                { isMobile ? this.renderAllTabs() : this.renderActiveTab() }
             </>
         );
     }

--- a/packages/scandipwa/src/component/ProductTabs/ProductTabs.component.js
+++ b/packages/scandipwa/src/component/ProductTabs/ProductTabs.component.js
@@ -16,7 +16,6 @@ import ContentWrapper from 'Component/ContentWrapper';
 import ProductTab from 'Component/ProductTab';
 import { isMobile } from 'Util/Mobile';
 
-// import { isMobile } from 'Util/Mobile';
 import './ProductTabs.style';
 
 /** @namespace Component/ProductTabs/Component */
@@ -90,7 +89,7 @@ export class ProductTabs extends PureComponent {
                 <ul block="ProductTabs">
                     { tabs.map(this.renderTab) }
                 </ul>
-                { isMobile ? this.renderAllTabs() : this.renderActiveTab() }
+                { isMobile.any() ? this.renderAllTabs() : this.renderActiveTab() }
             </>
         );
     }

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.component.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.component.js
@@ -212,31 +212,13 @@ export class ProductPage extends PureComponent {
         );
     }
 
-    renderProductTabItems() {
-        return Object.values(this.tabMap).reduce((tabRenders, { shouldTabRender, render, name }) => {
-            if (shouldTabRender()) {
-                tabRenders.push(render(name));
-            }
-
-            return tabRenders;
-        }, []);
-    }
-
-    getTabNames() {
-        return Object.values(this.tabMap).reduce((tabNames, { shouldTabRender, name }) => {
-            if (shouldTabRender()) {
-                tabNames.push(name);
-            }
-
-            return tabNames;
-        }, []);
+    shouldTabsRender() {
+        return Object.values(this.tabMap).filter(({ shouldTabRender }) => shouldTabRender());
     }
 
     renderProductTabs() {
         return (
-            <ProductTabs tabNames={ this.getTabNames() }>
-                { this.renderProductTabItems() }
-            </ProductTabs>
+            <ProductTabs tabs={ this.shouldTabsRender() } />
         );
     }
 

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.component.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.component.js
@@ -60,7 +60,7 @@ export class ProductPage extends PureComponent {
             name: __('About'),
             shouldTabRender: () => {
                 const { isInformationTabEmpty } = this.props;
-                return isInformationTabEmpty;
+                return !isInformationTabEmpty;
             },
             render: (key) => this.renderProductInformationTab(key)
         },
@@ -68,13 +68,13 @@ export class ProductPage extends PureComponent {
             name: __('Details'),
             shouldTabRender: () => {
                 const { isAttributesTabEmpty } = this.props;
-                return isAttributesTabEmpty;
+                return !isAttributesTabEmpty;
             },
             render: (key) => this.renderProductAttributesTab(key)
         },
         [PRODUCT_REVIEWS]: {
             name: __('Reviews'),
-            // Return true since it always returns 'Add review' button
+            // Return true since we always show 'Add review' button
             shouldTabRender: () => true,
             render: (key) => this.renderProductReviewsTab(key)
         }

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.component.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.component.js
@@ -74,8 +74,8 @@ export class ProductPage extends PureComponent {
         },
         [PRODUCT_REVIEWS]: {
             name: __('Reviews'),
-            // Return false since it always returns 'Add review' button
-            shouldTabRender: () => false,
+            // Return true since it always returns 'Add review' button
+            shouldTabRender: () => true,
             render: (key) => this.renderProductReviewsTab(key)
         }
     };
@@ -214,7 +214,7 @@ export class ProductPage extends PureComponent {
 
     renderProductTabItems() {
         return Object.values(this.tabMap).reduce((tabRenders, { shouldTabRender, render, name }) => {
-            if (!shouldTabRender()) {
+            if (shouldTabRender()) {
                 tabRenders.push(render(name));
             }
 
@@ -224,7 +224,7 @@ export class ProductPage extends PureComponent {
 
     getTabNames() {
         return Object.values(this.tabMap).reduce((tabNames, { shouldTabRender, name }) => {
-            if (!shouldTabRender()) {
+            if (shouldTabRender()) {
                 tabNames.push(name);
             }
 

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -292,7 +292,7 @@ export class ProductPageContainer extends PureComponent {
     isProductInformationTabEmpty() {
         const dataSource = this.getDataSource();
 
-        return !!dataSource?.description?.html.length;
+        return dataSource?.description?.html?.length !== 0;
     }
 
     isProductAttributesTabEmpty() {

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -277,13 +277,13 @@ export class ProductPageContainer extends PureComponent {
     isProductInformationTabEmpty() {
         const dataSource = this.getDataSource();
 
-        return dataSource?.description?.html.length;
+        return !!dataSource?.description?.html.length;
     }
 
     isProductAttributesTabEmpty() {
         const dataSource = this.getDataSource();
 
-        return Object.keys(dataSource?.attributes || {}).length === 0;
+        return !!Object.keys(dataSource?.attributes || {}).length;
     }
 
     _addToRecentlyViewedProducts() {

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -277,7 +277,7 @@ export class ProductPageContainer extends PureComponent {
     isProductInformationTabEmpty() {
         const dataSource = this.getDataSource();
 
-        return !dataSource?.description?.html.length;
+        return dataSource?.description?.html.length;
     }
 
     isProductAttributesTabEmpty() {

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -298,7 +298,7 @@ export class ProductPageContainer extends PureComponent {
     isProductAttributesTabEmpty() {
         const dataSource = this.getDataSource();
 
-        return !!Object.keys(dataSource?.attributes || {}).length;
+        return Object.keys(dataSource?.attributes || {}).length !== 0;
     }
 
     _addToRecentlyViewedProducts() {

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -292,13 +292,13 @@ export class ProductPageContainer extends PureComponent {
     isProductInformationTabEmpty() {
         const dataSource = this.getDataSource();
 
-        return dataSource?.description?.html?.length !== 0;
+        return dataSource?.description?.html?.length === 0;
     }
 
     isProductAttributesTabEmpty() {
         const dataSource = this.getDataSource();
 
-        return Object.keys(dataSource?.attributes || {}).length !== 0;
+        return Object.keys(dataSource?.attributes || {}).length === 0;
     }
 
     _addToRecentlyViewedProducts() {


### PR DESCRIPTION
This commit is a simple logic refactoring since the following code looks really confusing:
```js
if (!item.shouldTabRender()) {
  tabRenders.push(item.render(item.name));
}
```
This literally means that we render tab if we shouldn't render it. Doesn't sound optimistic, especially considering that this logic is correct, despite the fact of working vice-versa