### PR TITLE
#2310 - search page endless loader

### DIFF
--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.js
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.js
@@ -346,10 +346,11 @@ export class CategoryPageContainer extends PureComponent {
             categoryIds,
             category: {
                 id
-            }
+            },
+            isSearchPage
         } = this.props;
 
-        return categoryIds === id;
+        return isSearchPage || categoryIds === id;
     }
 
     containerProps = () => ({


### PR DESCRIPTION
https://github.com/scandipwa/scandipwa/issues/2310

We don't need to perform `isCurrentCategoryLoaded` check or Search page, as it is not a category and no category data request is performed when search page is loaded.

And this category data request is exactly the reason why this check has been added. See explanation here
https://github.com/scandipwa/scandipwa/blob/9377a1434cef23a7b2e38bbdab92f6ab03c4a035/packages/scandipwa/src/component/CategoryProductList/CategoryProductList.container.js#L88
```
         * Do not request page, if category is not yet loaded
         * without this command the products are requested twice:
         * 1. Once with global default sorting
         * 2. Once with category default sorting
```
        