### PR TITLE
#1780 Multistore recently viewed products

### DIFF
--- a/packages/scandipwa/src/component/RecentlyViewedWidget/RecentlyViewedWidget.container.js
+++ b/packages/scandipwa/src/component/RecentlyViewedWidget/RecentlyViewedWidget.container.js
@@ -9,6 +9,7 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
@@ -16,7 +17,8 @@ import RecentlyViewedWidget from './RecentlyViewedWidget.component';
 
 /** @namespace Component/RecentlyViewedWidget/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
-    products: state.RecentlyViewedProductsReducer.recentlyViewedProducts
+    recentProducts: state.RecentlyViewedProductsReducer.recentlyViewedProducts,
+    store: state.ConfigReducer.code
 });
 
 /** @namespace Component/Slider/Container/mapDispatchToProps */
@@ -25,6 +27,11 @@ export const mapDispatchToProps = (dispatch) => ({});
 
 /** @namespace Component/RecentlyViewedWidget/Container */
 export class RecentlyViewedWidgetContainer extends PureComponent {
+    static propTypes = {
+        recentProducts: PropTypes.object.isRequired,
+        store: PropTypes.string.isRequired
+    };
+
     state = {
         siblingsHaveBrands: false,
         siblingsHavePriceBadge: false,
@@ -40,6 +47,13 @@ export class RecentlyViewedWidgetContainer extends PureComponent {
             siblingsHaveConfigurableOptions
         } = this.state;
 
+        const {
+            store,
+            recentProducts
+        } = this.props;
+
+        const products = recentProducts[store] ?? [];
+
         return {
             productCardFunctions: {
                 setSiblingsHaveBrands: () => this.setState({ siblingsHaveBrands: true }),
@@ -52,7 +66,8 @@ export class RecentlyViewedWidgetContainer extends PureComponent {
                 siblingsHavePriceBadge,
                 siblingsHaveTierPrice,
                 siblingsHaveConfigurableOptions
-            }
+            },
+            products
         };
     }
 

--- a/packages/scandipwa/src/component/RecentlyViewedWidget/RecentlyViewedWidget.container.js
+++ b/packages/scandipwa/src/component/RecentlyViewedWidget/RecentlyViewedWidget.container.js
@@ -13,6 +13,8 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
+import { ItemsType } from 'Type/ProductList';
+
 import RecentlyViewedWidget from './RecentlyViewedWidget.component';
 
 /** @namespace Component/RecentlyViewedWidget/Container/mapStateToProps */
@@ -28,7 +30,7 @@ export const mapDispatchToProps = (dispatch) => ({});
 /** @namespace Component/RecentlyViewedWidget/Container */
 export class RecentlyViewedWidgetContainer extends PureComponent {
     static propTypes = {
-        recentProducts: PropTypes.object.isRequired,
+        recentProducts: PropTypes.objectOf(ItemsType).isRequired,
         store: PropTypes.string.isRequired
     };
 

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -55,7 +55,8 @@ export const mapStateToProps = (state) => ({
     product: state.ProductReducer.product,
     navigation: state.NavigationReducer[TOP_NAVIGATION_TYPE],
     metaTitle: state.MetaReducer.title,
-    device: state.ConfigReducer.device
+    device: state.ConfigReducer.device,
+    store: state.ConfigReducer.code
 });
 
 /** @namespace Route/ProductPage/Container/mapDispatchToProps */
@@ -76,7 +77,7 @@ export const mapDispatchToProps = (dispatch) => ({
         ({ default: dispatcher }) => dispatcher.updateWithProduct(product, dispatch)
     ),
     goToPreviousNavigationState: (state) => dispatch(goToPreviousNavigationState(TOP_NAVIGATION_TYPE, state)),
-    updateRecentlyViewedProducts: (products) => dispatch(updateRecentlyViewedProducts(products))
+    updateRecentlyViewedProducts: (products, store) => dispatch(updateRecentlyViewedProducts(products, store))
 });
 
 /** @namespace Route/ProductPage/Container */
@@ -118,7 +119,8 @@ export class ProductPageContainer extends PureComponent {
         goToPreviousNavigationState: PropTypes.func.isRequired,
         navigation: PropTypes.shape(PropTypes.shape).isRequired,
         metaTitle: PropTypes.string,
-        updateRecentlyViewedProducts: PropTypes.func.isRequired
+        updateRecentlyViewedProducts: PropTypes.func.isRequired,
+        store: PropTypes.string.isRequired
     };
 
     static defaultProps = {
@@ -312,7 +314,8 @@ export class ProductPageContainer extends PureComponent {
         const {
             product,
             product: { sku },
-            updateRecentlyViewedProducts
+            updateRecentlyViewedProducts,
+            store
         } = this.props;
 
         // necessary for skipping not loaded products
@@ -320,7 +323,7 @@ export class ProductPageContainer extends PureComponent {
             return;
         }
 
-        updateRecentlyViewedProducts(product);
+        updateRecentlyViewedProducts(product, store);
     }
 
     scrollTop() {

--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.action.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.action.js
@@ -14,10 +14,12 @@ export const UPDATE_RECENTLY_VIEWED_PRODUCTS = 'UPDATE_RECENTLY_VIEWED_PRODUCTS'
 /**
  * Update RecentlyViewed products list.
  * @param  {Object} product Product returned from fetch
+ * @param  {String} store code
  * @return {void}
  * @namespace Store/RecentlyViewedProducts/Action/updateRecentlyViewedProducts
  */
-export const updateRecentlyViewedProducts = (product) => ({
+export const updateRecentlyViewedProducts = (product, store) => ({
     type: UPDATE_RECENTLY_VIEWED_PRODUCTS,
-    product
+    product,
+    store
 });

--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
@@ -20,7 +20,7 @@ import BrowserDatabase from 'Util/BrowserDatabase';
 
 /** @namespace Store/RecentlyViewedProducts/Reducer/getInitialState */
 export const getInitialState = () => ({
-    recentlyViewedProducts: BrowserDatabase.getItem(RECENTLY_VIEWED_PRODUCTS) || []
+    recentlyViewedProducts: BrowserDatabase.getItem(RECENTLY_VIEWED_PRODUCTS) || {}
 });
 
 /** @namespace Store/RecentlyViewedProducts/Reducer/recentlyViewedProductsReducer */
@@ -34,15 +34,23 @@ export const RecentlyViewedProductsReducer = (
             product,
             product: { sku: newSku }
         } = action;
-        const { recentlyViewedProducts } = state;
 
-        if (recentlyViewedProducts.length === MAX_NUMBER_OF_RECENT_PRODUCTS) {
-            recentlyViewedProducts.pop();
+        const { recentlyViewedProducts = {} } = state;
+        const { store } = action;
+        const storeProducts = recentlyViewedProducts[store] ?? [];
+
+        if (storeProducts.length === MAX_NUMBER_OF_RECENT_PRODUCTS) {
+            storeProducts.pop();
         }
 
         // Remove product from existing recentProducts to add it later in the beginning
-        const newRecentProducts = recentlyViewedProducts.filter(({ sku }) => (newSku !== sku));
-        newRecentProducts.unshift(product);
+        const newStoreRecentProducts = storeProducts.filter(({ sku }) => (newSku !== sku));
+        newStoreRecentProducts.unshift(product);
+
+        const newRecentProducts = {
+            ...recentlyViewedProducts,
+            [store]: newStoreRecentProducts
+        };
 
         BrowserDatabase.setItem(newRecentProducts, RECENTLY_VIEWED_PRODUCTS);
 


### PR DESCRIPTION
Original issue: #1780 

**Issue**:  
Multi-store website setup with same base URL shares recently viewed products, because products are stored locally inside ```localStorege``` without indication of which store is targeted.

**Solution**
Added access by ```store_code``` for recently viewed products to differ between instances.