### PR TITLE
Implement guest redirect if downloadable product are not allowed in checkout

### DIFF
--- a/packages/scandipwa/src/query/Config.query.js
+++ b/packages/scandipwa/src/query/Config.query.js
@@ -100,6 +100,7 @@ export class ConfigQuery {
             'default_title',
             'default_description',
             'default_country',
+            'downloadable_disable_guest_checkout',
             'secure_base_media_url',
             // 'paypal_sandbox_flag',
             // 'paypal_client_id',

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -207,7 +207,7 @@ export class CheckoutContainer extends PureComponent {
 
         // if guest is not allowed to checkout with downloadable => redirect to login page
         if (!isSignedIn() && isGuestNotAllowDownloadable) {
-            this.checkIfDownloadableInCart();
+            this.handleRedirectIfDownloadableInCart();
         }
 
         updateMeta({ title: __('Checkout') });
@@ -310,12 +310,13 @@ export class CheckoutContainer extends PureComponent {
         history.goBack();
     }
 
-    checkIfDownloadableInCart() {
-        const { totals: { items } } = this.props;
+    handleRedirectIfDownloadableInCart() {
+        const { totals: { items }, showInfoNotification } = this.props;
 
         const isDownloadable = items.find(({ product }) => product.type_id === DOWNLOADABLE);
 
         if (isDownloadable) {
+            showInfoNotification(__('Please sign in or remove downloadable products from cart!'));
             history.push(appendWithStoreCode('/account/login'));
         }
     }


### PR DESCRIPTION
Fix #2333 

Related: https://github.com/scandipwa/store-graphql/pull/21

Guest is redirected to /account/login if downloadable products are not allowed in checkout and guest have at least one of them in it.