### PR TITLE
Bugfix #2400

### DIFF
--- a/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
@@ -605,7 +605,7 @@ export class ProductActions extends PureComponent {
             product: { downloadable_product_samples }
         } = this.props;
 
-        if (!downloadable_product_samples) {
+        if (!downloadable_product_samples || !downloadable_product_samples.length) {
             return null;
         }
 
@@ -624,10 +624,10 @@ export class ProductActions extends PureComponent {
 
     renderDownloadableProductSample() {
         const {
-            product: { type_id, samples_title }
+            product: { type_id, samples_title, downloadable_product_samples }
         } = this.props;
 
-        if (type_id !== DOWNLOADABLE) {
+        if (type_id !== DOWNLOADABLE || !downloadable_product_samples || !downloadable_product_samples.length) {
             return null;
         }
 

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
@@ -25,11 +25,13 @@ export class ProductDownloadableLinks extends PureComponent {
         isRequired: PropTypes.bool.isRequired,
         links: PropTypes.array,
         title: PropTypes.string.isRequired,
-        setSelectedCheckboxValues: PropTypes.func.isRequired
+        setSelectedCheckboxValues: PropTypes.func.isRequired,
+        selectedLinks: PropTypes.array
     };
 
     static defaultProps = {
-        links: []
+        links: [],
+        selectedLinks: []
     };
 
     getLabel(link) {
@@ -37,10 +39,20 @@ export class ProductDownloadableLinks extends PureComponent {
         const { isRequired } = this.props;
 
         if (!isRequired) {
-            return title;
+            return (
+
+            <span block="ProductDownloadableLink" elem="SampleTitle">
+                { title }
+            </span>
+            );
         }
 
-        return `${ title } (+${ formatPrice(price) })`;
+        return (
+            <span block="ProductDownloadableLink" elem="SampleTitle">
+                { title }
+                { `(+${ formatPrice(price) })` }
+            </span>
+        );
     }
 
     renderLabel(link) {
@@ -89,17 +101,38 @@ export class ProductDownloadableLinks extends PureComponent {
         </div>
     );
 
-    renderLinks() {
-        const { links } = this.props;
+    renderRequired(isRequired) {
+        const { selectedLinks } = this.props;
 
-        return links.map(this.renderLink);
+        if (isRequired !== true || selectedLinks.length > 0) {
+            return null;
+        }
+
+        return (
+            <div
+              block="ProductDownloadableLink"
+              elem="Required"
+            >
+                { __('This field is required!') }
+            </div>
+        );
+    }
+
+    renderLinks() {
+        const { links, isRequired } = this.props;
+        return (
+            <>
+            { links.map(this.renderLink) }
+            { this.renderRequired(isRequired) }
+            </>
+        );
     }
 
     renderTitle() {
-        const { title, isRequired } = this.props;
+        const { title } = this.props;
 
         return (
-            <h3 block="ProductDownloadableLinks" elem="Title" mods={ { isRequired } }>
+            <h3 block="ProductDownloadableLinks" elem="Title">
                 { title }
             </h3>
         );

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
@@ -40,7 +40,6 @@ export class ProductDownloadableLinks extends PureComponent {
 
         if (!isRequired) {
             return (
-
             <span block="ProductDownloadableLink" elem="SampleTitle">
                 { title }
             </span>
@@ -122,8 +121,8 @@ export class ProductDownloadableLinks extends PureComponent {
         const { links, isRequired } = this.props;
         return (
             <>
-            { links.map(this.renderLink) }
-            { this.renderRequired(isRequired) }
+                { links.map(this.renderLink) }
+                { this.renderRequired(isRequired) }
             </>
         );
     }

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -62,7 +62,7 @@
 
     &-Required {
         color: var(--primary-error-color);
-        padding: 1rem 0 0rem 1.5rem;
+        padding: 1rem 0 0 1.5rem;
     }
 
     @include mobile {

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -25,6 +25,12 @@
                 display: none;
             }
         }
+
+        &Content_isContentExpanded {
+            @include mobile {
+                padding: 0 1.4rem 1.4rem;
+            }
+        }
     }
 
     @include after-mobile {
@@ -42,7 +48,7 @@
         margin-top: 0;
     }
 
-    &-SampleLabel {
+    &-SampleTitle {
         font-weight: bold;
     }
 
@@ -52,6 +58,11 @@
         @include mobile {
             margin-right: 1.6rem;
         }
+    }
+
+    &-Required {
+        color: var(--primary-error-color);
+        padding: 1rem 0 0rem 1.5rem;
     }
 
     @include mobile {


### PR DESCRIPTION
Issue: #2400 

1. Samples title is displayed only if samples exist
2. Instead of star, text: "This field is required!" is displayed
3. Negotiated to implement indent as in luma - big indent and not bold link
4. Link option is in line with other elements