### PR TITLE
#2461 Bugfix - Wrong subcategories are displayed in Layered navigation if the product belongs to few categories

### DIFF
--- a/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
+++ b/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
@@ -22,11 +22,14 @@ import { formatPrice } from 'Util/Price';
 /** @namespace Component/CategoryConfigurableAttributes/Component */
 export class CategoryConfigurableAttributes extends ProductConfigurableAttributes {
     static propTypes = {
-        childrenCategories: PropTypes.arrayOf(PropTypes.shape(CategoryFragment))
+        ...ProductConfigurableAttributes.propTypes,
+        currency_code: PropTypes.string.isRequired,
+        show_product_count: PropTypes.bool.isRequired,
+        childrenCategories: PropTypes.arrayOf(PropTypes.shape(CategoryFragment)).isRequired
     };
 
     renderSubCategories(option) {
-        const optionWithSubcategories = option;
+        const optionWithSubcategories = { ...option };
         const { childrenCategories } = this.props;
         const { attribute_values } = option;
         const childrenCategoryIds = childrenCategories.map((category) => category.id.toString());

--- a/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
+++ b/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
@@ -9,15 +9,36 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+import PropTypes from 'prop-types';
+
 import ExpandableContent from 'Component/ExpandableContent';
 import ExpandableContentShowMore from 'Component/ExpandableContentShowMore';
 import ProductAttributeValue from 'Component/ProductAttributeValue/ProductAttributeValue.component';
 // eslint-disable-next-line max-len
 import ProductConfigurableAttributes from 'Component/ProductConfigurableAttributes/ProductConfigurableAttributes.component';
+import { CategoryFragment } from 'Type/Category';
 import { formatPrice } from 'Util/Price';
 
 /** @namespace Component/CategoryConfigurableAttributes/Component */
 export class CategoryConfigurableAttributes extends ProductConfigurableAttributes {
+    static propTypes = {
+        childrenCategories: PropTypes.arrayOf(PropTypes.shape(CategoryFragment))
+    };
+
+    renderSubCategories(option) {
+        const optionWithSubcategories = option;
+        const { childrenCategories } = this.props;
+        const { attribute_values } = option;
+        const childrenCategoryIds = childrenCategories.map((category) => category.id.toString());
+        const subCategoriesIds = attribute_values.filter((item) => childrenCategoryIds.includes(item));
+        optionWithSubcategories.attribute_values = subCategoriesIds;
+        if (subCategoriesIds.length) {
+            return this.renderDropdownOrSwatch(optionWithSubcategories);
+        }
+
+        return null;
+    }
+
     getPriceLabel(option) {
         const { currency_code } = this.props;
         const { label } = option;
@@ -120,16 +141,7 @@ export class CategoryConfigurableAttributes extends ProductConfigurableAttribute
         case 'price':
             return this.renderPriceSwatch(option);
         case 'category_id':
-            const { childrenCategories } = this.props;
-            const { attribute_values } = option;
-            const childrenCategoryIds = childrenCategories.map((category) => category.id.toString());
-            const subCategoriesIds = attribute_values.filter((item) => childrenCategoryIds.includes(item));
-            if (subCategoriesIds.length) {
-                this.props.configurable_options.category_id.attribute_values = subCategoriesIds;
-                return this.renderDropdownOrSwatch(option);
-            }
-
-            return null;
+            return this.renderSubCategories(option);
         default:
             return this.renderDropdownOrSwatch(option);
         }

--- a/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
+++ b/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
@@ -8,7 +8,6 @@
  * @package scandipwa/base-theme
  * @link https://github.com/scandipwa/base-theme
  */
-import { connect } from 'react-redux';
 
 import ExpandableContent from 'Component/ExpandableContent';
 import ExpandableContentShowMore from 'Component/ExpandableContentShowMore';

--- a/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
+++ b/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
@@ -8,6 +8,7 @@
  * @package scandipwa/base-theme
  * @link https://github.com/scandipwa/base-theme
  */
+import { connect } from 'react-redux';
 
 import ExpandableContent from 'Component/ExpandableContent';
 import ExpandableContentShowMore from 'Component/ExpandableContentShowMore';
@@ -15,6 +16,14 @@ import ProductAttributeValue from 'Component/ProductAttributeValue/ProductAttrib
 // eslint-disable-next-line max-len
 import ProductConfigurableAttributes from 'Component/ProductConfigurableAttributes/ProductConfigurableAttributes.component';
 import { formatPrice } from 'Util/Price';
+
+/** @namespace Component/CategoryConfigurableAttributes/Component/mapStateToProps */
+export const mapStateToProps = (state) => ({
+    childrenCategories: state.CategoryReducer.category.children
+});
+
+/** @namespace Component/CategoryConfigurableAttributes/Component/mapDispatchToProps */
+export const mapDispatchToProps = () => ({});
 
 /** @namespace Component/CategoryConfigurableAttributes/Component */
 export class CategoryConfigurableAttributes extends ProductConfigurableAttributes {
@@ -119,6 +128,15 @@ export class CategoryConfigurableAttributes extends ProductConfigurableAttribute
         switch (attribute_code) {
         case 'price':
             return this.renderPriceSwatch(option);
+        case 'category_id':
+            const childrenCategoryIds = this.props.childrenCategories.map((category) => category.id.toString());
+            const subCategoriesIds = option.attribute_values.filter((item) => childrenCategoryIds.includes(item));
+            if (subCategoriesIds.length) {
+                this.props.configurable_options.category_id.attribute_values = subCategoriesIds;
+                return this.renderDropdownOrSwatch(option);
+            }
+
+            return (null);
         default:
             return this.renderDropdownOrSwatch(option);
         }
@@ -149,4 +167,4 @@ export class CategoryConfigurableAttributes extends ProductConfigurableAttribute
     }
 }
 
-export default CategoryConfigurableAttributes;
+export default connect(mapStateToProps, mapDispatchToProps)(CategoryConfigurableAttributes);

--- a/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
+++ b/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
@@ -25,21 +25,21 @@ export class CategoryConfigurableAttributes extends ProductConfigurableAttribute
         ...ProductConfigurableAttributes.propTypes,
         currency_code: PropTypes.string.isRequired,
         show_product_count: PropTypes.bool.isRequired,
-        childrenCategories: PropTypes.arrayOf(PropTypes.shape(CategoryFragment)).isRequired
+        childrenCategories: PropTypes.arrayOf(PropTypes.shape(CategoryFragment)).isRequired,
+        getSubCategories: PropTypes.func.isRequired
     };
 
     renderSubCategories(option) {
-        const optionWithSubcategories = { ...option };
-        const { childrenCategories } = this.props;
-        const { attribute_values } = option;
-        const childrenCategoryIds = childrenCategories.map((category) => category.id.toString());
-        const subCategoriesIds = attribute_values.filter((item) => childrenCategoryIds.includes(item));
-        optionWithSubcategories.attribute_values = subCategoriesIds;
-        if (subCategoriesIds.length) {
-            return this.renderDropdownOrSwatch(optionWithSubcategories);
+        const { getSubCategories } = this.props;
+
+        const optionWithSubcategories = getSubCategories(option);
+        const { attribute_values = [] } = optionWithSubcategories;
+
+        if (!attribute_values.length) {
+            return null;
         }
 
-        return null;
+        return this.renderDropdownOrSwatch(optionWithSubcategories);
     }
 
     getPriceLabel(option) {

--- a/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
+++ b/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
@@ -17,14 +17,6 @@ import ProductAttributeValue from 'Component/ProductAttributeValue/ProductAttrib
 import ProductConfigurableAttributes from 'Component/ProductConfigurableAttributes/ProductConfigurableAttributes.component';
 import { formatPrice } from 'Util/Price';
 
-/** @namespace Component/CategoryConfigurableAttributes/Component/mapStateToProps */
-export const mapStateToProps = (state) => ({
-    childrenCategories: state.CategoryReducer.category.children
-});
-
-/** @namespace Component/CategoryConfigurableAttributes/Component/mapDispatchToProps */
-export const mapDispatchToProps = () => ({});
-
 /** @namespace Component/CategoryConfigurableAttributes/Component */
 export class CategoryConfigurableAttributes extends ProductConfigurableAttributes {
     getPriceLabel(option) {
@@ -129,14 +121,16 @@ export class CategoryConfigurableAttributes extends ProductConfigurableAttribute
         case 'price':
             return this.renderPriceSwatch(option);
         case 'category_id':
-            const childrenCategoryIds = this.props.childrenCategories.map((category) => category.id.toString());
-            const subCategoriesIds = option.attribute_values.filter((item) => childrenCategoryIds.includes(item));
+            const { childrenCategories } = this.props;
+            const { attribute_values } = option;
+            const childrenCategoryIds = childrenCategories.map((category) => category.id.toString());
+            const subCategoriesIds = attribute_values.filter((item) => childrenCategoryIds.includes(item));
             if (subCategoriesIds.length) {
                 this.props.configurable_options.category_id.attribute_values = subCategoriesIds;
                 return this.renderDropdownOrSwatch(option);
             }
 
-            return (null);
+            return null;
         default:
             return this.renderDropdownOrSwatch(option);
         }
@@ -167,4 +161,4 @@ export class CategoryConfigurableAttributes extends ProductConfigurableAttribute
     }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(CategoryConfigurableAttributes);
+export default CategoryConfigurableAttributes;

--- a/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.container.js
+++ b/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.container.js
@@ -25,6 +25,22 @@ export const mapStateToProps = (state) => ({
 
 /** @namespace Component/CategoryConfigurableAttributes/Container */
 export class CategoryConfigurableAttributesContainer extends ProductConfigurableAttributesContainer {
+    containerFunctions = {
+        ...this.containerFunctions,
+        getSubCategories: this.getSubCategories.bind(this)
+    };
+
+    getSubCategories(option) {
+        const optionWithSubcategories = { ...option };
+        const { childrenCategories } = this.props;
+        const { attribute_values } = option;
+        const childrenCategoryIds = childrenCategories.map((category) => category.id.toString());
+        const subCategoriesIds = attribute_values.filter((item) => childrenCategoryIds.includes(item));
+        optionWithSubcategories.attribute_values = subCategoriesIds;
+
+        return optionWithSubcategories;
+    }
+
     render() {
         return (
             <CategoryConfigurableAttributes

--- a/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.container.js
+++ b/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.container.js
@@ -19,7 +19,8 @@ import CategoryConfigurableAttributes from './CategoryConfigurableAttributes.com
 /** @namespace Component/CategoryConfigurableAttributes/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     currency_code: state.ConfigReducer.currencyData.current_currency_code,
-    show_product_count: state.ConfigReducer.layered_navigation_product_count_enabled
+    show_product_count: state.ConfigReducer.layered_navigation_product_count_enabled,
+    childrenCategories: state.CategoryReducer.category.children
 });
 
 /** @namespace Component/CategoryConfigurableAttributes/Container */


### PR DESCRIPTION
Fixed [issue#2461](https://github.com/scandipwa/scandipwa/issues/2461)