### PR TITLE
Purchase Order Fix

### DIFF
--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -580,6 +580,7 @@ export class CheckoutContainer extends PureComponent {
             id, // drop this
             country_id,
             region_code, // drop this
+            purchaseOrderNumber, // drop this
             region_id,
             region,
             ...restOfBillingAddress


### PR DESCRIPTION
Fixed #2500 
Fixed checkout workflow if purchase order payment method is selected.
Issue happens only if address form is visible on the billing step.