### PR TITLE
#2426 - page jumps up

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.container.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.container.js
@@ -20,7 +20,7 @@ import { CartItemType } from 'Type/MiniCart';
 import { itemIsOutOfStock } from 'Util/Cart';
 import { CONFIGURABLE } from 'Util/Product';
 import { makeCancelable } from 'Util/Promise';
-import { objectToUri } from 'Util/Url';
+import { getSkuFromURL, objectToUri } from 'Util/Url';
 
 import CartItem from './CartItem.component';
 
@@ -252,7 +252,7 @@ export class CartItemContainer extends PureComponent {
         const stateProduct = parent || product;
 
         return {
-            pathname: url,
+            pathname: getSkuFromURL(url),
             state: { product: stateProduct, pageKey: url },
             search: objectToUri(parameters)
         };

--- a/packages/scandipwa/src/component/CartItem/CartItem.container.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.container.js
@@ -20,7 +20,7 @@ import { CartItemType } from 'Type/MiniCart';
 import { itemIsOutOfStock } from 'Util/Cart';
 import { CONFIGURABLE } from 'Util/Product';
 import { makeCancelable } from 'Util/Promise';
-import { getSkuFromURL, objectToUri } from 'Util/Url';
+import { objectToUri } from 'Util/Url';
 
 import CartItem from './CartItem.component';
 
@@ -253,10 +253,7 @@ export class CartItemContainer extends PureComponent {
 
         return {
             pathname: url,
-            state: {
-                product: stateProduct,
-                pageKey: getSkuFromURL(url)
-            },
+            state: { product: stateProduct },
             search: objectToUri(parameters)
         };
     }

--- a/packages/scandipwa/src/component/CartItem/CartItem.container.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.container.js
@@ -252,8 +252,11 @@ export class CartItemContainer extends PureComponent {
         const stateProduct = parent || product;
 
         return {
-            pathname: getSkuFromURL(url),
-            state: { product: stateProduct, pageKey: url },
+            pathname: url,
+            state: {
+                product: stateProduct,
+                pageKey: getSkuFromURL(url)
+            },
             search: objectToUri(parameters)
         };
     }

--- a/packages/scandipwa/src/component/CartItem/CartItem.container.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.container.js
@@ -253,7 +253,7 @@ export class CartItemContainer extends PureComponent {
 
         return {
             pathname: url,
-            state: { product: stateProduct, pageKey: stateProduct.id },
+            state: { product: stateProduct, pageKey: url },
             search: objectToUri(parameters)
         };
     }

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -18,7 +18,7 @@ import { DeviceType } from 'Type/Device';
 import { FilterType, ProductType } from 'Type/ProductList';
 import history from 'Util/History';
 import { CONFIGURABLE, getVariantsIndexes } from 'Util/Product';
-import { getSkuFromURL, objectToUri } from 'Util/Url';
+import { objectToUri } from 'Util/Url';
 
 import ProductCard from './ProductCard.component';
 import { IN_STOCK } from './ProductCard.config';
@@ -99,11 +99,7 @@ export class ProductCardContainer extends PureComponent {
 
         return {
             pathname: url,
-            state: {
-                product,
-                pageKey: getSkuFromURL(url),
-                prevCategoryId: category
-            },
+            state: { product, prevCategoryId: category },
             search: objectToUri(parameters)
         };
     }

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -18,7 +18,7 @@ import { DeviceType } from 'Type/Device';
 import { FilterType, ProductType } from 'Type/ProductList';
 import history from 'Util/History';
 import { CONFIGURABLE, getVariantsIndexes } from 'Util/Product';
-import { objectToUri } from 'Util/Url';
+import { getSkuFromURL, objectToUri } from 'Util/Url';
 
 import ProductCard from './ProductCard.component';
 import { IN_STOCK } from './ProductCard.config';
@@ -99,7 +99,11 @@ export class ProductCardContainer extends PureComponent {
 
         return {
             pathname: url,
-            state: { product, pageKey: url, prevCategoryId: category },
+            state: {
+                product,
+                pageKey: getSkuFromURL(url),
+                prevCategoryId: category
+            },
             search: objectToUri(parameters)
         };
     }

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -99,7 +99,7 @@ export class ProductCardContainer extends PureComponent {
 
         return {
             pathname: url,
-            state: { product, pageKey: product.id, prevCategoryId: category },
+            state: { product, pageKey: url, prevCategoryId: category },
             search: objectToUri(parameters)
         };
     }

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.js
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.js
@@ -56,16 +56,14 @@ export class UrlRewrites extends PureComponent {
         const {
             history: {
                 location: {
-                    state: {
-                        pageKey = null
-                    } = {}
+                    pathname
                 } = {}
             } = {}
         } = props;
 
         switch (type) {
         case TYPE_PRODUCT:
-            return <ProductPage { ...props } key={ pageKey } />;
+            return <ProductPage { ...props } key={ pathname } />;
         case TYPE_CMS_PAGE:
             return <CmsPage { ...props } />;
         case TYPE_CATEGORY:

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.js
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import { lazy, PureComponent, Suspense } from 'react';
 
 import NoMatch from 'Route/NoMatch';
+import { getSkuFromURL } from 'Util/Url';
 
 import {
     TYPE_CATEGORY,
@@ -63,7 +64,7 @@ export class UrlRewrites extends PureComponent {
 
         switch (type) {
         case TYPE_PRODUCT:
-            return <ProductPage { ...props } key={ pathname } />;
+            return <ProductPage { ...props } key={ getSkuFromURL(pathname) } />;
         case TYPE_CMS_PAGE:
             return <CmsPage { ...props } />;
         case TYPE_CATEGORY:

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.js
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.js
@@ -14,7 +14,6 @@ import PropTypes from 'prop-types';
 import { lazy, PureComponent, Suspense } from 'react';
 
 import NoMatch from 'Route/NoMatch';
-import { getSkuFromURL } from 'Util/Url';
 
 import {
     TYPE_CATEGORY,
@@ -54,17 +53,11 @@ export class UrlRewrites extends PureComponent {
 
     renderContent() {
         const { props, type } = this.props;
-        const {
-            history: {
-                location: {
-                    pathname
-                } = {}
-            } = {}
-        } = props;
+        const { id } = props;
 
         switch (type) {
         case TYPE_PRODUCT:
-            return <ProductPage { ...props } key={ getSkuFromURL(pathname) } />;
+            return <ProductPage { ...props } key={ id } />;
         case TYPE_CMS_PAGE:
             return <CmsPage { ...props } />;
         case TYPE_CATEGORY:

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.js
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.js
@@ -144,14 +144,14 @@ export class UrlRewritesContainer extends PureComponent {
                 const product = history?.state?.state?.product;
 
                 if (product) {
-                    const { sku: historySKU } = product;
-                    return { productSKU: historySKU };
+                    const { sku: historySKU, id } = product;
+                    return { productSKU: historySKU, id };
                 }
 
                 return {};
             }
 
-            return { productSKU: sku };
+            return { productSKU: sku, id };
         case TYPE_CMS_PAGE:
             if (isLoading) {
                 return { isOnlyPlaceholder: true };

--- a/packages/scandipwa/src/util/Url/Url.js
+++ b/packages/scandipwa/src/util/Url/Url.js
@@ -238,3 +238,8 @@ export const objectToUri = (keyValueObject = {}) => {
 
     return paramString.length > 0 ? `?${paramString}` : '';
 };
+
+/**
+ * Get product product SKU from URL.
+ */
+export const getSkuFromURL = (uri) => uri.match(/.*\/(.+?)(\.\w+|)$/)[1];

--- a/packages/scandipwa/src/util/Url/Url.js
+++ b/packages/scandipwa/src/util/Url/Url.js
@@ -238,8 +238,3 @@ export const objectToUri = (keyValueObject = {}) => {
 
     return paramString.length > 0 ? `?${paramString}` : '';
 };
-
-/**
- * Get product product SKU from URL.
- */
-export const getSkuFromURL = (uri) => uri.match(/.*\/(.+?)(\.\w+|)$/)[1];


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/pull/2426

Related to https://github.com/scandipwa/scandipwa/pull/2183.

**Reason for the problem:**
When we go to Product Page from search results, `ProductPageContainer` receives key equal to product_id (e.g. 1351, for product http://scandipwapmrev.indvp.com//default/n-seventy-transitional-jacket-13.html). When we select another size on Product Page, the key is reset to `null`. When the page is loaded directly, key equals `null` as well. So in order that issue #2426 doesn't appear, it is needed key not to change when changing product options (to have it equal to null, product_id or some other unique identifier of the product).
Using product_id as key when product is loaded directly is tricky, as you still don't know product id, when this line of code is being executed:
https://github.com/scandipwa/scandipwa/blob/master/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.js#L68

**Solution:**
The solution I came up with is to replace product id with a pathname, which:
1.  is known for the product, no matter whether you navigate to product page from search results or via direct URL
2.  doesn't change when product options and hence query params in URL are updated
3. is unique between products, as is based on unique SKUs

Yet I need some advice regarding this solution, as probably I haven't taken into account some of the aspects of the solution with product_id. 