### PR TITLE
Not show configurable option if not assigned to current website

### DIFF
--- a/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
@@ -63,6 +63,7 @@ export class ProductActions extends PureComponent {
         updateConfigurableVariant: PropTypes.func.isRequired,
         parameters: PropTypes.objectOf(PropTypes.string).isRequired,
         getIsConfigurableAttributeAvailable: PropTypes.func.isRequired,
+        filterConfigurableOptions: PropTypes.func.isRequired,
         groupedProductQuantity: PropTypes.objectOf(PropTypes.number).isRequired,
         clearGroupedProductQuantity: PropTypes.func.isRequired,
         setGroupedProductQuantity: PropTypes.func.isRequired,
@@ -157,7 +158,8 @@ export class ProductActions extends PureComponent {
             parameters,
             areDetailsLoaded,
             product: { configurable_options, type_id },
-            getIsConfigurableAttributeAvailable
+            getIsConfigurableAttributeAvailable,
+            filterConfigurableOptions
         } = this.props;
 
         if (type_id !== 'configurable') {
@@ -178,7 +180,7 @@ export class ProductActions extends PureComponent {
                   getLink={ getLink }
                   parameters={ parameters }
                   updateConfigurableVariant={ updateConfigurableVariant }
-                  configurable_options={ configurable_options }
+                  configurable_options={ filterConfigurableOptions(configurable_options) }
                   getIsConfigurableAttributeAvailable={ getIsConfigurableAttributeAvailable }
                   isContentExpanded
                 />

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.container.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.container.js
@@ -102,7 +102,8 @@ export class ProductActionsContainer extends PureComponent {
         setQuantity: this.setQuantity.bind(this),
         setGroupedProductQuantity: this._setGroupedProductQuantity.bind(this),
         clearGroupedProductQuantity: this._clearGroupedProductQuantity.bind(this),
-        getIsConfigurableAttributeAvailable: this.getIsConfigurableAttributeAvailable.bind(this)
+        getIsConfigurableAttributeAvailable: this.getIsConfigurableAttributeAvailable.bind(this),
+        filterConfigurableOptions: this.filterConfigurableOptions.bind(this)
     };
 
     static getDerivedStateFromProps(props, state) {
@@ -166,6 +167,33 @@ export class ProductActionsContainer extends PureComponent {
         }
 
         return variants[configurableVariantIndex].product[attribute] === value;
+    }
+
+    filterConfigurableOptions(options) {
+        const { product: { variants } } = this.props;
+
+        return Object.values(options).reduce((acc, option) => {
+            const { attribute_values, attribute_code } = option;
+
+            // show option if it exist as variant for configurable product
+            const filteredOptions = attribute_values.reduce((acc, value) => {
+                const isVariantExist = variants.find(({ attributes }) => {
+                    const { attribute_value: foundValue } = attributes[attribute_code] || {};
+
+                    return value === foundValue;
+                });
+
+                if (isVariantExist) {
+                    acc.push(value);
+                }
+
+                return acc;
+            }, []);
+
+            acc.push({ ...option, attribute_values: filteredOptions });
+
+            return acc;
+        }, []);
     }
 
     getIsConfigurableAttributeAvailable({ attribute_code, attribute_value }) {


### PR DESCRIPTION
fixes #2375 

Show configurable option if exist variant for it on PDP. Same magento 2.4.2 doesn't shows option if attribute exist, but no variant for current store.