### PR TITLE
#1829 - billing step failure france

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -431,5 +431,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://40kskudemo.scandipwa.com/"
+    "proxy": "https://scandipwapmrev.indvp.com/"
 }

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -431,5 +431,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://scandipwapmrev.indvp.com/"
+    "proxy": "https://40kskudemo.scandipwa.com/"
 }

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -586,7 +586,8 @@ export class CheckoutContainer extends PureComponent {
         const newAddress = {
             ...restOfBillingAddress,
             country_code: country_id,
-            region
+            region,
+            region_id
         };
 
         /**


### PR DESCRIPTION
Current  ScandiPWA logic sends `regionCode` as value of `region` field on billing step. It works fine, unless code is numeric due to the following Magento logic (https://github.com/magento/magento2/blob/aaeadff2f3130f2ddf14018cb64ca259799d1a1c/app/code/Magento/Customer/Model/Address/AbstractAddress.php#L426):
```
public function getRegionId()
    {
        $regionId = $this->getData('region_id');
        $region = $this->getData('region');
        if (!$regionId) {
            if (is_numeric($region)) {
                $this->setData('region_id', $region);
                $this->unsRegion();
            } else {
                $regionModel = $this->_createRegionInstance()->loadByCode(
                    $this->getRegionCode(),
                    $this->getCountryId()
                );
                $this->setData('region_id', $regionModel->getId());
            }
        }
        return $this->getData('region_id');
    }
```

If region code is numeric it is being interpreted as region id 😠  France is the only country that has numeric country codes. 

The easiest and most reliable way to resolve the issue is to rely on region ids, not on region codes, as it is on shipping step.