### PR TITLE
Swipe Back Preview Fix

### DIFF
--- a/packages/scandipwa/src/util/History/index.js
+++ b/packages/scandipwa/src/util/History/index.js
@@ -11,9 +11,5 @@
 
 import { createBrowserHistory } from 'history';
 
-if (window.history) {
-    window.history.scrollRestoration = 'manual';
-}
-
 export const history = createBrowserHistory({ basename: '/' });
 export default history;


### PR DESCRIPTION
Fixes #2506 
Fixed swipe back previews on mobile browser.
The issue happened if you scroll page a bit and swipe back.
This happened due to manual scroll restoration.
Manual scroll restoration was added for a PDP page scroll fix, but this issue was actually fixed in a different way.
So the manual scroll restoration is not needed.