### PR TITLE
Bugfix #2493 - Fixed Windows: Chrome: Price cut on grouped product page

### DIFF
--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
@@ -18,7 +18,7 @@
 .ProductPrice {
     color: var(--price-color);
     font-weight: 700;
-    line-height: 1;
+    line-height: 2;
     vertical-align: middle;
     margin-bottom: 0;
 


### PR DESCRIPTION
https://github.com/scandipwa/scandipwa/issues/2493
Issue was fixed by changing value of line height for .ProductPrice .
![unnamed](https://user-images.githubusercontent.com/82803399/115588200-2a859d00-a2d7-11eb-8c8f-c9011fc9748a.png)
![product price](https://user-images.githubusercontent.com/82803399/115588230-33766e80-a2d7-11eb-8a6d-b3df8530abaa.JPG)
![solved](https://user-images.githubusercontent.com/82803399/115588238-35d8c880-a2d7-11eb-90ef-f089a54e8261.JPG)


