### PR TITLE
Adjust region handle on myaddress edit

### DIFF
--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
@@ -42,13 +42,13 @@ export class MyAccountAddressForm extends FieldForm {
             address: {
                 country_id,
                 region: { region_id } = {},
-                is_state_required,
                 city = ''
             }
         } = props;
 
         const countryId = country_id || default_country;
         const country = countries.find(({ id }) => id === countryId);
+        const isStateRequired = country.is_state_required;
         const { available_regions: availableRegions } = country || {};
         const regions = availableRegions || [{}];
         const regionId = region_id || regions[0].id;
@@ -57,14 +57,14 @@ export class MyAccountAddressForm extends FieldForm {
             countryId,
             availableRegions,
             regionId,
-            isStateRequired: is_state_required,
+            isStateRequired,
             city
         };
     }
 
     onFormSuccess = (fields) => {
         const { onSave, addressLinesQty } = this.props;
-        const { region_id, region_string: region, ...newAddress } = addressLinesQty > 1
+        const { region_id = 0, region_string: region, ...newAddress } = addressLinesQty > 1
             ? setAddressesInFormObject(fields, addressLinesQty)
             : fields;
 


### PR DESCRIPTION
fixes #2484 

Related: https://github.com/scandipwa/customer-graph-ql/pull/17

In case if there is no region selected from options that country can provide (it just doesn't provides them) we send 0  in region_id to BE. 
Also fixed issue when opening address edit and if current country requires state, it was not showing it at first time, only if we select any country and then select back previous it will show us state field.