### PR TITLE
Will retain link parameters when popup is opened

### DIFF
--- a/packages/scandipwa/src/component/Popup/Popup.component.js
+++ b/packages/scandipwa/src/component/Popup/Popup.component.js
@@ -68,7 +68,7 @@ export class Popup extends Overlay {
                 popupOpen: true
             },
             '',
-            location.pathname
+            `${location.pathname}${location.search}`
         );
 
         onVisible();

--- a/packages/scandipwa/src/component/Popup/Popup.component.js
+++ b/packages/scandipwa/src/component/Popup/Popup.component.js
@@ -68,7 +68,7 @@ export class Popup extends Overlay {
                 popupOpen: true
             },
             '',
-            `${location.pathname}${location.search}`
+            `${location.pathname}${location.search}${location.hash}`
         );
 
         onVisible();


### PR DESCRIPTION
If user or a google bot lands for the very first time on some page with parameters, like `/women.html?page=2` or `/women.html?customFilters=color:395124;size:395234` the "new version" popup will be triggered and parameters will be lost.

This commit fixes that, parameters will be retained 