### PR TITLE
Bugfix #2575 - The text "Choose Option" in the dropdown list isn't diplayed in Firefox 76 or previous versions

### DIFF
--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.component.js
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.component.js
@@ -130,7 +130,7 @@ export class FieldSelect extends PureComponent {
         }
 
         return (
-            <option value="" label={ placeholder } />
+            <option value="" label={ placeholder }>{ placeholder }</option>
         );
     }
 


### PR DESCRIPTION
Fixed [issue#2575](https://github.com/scandipwa/scandipwa/issues/2575)