### PR TITLE
#2467 bugfix - narrow table in my downloadable in safari

### DIFF
--- a/packages/scandipwa/src/component/MyAccountMyOrders/MyAccountMyOrders.style.scss
+++ b/packages/scandipwa/src/component/MyAccountMyOrders/MyAccountMyOrders.style.scss
@@ -26,7 +26,7 @@
         }
     }
 
-    &-Table:not(.MyDownloadable) {
+    &-Table {
         width: 100%;
         min-width: 100%;
         max-width: 100%;
@@ -35,6 +35,7 @@
     .MyDownloadable {
         @include mobile {
             white-space: nowrap;
+            table-layout: auto;
         }
     }
 


### PR DESCRIPTION
#2467
1. Applied table width styling also to My downloadables table not only My orders. Fixing the table width.
2. Changed table-layout for My downloadables mobile view. Fixing the column overlapping which was the result of table width change.
