### PR TITLE
#2304 Downloadable product fixes

### DIFF
--- a/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
@@ -66,6 +66,7 @@ export class ProductActions extends PureComponent {
         clearGroupedProductQuantity: PropTypes.func.isRequired,
         setGroupedProductQuantity: PropTypes.func.isRequired,
         setLinkedDownloadables: PropTypes.func.isRequired,
+        setLinkedDownloadablesPrice: PropTypes.func.isRequired,
         onProductValidationError: PropTypes.func.isRequired,
         getSelectedCustomizableOptions: PropTypes.func.isRequired,
         productOptionsData: PropTypes.object.isRequired,
@@ -585,16 +586,18 @@ export class ProductActions extends PureComponent {
             const { title, sample_url } = item;
 
             return (
-                <Link to={ sample_url } block="ProductActions" elem="SampleLink">
-                    { title }
-                </Link>
+                <dd block="ProductActions" elem="SamplesLink">
+                    <Link to={ sample_url }>
+                        { title }
+                    </Link>
+                </dd>
             );
         });
     }
 
     renderDownloadableProductSample() {
         const {
-            product: { type_id }
+            product: { type_id, samples_title }
         } = this.props;
 
         if (type_id !== DOWNLOADABLE) {
@@ -602,32 +605,42 @@ export class ProductActions extends PureComponent {
         }
 
         return (
-            <div block="ProductActions" elem="Samples">
+            <dl block="ProductActions" elem="Samples">
+                <dt block="ProductActions" elem="SamplesTitle">
+                    { samples_title }
+                </dt>
                 { this.renderDownloadableProductSampleItems() }
-            </div>
+            </dl>
         );
     }
 
     renderDownloadableProductLinks() {
         const {
-            product: { type_id, downloadable_product_links, links_title },
-            setLinkedDownloadables
+            setLinkedDownloadables,
+            setLinkedDownloadablesPrice,
+            product: {
+                type_id, downloadable_product_links, links_title, links_purchased_separately
+            }
         } = this.props;
 
         if (type_id !== DOWNLOADABLE) {
             return null;
         }
 
+        const isRequired = links_purchased_separately === 1;
+
         return (
             <section
               block="ProductActions"
-              elem="Section"
+              elem="SectionDownloadable"
               mods={ { type: 'customizable_options' } }
             >
                 <ProductDownloadableLinks
                   links={ downloadable_product_links }
                   setLinkedDownloadables={ setLinkedDownloadables }
+                  setLinkedDownloadablesPrice={ setLinkedDownloadablesPrice }
                   title={ links_title }
+                  isRequired={ isRequired }
                 />
             </section>
         );
@@ -635,30 +648,32 @@ export class ProductActions extends PureComponent {
 
     render() {
         return (
-            <article block="ProductActions">
-                { this.renderPriceWithGlobalSchema() }
-                { this.renderShortDescription() }
-                { this.renderDownloadableProductSample() }
-                <div
-                  block="ProductActions"
-                  elem="AddToCartWrapper"
-                  mix={ { block: 'FixedElement', elem: 'Bottom' } }
-                >
-                    { this.renderQuantityInput() }
-                    { this.renderAddToCart() }
-                    { this.renderProductCompareButton() }
-                    { this.renderProductWishlistButton() }
-                </div>
-                { this.renderReviews() }
-                { this.renderNameAndBrand() }
-                { this.renderSkuAndStock() }
-                { this.renderConfigurableAttributes() }
-                { this.renderCustomizableOptions() }
+            <>
+                <article block="ProductActions">
+                    { this.renderPriceWithGlobalSchema() }
+                    { this.renderShortDescription() }
+                    { this.renderDownloadableProductSample() }
+                    <div
+                      block="ProductActions"
+                      elem="AddToCartWrapper"
+                      mix={ { block: 'FixedElement', elem: 'Bottom' } }
+                    >
+                        { this.renderQuantityInput() }
+                        { this.renderAddToCart() }
+                        { this.renderProductCompareButton() }
+                        { this.renderProductWishlistButton() }
+                    </div>
+                    { this.renderReviews() }
+                    { this.renderNameAndBrand() }
+                    { this.renderSkuAndStock() }
+                    { this.renderConfigurableAttributes() }
+                    { this.renderCustomizableOptions() }
+                    { this.renderBundleItems() }
+                    { this.renderGroupedItems() }
+                    { this.renderTierPrices() }
+                </article>
                 { this.renderDownloadableProductLinks() }
-                { this.renderBundleItems() }
-                { this.renderGroupedItems() }
-                { this.renderTierPrices() }
-            </article>
+            </>
         );
     }
 }

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.container.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.container.js
@@ -17,6 +17,7 @@ import { ProductType } from 'Type/ProductList';
 import {
     BUNDLE,
     CONFIGURABLE,
+    DOWNLOADABLE,
     GROUPED
 } from 'Util/Product';
 
@@ -39,6 +40,7 @@ export class ProductActionsContainer extends PureComponent {
         parameters: PropTypes.objectOf(PropTypes.string).isRequired,
         selectedBundlePrice: PropTypes.number.isRequired,
         selectedBundlePriceExclTax: PropTypes.number.isRequired,
+        selectedLinkPrice: PropTypes.number.isRequired,
         getLink: PropTypes.func.isRequired
     };
 
@@ -269,10 +271,11 @@ export class ProductActionsContainer extends PureComponent {
     getProductPrice() {
         const {
             product,
-            product: { variants = [], type_id },
+            product: { variants = [], type_id, links_purchased_separately },
             configurableVariantIndex,
             selectedBundlePrice,
-            selectedBundlePriceExclTax
+            selectedBundlePriceExclTax,
+            selectedLinkPrice
         } = this.props;
 
         const {
@@ -280,35 +283,49 @@ export class ProductActionsContainer extends PureComponent {
         } = variants[configurableVariantIndex] || product;
 
         if (type_id === BUNDLE) {
-            const {
-                price_range: {
-                    minimum_price: {
-                        regular_price: { currency },
-                        discount: { percent_off }
-                    }
-                }
-            } = product;
+            return this._getCustomPrice(selectedBundlePrice, selectedBundlePriceExclTax);
+        }
 
-            // eslint-disable-next-line no-magic-numbers
-            const discount = (1 - percent_off / 100);
-
-            const finalBundlePrice = selectedBundlePrice * discount;
-            const finalBundlePriceExclTax = selectedBundlePriceExclTax * discount;
-
-            const priceValue = { value: finalBundlePrice, currency };
-            const priceValueExclTax = { value: finalBundlePriceExclTax, currency };
-
-            return {
-                minimum_price: {
-                    final_price: priceValue,
-                    regular_price: priceValue,
-                    final_price_excl_tax: priceValueExclTax,
-                    regular_price_excl_tax: priceValueExclTax
-                }
-            };
+        if (type_id === DOWNLOADABLE && links_purchased_separately) {
+            return this._getCustomPrice(selectedLinkPrice, selectedLinkPrice, true);
         }
 
         return price_range;
+    }
+
+    _getCustomPrice(price, withoutTax, addBase = false) {
+        const {
+            product: {
+                price_range: {
+                    minimum_price: {
+                        regular_price: { currency, value },
+                        regular_price_excl_tax: { value: value_excl_tax },
+                        discount: { percent_off }
+                    }
+                }
+            }
+        } = this.props;
+
+        // eslint-disable-next-line no-magic-numbers
+        const discount = (1 - percent_off / 100);
+
+        const basePrice = addBase ? value : 0;
+        const basePriceExclTax = addBase ? value_excl_tax : 0;
+
+        const finalPrice = (basePrice + price) * discount;
+        const finalPriceExclTax = (basePriceExclTax + withoutTax) * discount;
+
+        const priceValue = { value: finalPrice, currency };
+        const priceValueExclTax = { value: finalPriceExclTax, currency };
+
+        return {
+            minimum_price: {
+                final_price: priceValue,
+                regular_price: priceValue,
+                final_price_excl_tax: priceValueExclTax,
+                regular_price_excl_tax: priceValueExclTax
+            }
+        };
     }
 
     _getGroupedProductQuantity() {

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -171,7 +171,10 @@
     }
 
     &-Title {
+        font-size: 2.4rem;
         line-height: 3.6rem;
+        text-transform: none;
+        margin: 0;
 
         @include mobile {
             font-size: 2.8rem;
@@ -211,7 +214,19 @@
     }
 
     &-Samples {
-        order: 5;
+        order: 20;
+        border-top: 1px solid var(--expandable-content-divider-color);
+        padding: 2rem 1rem;
+        margin-top: 1rem;
+
+        &Title {
+            font-weight: bold;
+            margin-bottom: .5rem;
+        }
+
+        &Link {
+            padding: .5rem 0;
+        }
     }
 
     &-AddToCart {

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
@@ -15,10 +15,13 @@ import Field from 'Component/Field';
 import Link from 'Component/Link';
 import { formatPrice } from 'Util/Price';
 
+import './ProductDownloadableLinks.style.scss';
+
 /** @namespace Component/ProductDownloadableLinks/Component */
 export class ProductDownloadableLinks extends PureComponent {
     static propTypes = {
         isLoading: PropTypes.bool.isRequired,
+        isRequired: PropTypes.bool.isRequired,
         links: PropTypes.array,
         title: PropTypes.string.isRequired,
         setSelectedCheckboxValues: PropTypes.func.isRequired
@@ -30,43 +33,76 @@ export class ProductDownloadableLinks extends PureComponent {
 
     getLabel(link) {
         const { title, price } = link;
+        const { isRequired } = this.props;
 
-        return `${ title } (${ formatPrice(price) })`;
+        if (!isRequired) {
+            return title;
+        }
+
+        return `${ title } (+${ formatPrice(price) })`;
+    }
+
+    renderLabel(link) {
+        const { sample_url } = link;
+
+        if (!sample_url) {
+            return this.getLabel(link);
+        }
+
+        return (
+            <>
+                { this.getLabel(link) }
+                <Link to={ sample_url } block="ProductDownloadableLink" elem="SampleLink">
+                    { __('Sample') }
+                </Link>
+            </>
+        );
     }
 
     renderCheckBox(link) {
-        const { sample_url, id } = link;
-        const { setSelectedCheckboxValues } = this.props;
+        const { setSelectedCheckboxValues, isRequired } = this.props;
+        const { id } = link;
+
+        if (!isRequired) {
+            return null;
+        }
 
         return (
-            <div>
-                <Field
-                  type="checkbox"
-                  label={ this.getLabel(link) }
-                  key={ id }
-                  id={ `link-${id}` }
-                  name={ `link-${id}` }
-                  value={ id }
-                  onChange={ setSelectedCheckboxValues }
-                />
-                <Link to={ sample_url } block="ProductDownloadableLinks" elem="SampleLink">
-                    { __('Sample') }
-                </Link>
+            <Field
+              type="checkbox"
+              key={ id }
+              id={ `link-${ id }` }
+              name={ `link-${ id }` }
+              value={ id }
+              onChange={ setSelectedCheckboxValues }
+            />
+        );
+    }
+
+    renderLink(link) {
+        return (
+            <div block="ProductDownloadableLink">
+                { this.renderCheckBox(link) }
+                <span block="ProductDownloadableLink" elem="SampleLabel">
+                    { this.renderLabel(link) }
+                </span>
             </div>
         );
     }
 
-    renderCheckBoxes() {
+    renderLinks() {
         const { links } = this.props;
 
-        return links.map((link) => this.renderCheckBox(link));
+        return links.map((link) => this.renderLink(link));
     }
 
     renderTitle() {
-        const { title } = this.props;
+        const { title, isRequired } = this.props;
+
+        const elem = `Title${ isRequired ? '-Required' : '' }`;
 
         return (
-            <h3 block="ProductDownloadableLinks" elem="Title">
+            <h3 block="ProductDownloadableLinks" elem={ elem }>
                 { title }
             </h3>
         );
@@ -76,7 +112,7 @@ export class ProductDownloadableLinks extends PureComponent {
         return (
             <>
             { this.renderTitle() }
-            { this.renderCheckBoxes() }
+            { this.renderLinks() }
             </>
         );
     }

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
@@ -79,30 +79,26 @@ export class ProductDownloadableLinks extends PureComponent {
         );
     }
 
-    renderLink(link) {
-        return (
-            <div block="ProductDownloadableLink">
-                { this.renderCheckBox(link) }
-                <span block="ProductDownloadableLink" elem="SampleLabel">
-                    { this.renderLabel(link) }
-                </span>
-            </div>
-        );
-    }
+    renderLink = (link) => (
+        <div block="ProductDownloadableLink">
+            { this.renderCheckBox(link) }
+            <span block="ProductDownloadableLink" elem="SampleLabel">
+                { this.renderLabel(link) }
+            </span>
+        </div>
+    );
 
     renderLinks() {
         const { links } = this.props;
 
-        return links.map((link) => this.renderLink(link));
+        return links.map(this.renderLink);
     }
 
     renderTitle() {
         const { title, isRequired } = this.props;
 
-        const elem = `Title${ isRequired ? '-Required' : '' }`;
-
         return (
-            <h3 block="ProductDownloadableLinks" elem={ elem }>
+            <h3 block="ProductDownloadableLinks" elem="Title" mods={ { isRequired } }>
                 { title }
             </h3>
         );

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.container.js
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.container.js
@@ -18,13 +18,16 @@ import ProductDownloadableLinks from './ProductDownloadableLinks.component';
 export class ProductDownloadableLinksContainer extends PureComponent {
     static propTypes = {
         title: PropTypes.string,
+        isRequired: PropTypes.bool,
         links: PropTypes.array,
-        setLinkedDownloadables: PropTypes.func.isRequired
+        setLinkedDownloadables: PropTypes.func.isRequired,
+        setLinkedDownloadablesPrice: PropTypes.func.isRequired
     };
 
     static defaultProps = {
         title: '',
-        links: []
+        links: [],
+        isRequired: false
     };
 
     state = {
@@ -69,10 +72,26 @@ export class ProductDownloadableLinksContainer extends PureComponent {
     }
 
     updateSelectedOptionsArray() {
-        const { setLinkedDownloadables } = this.props;
+        const { setLinkedDownloadables, setLinkedDownloadablesPrice } = this.props;
         const { selectedLinks } = this.state;
 
         setLinkedDownloadables(selectedLinks);
+
+        const price = this.getTotalPrice();
+        setLinkedDownloadablesPrice(price);
+    }
+
+    getTotalPrice() {
+        const { selectedLinks } = this.state;
+        const { links } = this.props;
+
+        return selectedLinks.reduce(
+            (base, { link_id }) => {
+                const link = links.find(({ id }) => id === link_id);
+                return base + link.price;
+            },
+            0
+        );
     }
 
     setSelectedCheckboxValues(option_id, option_value) {

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -4,8 +4,8 @@
 
     &-Title {
         margin-bottom: .1rem;
-        &-Required {
-            &:after{
+        &_isRequired {
+            &::after{
                 content: '*';
                 color: var(--primary-base-color);
                 padding: 0 .5rem;

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -1,5 +1,34 @@
 .ProductDownloadableLinks {
+    padding: 0 1rem;
+    margin-bottom: 3rem;
+
     &-Title {
+        margin-bottom: .1rem;
+        &-Required {
+            &:after{
+                content: '*';
+                color: var(--primary-base-color);
+                padding: 0 .5rem;
+            }
+        }
+    }
+}
+
+.ProductDownloadableLink {
+    padding: 1.5rem 0 1rem;
+    border-bottom: 1px solid var(--expandable-content-divider-color);
+
+    .Field {
+        display: inline-block;
+        margin-right: 1rem;
         margin-top: 0;
+    }
+
+    &-SampleLable {
+        font-weight: bold;
+    }
+
+    &-SampleLink {
+        float: right;
     }
 }

--- a/packages/scandipwa/src/query/ProductList.query.js
+++ b/packages/scandipwa/src/query/ProductList.query.js
@@ -322,6 +322,7 @@ export class ProductListQuery {
     _getDownloadableProductLinks() {
         return [
             'links_title',
+            'samples_title',
             'links_purchased_separately',
             this._getDownloadableProductLinkField(),
             this._getDownloadableProductSampleField()

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.component.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.component.js
@@ -47,8 +47,10 @@ export class ProductPage extends PureComponent {
         areDetailsLoaded: PropTypes.bool.isRequired,
         getSelectedCustomizableOptions: PropTypes.func.isRequired,
         setLinkedDownloadables: PropTypes.func.isRequired,
+        setLinkedDownloadablesPrice: PropTypes.func.isRequired,
         productOptionsData: PropTypes.object.isRequired,
         setBundlePrice: PropTypes.func.isRequired,
+        selectedLinkPrice: PropTypes.number.isRequired,
         selectedBundlePrice: PropTypes.number.isRequired,
         device: DeviceType.isRequired,
         isInformationTabEmpty: PropTypes.bool.isRequired,
@@ -118,7 +120,9 @@ export class ProductPage extends PureComponent {
             setBundlePrice,
             selectedBundlePrice,
             selectedBundlePriceExclTax,
-            setLinkedDownloadables
+            setLinkedDownloadables,
+            setLinkedDownloadablesPrice,
+            selectedLinkPrice
         } = this.props;
 
         return (
@@ -142,6 +146,8 @@ export class ProductPage extends PureComponent {
                   selectedBundlePrice={ selectedBundlePrice }
                   selectedBundlePriceExclTax={ selectedBundlePriceExclTax }
                   setLinkedDownloadables={ setLinkedDownloadables }
+                  setLinkedDownloadablesPrice={ setLinkedDownloadablesPrice }
+                  selectedLinkPrice={ selectedLinkPrice }
                 />
             </>
         );

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -87,6 +87,7 @@ export class ProductPageContainer extends PureComponent {
         productOptionsData: {},
         selectedBundlePrice: 0,
         selectedBundlePriceExclTax: 0,
+        selectedLinkPrice: 0,
         currentProductSKU: ''
     };
 
@@ -96,6 +97,7 @@ export class ProductPageContainer extends PureComponent {
         getSelectedCustomizableOptions: this.getSelectedCustomizableOptions.bind(this),
         setBundlePrice: this.setBundlePrice.bind(this),
         setLinkedDownloadables: this.setLinkedDownloadables.bind(this),
+        setLinkedDownloadablesPrice: this.setLinkedDownloadablesPrice.bind(this),
         isProductInformationTabEmpty: this.isProductInformationTabEmpty.bind(this),
         isProductAttributesTabEmpty: this.isProductAttributesTabEmpty.bind(this)
     };
@@ -355,6 +357,12 @@ export class ProductPageContainer extends PureComponent {
         return this.setState({
             productOptionsData:
                 { ...productOptionsData, requiredOptions }
+        });
+    }
+
+    setLinkedDownloadablesPrice(price) {
+        this.setState({
+            selectedLinkPrice: price
         });
     }
 


### PR DESCRIPTION
Original issue: #2304 
Required PR to work: https://github.com/scandipwa/catalog-graphql/pull/89

In this PR:
* Added samples title output
* Position and styling fixes for sample
* Styling fixes for product title 
* Styling and render location changes for links to match luma
* Required '*' for links title
* Hides check-boxes if not required (keeps link list)
* Price update for downloadable product