### PR TITLE
#1822 - remove a + a too generic style

### DIFF
--- a/packages/scandipwa/src/component/Footer/Footer.style.scss
+++ b/packages/scandipwa/src/component/Footer/Footer.style.scss
@@ -110,10 +110,6 @@
                 justify-content: center;
             }
         }
-
-        a + a {
-            margin-left: 0;
-        }
     }
 
     &-ColumnItem {

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -30,8 +30,6 @@
     --button-padding: 0;
     --option-is-selected: 0;
 
-    margin-left: 0;
-
     &-Color,
     &-String,
     &-Image,

--- a/packages/scandipwa/src/style/base/_link.scss
+++ b/packages/scandipwa/src/style/base/_link.scss
@@ -23,12 +23,4 @@ a {
     &:focus {
         text-decoration: underline;
     }
-
-    + a {
-        margin-left: 1.2rem;
-
-        @include mobile {
-            margin-left: 1.4rem;
-        }
-    }
 }

--- a/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
+++ b/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
@@ -88,9 +88,5 @@
 
     a {
         display: block;
-
-        + a {
-            margin-left: 0;
-        }
     }
 }


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/1822

- Remove `a + a: { margin-left: 1.2rem }` generic style
- Remove its overrides to `a + a: { margin: 0 }`, as it is not necessary any more 