### PR TITLE
#1877 grouped product quantity wishlist support

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -430,5 +430,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "http://192.168.1.119/"
+    "proxy": "https://scandipwapmrev.indvp.com/"
 }

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -430,5 +430,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://scandipwapmrev.indvp.com/"
+    "proxy": "http://192.168.1.119/"
 }

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
@@ -467,6 +467,7 @@ export class ProductActions extends PureComponent {
         const {
             product,
             quantity,
+            groupedProductQuantity,
             configurableVariantIndex,
             onProductValidationError
         } = this.props;
@@ -475,6 +476,7 @@ export class ProductActions extends PureComponent {
             <ProductWishlistButton
               product={ product }
               quantity={ quantity }
+              groupedProductQuantity={ groupedProductQuantity }
               configurableVariantIndex={ configurableVariantIndex }
               onProductValidationError={ onProductValidationError }
             />

--- a/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
+++ b/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
@@ -123,9 +123,7 @@ export class ProductWishlistButtonContainer extends PureComponent {
 
         const { sku: variantSku, product_option } = product;
         if (add) {
-            return addProductToWishlist({
-                sku, product_option, quantity
-            });
+            return addProductToWishlist({ sku, product_option, quantity });
         }
 
         const { wishlist: { id: item_id } } = Object.values(productsInWishlist).find(

--- a/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
+++ b/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
@@ -47,7 +47,7 @@ export const mapDispatchToProps = (dispatch) => ({
 export class ProductWishlistButtonContainer extends PureComponent {
     static propTypes = {
         quantity: PropTypes.number,
-        groupedProductQuantity: PropTypes.objectOf(PropTypes.number).isRequired,
+        groupedProductQuantity: PropTypes.objectOf(PropTypes.number),
         product: ProductType.isRequired,
         isAddingWishlistItem: PropTypes.bool.isRequired,
         configurableVariantIndex: PropTypes.number,
@@ -61,7 +61,8 @@ export class ProductWishlistButtonContainer extends PureComponent {
     static defaultProps = {
         quantity: 1,
         onProductValidationError: () => {},
-        configurableVariantIndex: -2
+        configurableVariantIndex: -2,
+        groupedProductQuantity: {}
     };
 
     state = {

--- a/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
+++ b/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
@@ -16,7 +16,7 @@ import { connect } from 'react-redux';
 import { showNotification } from 'Store/Notification/Notification.action';
 import { ProductType } from 'Type/ProductList';
 import { isSignedIn } from 'Util/Auth';
-import { getExtensionAttributes } from 'Util/Product';
+import { CONFIGURABLE, getExtensionAttributes, GROUPED } from 'Util/Product';
 
 import ProductWishlistButton from './ProductWishlistButton.component';
 import { ERROR_CONFIGURABLE_NOT_PROVIDED } from './ProductWishlistButton.config';
@@ -47,6 +47,7 @@ export const mapDispatchToProps = (dispatch) => ({
 export class ProductWishlistButtonContainer extends PureComponent {
     static propTypes = {
         quantity: PropTypes.number,
+        groupedProductQuantity: PropTypes.objectOf(PropTypes.number).isRequired,
         product: ProductType.isRequired,
         isAddingWishlistItem: PropTypes.bool.isRequired,
         configurableVariantIndex: PropTypes.number,
@@ -121,7 +122,9 @@ export class ProductWishlistButtonContainer extends PureComponent {
 
         const { sku: variantSku, product_option } = product;
         if (add) {
-            return addProductToWishlist({ sku, product_option, quantity });
+            return addProductToWishlist({
+                sku, product_option, quantity
+            });
         }
 
         const { wishlist: { id: item_id } } = Object.values(productsInWishlist).find(
@@ -157,7 +160,7 @@ export class ProductWishlistButtonContainer extends PureComponent {
     _getIsProductReady() {
         const { product: { type_id }, configurableVariantIndex } = this.props;
 
-        if (type_id === 'configurable' && configurableVariantIndex < 0) {
+        if (type_id === CONFIGURABLE && configurableVariantIndex < 0) {
             return false;
         }
 
@@ -168,10 +171,11 @@ export class ProductWishlistButtonContainer extends PureComponent {
         const {
             product,
             product: { type_id },
-            configurableVariantIndex
+            configurableVariantIndex,
+            groupedProductQuantity
         } = this.props;
 
-        if (type_id === 'configurable') {
+        if (type_id === CONFIGURABLE) {
             if (configurableVariantIndex < 0) {
                 return ERROR_CONFIGURABLE_NOT_PROVIDED;
             }
@@ -180,6 +184,11 @@ export class ProductWishlistButtonContainer extends PureComponent {
             const variant = product.variants[configurableVariantIndex];
 
             return { ...variant, product_option: { extension_attributes } };
+        }
+
+        if (type_id === GROUPED) {
+            const extension_attributes = getExtensionAttributes({ ...product, groupedProductQuantity });
+            return { ...product, product_option: { extension_attributes } };
         }
 
         return product;

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
@@ -93,34 +93,36 @@ export class WishlistItemContainer extends PureComponent {
         [GROUPED]: this.addGroupedProductToCart.bind(this)
     };
 
+    addSimpleProduct = this.addSimpleProductToCart.bind(this);
+
     addGroupedProductToCart() {
         const {
             product,
-            product: { items },
-            // groupedProductQuantity,
+            product: { items, groupedProductQuantity },
             addProductToCart
         } = this.props;
 
-        return Promise.all(items.map((item) => {
-            const { product: groupedProductItem } = item;
+        return Promise.all(
+            items.map((item) => {
+                const { product: groupedProductItem } = item;
 
-            const newProduct = {
-                ...groupedProductItem,
-                parent: product
-            };
+                const newProduct = {
+                    ...groupedProductItem,
+                    parent: product
+                };
 
-            // const quantity = groupedProductQuantity[groupedProductItem.id];
-            const quantity = 3;
+                const quantity = groupedProductQuantity.find((product) => product.id === groupedProductItem.id)?.qty;
 
-            if (!quantity) {
-                return Promise.resolve();
-            }
+                if (!quantity) {
+                    return Promise.resolve();
+                }
 
-            return addProductToCart({
-                product: newProduct,
-                quantity
-            });
-        }));
+                return addProductToCart({
+                    product: newProduct,
+                    quantity
+                });
+            })
+        );
     }
 
     addConfigurableProductToCart() {
@@ -199,7 +201,7 @@ export class WishlistItemContainer extends PureComponent {
             wishlist: { id }
         } = item;
 
-        const addToCartHandler = this.addToCartHandlerMap[type_id] || this.addSimpleProductToCart;
+        const addToCartHandler = this.addToCartHandlerMap[type_id] || this.addSimpleProduct;
 
         this.setState({ isLoading: true });
 

--- a/packages/scandipwa/src/query/ProductList.query.js
+++ b/packages/scandipwa/src/query/ProductList.query.js
@@ -300,7 +300,6 @@ export class ProductListQuery {
     /**
      * A GroupedProduct-specific field that queries the products that are grouped under this product
      * @returns {Field}
-     * @private
      */
     _getGroupedProductItems() {
         return new Fragment('GroupedProduct').addField(

--- a/packages/scandipwa/src/query/Wishlist.query.js
+++ b/packages/scandipwa/src/query/Wishlist.query.js
@@ -110,7 +110,10 @@ export class WishlistQuery {
 
     _getProductField() {
         return new Field('product')
-            .addFieldList(ProductListQuery._getProductInterfaceFields());
+            .addFieldList([
+                ...ProductListQuery._getProductInterfaceFields(),
+                ProductListQuery._getGroupedProductItems()
+            ]);
     }
 
     _getItemsField() {

--- a/packages/scandipwa/src/store/LinkedProducts/LinkedProducts.dispatcher.js
+++ b/packages/scandipwa/src/store/LinkedProducts/LinkedProducts.dispatcher.js
@@ -135,7 +135,8 @@ export class LinkedProductsDispatcher extends QueryDispatcher {
         }, {
             upsell: { total_count: 0, items: [] },
             related: { total_count: 0, items: [] },
-            crosssell: { total_count: 0, items: [] }
+            crosssell: { total_count: 0, items: [] },
+            associated: { total_count: 0, items: [] }
         });
 
         return linkedProducts;

--- a/packages/scandipwa/src/store/Wishlist/Wishlist.dispatcher.js
+++ b/packages/scandipwa/src/store/Wishlist/Wishlist.dispatcher.js
@@ -52,6 +52,7 @@ export class WishlistDispatcher {
                             id,
                             sku,
                             product,
+                            product_options: { grouped_product_qty: groupedProductQuantity },
                             description,
                             qty: quantity
                         } = wishlistItem;
@@ -61,6 +62,7 @@ export class WishlistDispatcher {
                             [id]: {
                                 ...product,
                                 quantity,
+                                groupedProductQuantity,
                                 wishlist: {
                                     id,
                                     sku,

--- a/packages/scandipwa/src/store/Wishlist/Wishlist.dispatcher.js
+++ b/packages/scandipwa/src/store/Wishlist/Wishlist.dispatcher.js
@@ -87,14 +87,17 @@ export class WishlistDispatcher {
 
     addItemToWishlist(dispatch, wishlistItem) {
         dispatch(updateIsLoading(true));
-        dispatch(showNotification('success', __('Product added to wish-list!')));
 
         return fetchMutation(WishlistQuery.getSaveWishlistItemMutation(wishlistItem)).then(
             /** @namespace Store/Wishlist/Dispatcher/addItemToWishlistFetchMutationThen */
-            () => this._syncWishlistWithBE(dispatch),
+            () => {
+                dispatch(showNotification('success', __('Product added to Wish list!')));
+                this._syncWishlistWithBE(dispatch);
+            },
+
             /** @namespace Store/Wishlist/Dispatcher/addItemToWishlistFetchMutationError */
             (error) => {
-                dispatch(showNotification('error', __('Error updating wish list!')));
+                dispatch(showNotification('error', __('Error updating Wish list!')));
                 // eslint-disable-next-line no-console
                 console.log(error);
             }

--- a/packages/scandipwa/src/util/Product/Product.js
+++ b/packages/scandipwa/src/util/Product/Product.js
@@ -294,7 +294,7 @@ export const getExtensionAttributes = (product) => {
 
     if (type_id === GROUPED) {
         const grouped_options = Object.entries(groupedProductQuantity)
-            .map(([product_id, quantity]) => ({ product_id: Number(product_id), quantity }));
+            .map(([product_id, quantity]) => ({ product_id: +product_id, quantity }));
 
         return { grouped_options };
     }

--- a/packages/scandipwa/src/util/Product/Product.js
+++ b/packages/scandipwa/src/util/Product/Product.js
@@ -9,7 +9,9 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-import { BUNDLE, CONFIGURABLE, SIMPLE } from 'Util/Product';
+import {
+    BUNDLE, CONFIGURABLE, GROUPED, SIMPLE
+} from 'Util/Product';
 
 /**
  * Checks whether every option is in attributes
@@ -241,7 +243,8 @@ export const getExtensionAttributes = (product) => {
         productOptions,
         productOptionsMulti,
         variants,
-        type_id
+        type_id,
+        groupedProductQuantity
     } = product;
 
     if (type_id === CONFIGURABLE) {
@@ -287,6 +290,13 @@ export const getExtensionAttributes = (product) => {
             customizable_options: productOptions || [],
             customizable_options_multi: productOptionsMulti || []
         };
+    }
+
+    if (type_id === GROUPED) {
+        const grouped_options = Object.entries(groupedProductQuantity)
+            .map(([product_id, quantity]) => ({ product_id: Number(product_id), quantity }));
+
+        return { grouped_options };
     }
 
     return {};


### PR DESCRIPTION
### ISSUE: https://github.com/scandipwa/scandipwa/issues/1877

Changes made:
- send selected grouped product quantities in `s_saveWishlistItem` GQL request
- parse product quantities for grouped products from response for `s_wishlist` request
- add grouped product from wishlist to cart so that single product quantities in cart correspond to ones the user entered when adding the product to wishlist

Related PRs: https://github.com/scandipwa/wishlist-graphql/pull/13 and https://github.com/scandipwa/quote-graphql/pull/64

### As discussed with @lianastaskevica: it turned out that the changes @riha112 made under https://github.com/scandipwa/scandipwa/issues/1876 task are supposed to include the same functionality. If PR for #1876, is successfully merged, merging this PR is not required. Please review the changes, and leave comments for me to take into account in the future. The PR itself will be cancelled after that.