### PR TITLE
#2424 - mobile popup invalid top position

### DIFF
--- a/packages/scandipwa/src/component/NewVersionPopup/NewVersionPopup.style.scss
+++ b/packages/scandipwa/src/component/NewVersionPopup/NewVersionPopup.style.scss
@@ -13,6 +13,7 @@
     @include mobile {
         align-items: flex-end;
         height: 100%;
+        top: 0;
     }
 
     &-Heading {

--- a/packages/scandipwa/src/component/Popup/Popup.style.scss
+++ b/packages/scandipwa/src/component/Popup/Popup.style.scss
@@ -50,6 +50,7 @@
         top: 0;
 
         @include mobile {
+            top: var(--header-total-height);
             height: calc(100% - var(--header-total-height));
         }
     }


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/2424

Caused by https://github.com/scandipwa/scandipwa/issues/2397, the fact that mobile popup should be placed just below the header was missed out.