### PR TITLE
Will delay opening menu slightly

### DIFF
--- a/packages/scandipwa/src/component/MenuItem/MenuItem.component.js
+++ b/packages/scandipwa/src/component/MenuItem/MenuItem.component.js
@@ -25,6 +25,7 @@ export class MenuItem extends PureComponent {
         item: PropTypes.object.isRequired,
         itemMods: PropTypes.object,
         handleCategoryHover: PropTypes.func.isRequired,
+        handleLinkLeave: PropTypes.func.isRequired,
         isLink: PropTypes.bool,
         onItemClick: PropTypes.func,
         device: DeviceType.isRequired
@@ -100,6 +101,7 @@ export class MenuItem extends PureComponent {
             item,
             itemMods,
             handleCategoryHover,
+            handleLinkLeave,
             onItemClick
         } = this.props;
 
@@ -117,6 +119,7 @@ export class MenuItem extends PureComponent {
               elem="Link"
               id={ item_id }
               onMouseEnter={ handleCategoryHover }
+              onMouseLeave={ handleLinkLeave }
               mods={ { isHovered } }
               onClick={ onItemClick }
             >

--- a/packages/scandipwa/src/component/MenuItem/MenuItem.config.js
+++ b/packages/scandipwa/src/component/MenuItem/MenuItem.config.js
@@ -1,0 +1,13 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export const HOVER_TIMEOUT = 250;

--- a/packages/scandipwa/src/component/MenuItem/MenuItem.container.js
+++ b/packages/scandipwa/src/component/MenuItem/MenuItem.container.js
@@ -14,6 +14,7 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import MenuItem from './MenuItem.component';
+import { HOVER_TIMEOUT } from './MenuItem.config';
 
 /** @namespace Component/Menu/Container/mapStateToProps */
 // eslint-disable-next-line no-unused-vars
@@ -30,7 +31,8 @@ export class MenuItemContainer extends PureComponent {
     static propTypes = {
         closeMenu: PropTypes.func,
         onCategoryHover: PropTypes.func,
-        item: PropTypes.object.isRequired
+        item: PropTypes.object.isRequired,
+        activeMenuItemsStack: PropTypes.array.isRequired
     };
 
     static defaultProps = {
@@ -40,8 +42,11 @@ export class MenuItemContainer extends PureComponent {
 
     containerFunctions = {
         handleCategoryHover: this.handleCategoryHover.bind(this),
+        handleLinkLeave: this.handleLinkLeave.bind(this),
         onItemClick: this.onItemClick.bind(this)
     };
+
+    menuHoverTimeout = null;
 
     onItemClick() {
         const { closeMenu } = this.props;
@@ -50,9 +55,17 @@ export class MenuItemContainer extends PureComponent {
     }
 
     handleCategoryHover() {
-        const { onCategoryHover, item } = this.props;
+        const { onCategoryHover, item, activeMenuItemsStack } = this.props;
 
-        onCategoryHover(item);
+        const hoverTimeOut = activeMenuItemsStack.length === 0 ? HOVER_TIMEOUT : 0;
+
+        this.menuHoverTimeout = setTimeout(() => {
+            onCategoryHover(item);
+        }, hoverTimeOut);
+    }
+
+    handleLinkLeave() {
+        clearTimeout(this.menuHoverTimeout);
     }
 
     render() {


### PR DESCRIPTION
To improve site UX - Have a `250ms` delay for the main menu to open. Now moving the mouse over the menu item opens the submenu even when I do not want it. It is distracting.

This fix will open menu with a slight delay, this will result in menu opening only if user intended to open the menu.