### PR TITLE
Bugfix/2366/grouped product load error

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -431,5 +431,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://40kskudemo.scandipwa.com/"
+    "proxy": "https://scandipwapmrev.indvp.com/"
 }

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -431,5 +431,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://scandipwapmrev.indvp.com/"
+    "proxy": "https://40kskudemo.scandipwa.com/"
 }

--- a/packages/scandipwa/src/store/LinkedProducts/LinkedProducts.dispatcher.js
+++ b/packages/scandipwa/src/store/LinkedProducts/LinkedProducts.dispatcher.js
@@ -135,7 +135,8 @@ export class LinkedProductsDispatcher extends QueryDispatcher {
         }, {
             upsell: { total_count: 0, items: [] },
             related: { total_count: 0, items: [] },
-            crosssell: { total_count: 0, items: [] }
+            crosssell: { total_count: 0, items: [] },
+            associated: { total_count: 0, items: [] }
         });
 
         return linkedProducts;


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/2366

Add `associated` link type to initial value of `reduce()`. 