### PR TITLE
#2417 bugfix - show price for bundle product card on PLP

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -26,8 +26,8 @@ import TierPrices from 'Component/TierPrices';
 import { GRID_LAYOUT, LIST_LAYOUT } from 'Route/CategoryPage/CategoryPage.config';
 import { DeviceType } from 'Type/Device';
 import { ProductType } from 'Type/ProductList';
-import { BUNDLE, CONFIGURABLE, GROUPED } from 'Util/Product';
 import { formatPrice, roundPrice } from 'Util/Price';
+import { BUNDLE, CONFIGURABLE, GROUPED } from 'Util/Product';
 
 import {
     OPTION_TYPE_COLOR,
@@ -140,10 +140,10 @@ export class ProductCard extends PureComponent {
 
         return (
             <p
-                mix={ {
-                    block: 'ProductCard',
-                    elem: 'PriceBadge'
-                } }
+              mix={ {
+                  block: 'ProductCard',
+                  elem: 'PriceBadge'
+              } }
             >
                 { label }
             </p>
@@ -176,10 +176,10 @@ export class ProductCard extends PureComponent {
 
         return (
             <p
-                mix={ {
-                    block: 'ProductCard',
-                    elem: 'PriceBadge'
-                } }
+              mix={ {
+                  block: 'ProductCard',
+                  elem: 'PriceBadge'
+              } }
             >
                 { __(bundleBadgeLabel) }
             </p>
@@ -200,9 +200,9 @@ export class ProductCard extends PureComponent {
 
         return (
             <del
-                block="ProductPrice"
-                elem="HighPrice"
-                aria-label={ __('Old product price') }
+              block="ProductPrice"
+              elem="HighPrice"
+              aria-label={ __('Old product price') }
             >
                 { roundPrice(`${ oldMaxBundlePrice }`) }
             </del>
@@ -219,11 +219,11 @@ export class ProductCard extends PureComponent {
 
         return (
             <p
-                aria-label={ __(`'Maximal product price: ${ finalMaxBundlePrice }'`) }
-                className="ProductPrice"
-                mods={ { hasDiscount: finalMaxBundlePrice !== oldMaxBundlePrice } }
-                block="ProductCard"
-                elem="Price"
+              aria-label={ __(`'Maximal product price: ${ finalMaxBundlePrice }'`) }
+              className="ProductPrice"
+              mods={ { hasDiscount: finalMaxBundlePrice !== oldMaxBundlePrice } }
+              block="ProductCard"
+              elem="Price"
             >
                 <ins>
                    <span>
@@ -238,9 +238,9 @@ export class ProductCard extends PureComponent {
     renderEmptyProductPrice() {
         return (
             <div
-                block="ProductCard"
-                elem="PriceWrapper"
-                mods={ { isEmpty: true } }
+              block="ProductCard"
+              elem="PriceWrapper"
+              mods={ { isEmpty: true } }
             />
         );
     }
@@ -262,18 +262,18 @@ export class ProductCard extends PureComponent {
         }
 
         switch (type_id) {
-            case CONFIGURABLE:
-                if (isConfigurableProductOutOfStock()) {
-                    return this.renderEmptyProductPrice();
-                }
-                break;
-            case BUNDLE:
-                if (isBundleProductOutOfStock()) {
-                    return this.renderEmptyProductPrice();
-                }
-                break;
-            default:
-                break;
+        case CONFIGURABLE:
+            if (isConfigurableProductOutOfStock()) {
+                return this.renderEmptyProductPrice();
+            }
+            break;
+        case BUNDLE:
+            if (isBundleProductOutOfStock()) {
+                return this.renderEmptyProductPrice();
+            }
+            break;
+        default:
+            break;
         }
 
         if (type_id === BUNDLE) {
@@ -282,8 +282,8 @@ export class ProductCard extends PureComponent {
                     <div block="ProductCard" elem="PriceWrapper">
                         { this.renderBundlePriceBadge('bottom') }
                         <ProductPrice
-                            price={ price_range }
-                            mix={ { block: 'ProductCard', elem: 'Price' } }
+                          price={ price_range }
+                          mix={ { block: 'ProductCard', elem: 'Price' } }
                         />
                         { this.renderBundlePriceBadge('top') }
                         { this.renderMaxBundlePrice() }
@@ -296,8 +296,8 @@ export class ProductCard extends PureComponent {
                     <div block="ProductCard" elem="PriceWrapper">
                         { this.renderBundlePriceBadge('bottom') }
                         <ProductPrice
-                            price={ price_range }
-                            mix={ { block: 'ProductCard', elem: 'Price' } }
+                          price={ price_range }
+                          mix={ { block: 'ProductCard', elem: 'Price' } }
                         />
                     </div>
                 );
@@ -309,8 +309,8 @@ export class ProductCard extends PureComponent {
                 { this.renderTierPrice() }
                 { this.renderProductTypePriceBadge() }
                 <ProductPrice
-                    price={ price_range }
-                    mix={ { block: 'ProductCard', elem: 'Price' } }
+                  price={ price_range }
+                  mix={ { block: 'ProductCard', elem: 'Price' } }
                 />
             </div>
         );
@@ -334,8 +334,8 @@ export class ProductCard extends PureComponent {
 
         return (
             <TierPrices
-                product={ productOrVariant }
-                isLowestPrice
+              product={ productOrVariant }
+              isLowestPrice
             />
         );
     }
@@ -343,11 +343,11 @@ export class ProductCard extends PureComponent {
     renderImageVisualOption(label, value, i) {
         return (
             <img
-                key={ i }
-                block="ProductCard"
-                elem="Image"
-                src={ `/media/attribute/swatch/swatch_thumb/110x90${value}` }
-                alt={ label }
+              key={ i }
+              block="ProductCard"
+              elem="Image"
+              src={ `/media/attribute/swatch/swatch_thumb/110x90${value}` }
+              alt={ label }
             />
         );
     }
@@ -361,12 +361,12 @@ export class ProductCard extends PureComponent {
 
         return (
             <span
-                block="ProductCard"
-                elem={ isColor ? 'Color' : 'String' }
-                key={ i }
-                style={ isColor ? { backgroundColor: value } : {} }
-                aria-label={ isColor ? label : '' }
-                title={ isColor ? '' : label }
+              block="ProductCard"
+              elem={ isColor ? 'Color' : 'String' }
+              key={ i }
+              style={ isColor ? { backgroundColor: value } : {} }
+              aria-label={ isColor ? label : '' }
+              title={ isColor ? '' : label }
             >
                 { isColor ? '' : value }
             </span>
@@ -405,12 +405,12 @@ export class ProductCard extends PureComponent {
 
         this.sharedComponent = (
             <Image
-                imageRef={ this.imageRef }
-                src={ thumbnail }
-                alt={ name }
-                ratio="custom"
-                mix={ { block: 'ProductCard', elem: 'Picture', mix } }
-                isPlaceholder={ !id }
+              imageRef={ this.imageRef }
+              src={ thumbnail }
+              alt={ name }
+              ratio="custom"
+              mix={ { block: 'ProductCard', elem: 'Picture', mix } }
+              isPlaceholder={ !id }
             />
         );
 
@@ -418,9 +418,9 @@ export class ProductCard extends PureComponent {
             <>
                 { this.sharedComponent }
                 <img
-                    style={ { display: 'none' } }
-                    alt={ name }
-                    src={ thumbnail }
+                  style={ { display: 'none' } }
+                  alt={ name }
+                  src={ thumbnail }
                 />
             </>
         );
@@ -442,9 +442,9 @@ export class ProductCard extends PureComponent {
 
         return (
             <div
-                block="ProductCard"
-                elem="Reviews"
-                mods={ { layout } }
+              block="ProductCard"
+              elem="Reviews"
+              mods={ { layout } }
             >
                 <ProductReviewRating summary={ rating_summary || 0 } />
             </div>
@@ -463,11 +463,11 @@ export class ProductCard extends PureComponent {
 
         return (
             <ProductCompareButton
-                productId={ id }
-                mix={ {
-                    block: 'ProductCompareButton',
-                    mods: { isGrey: true }
-                } }
+              productId={ id }
+              mix={ {
+                  block: 'ProductCompareButton',
+                  mods: { isGrey: true }
+              } }
             />
         );
     }
@@ -481,8 +481,8 @@ export class ProductCard extends PureComponent {
 
         return (
             <ProductWishlistButton
-                product={ product }
-                mix={ { block: 'ProductCard', elem: 'WishListButton' } }
+              product={ product }
+              mix={ { block: 'ProductCard', elem: 'WishListButton' } }
             />
         );
     }
@@ -519,12 +519,12 @@ export class ProductCard extends PureComponent {
 
         return (
             <ProductAttributeValue
-                attribute={ brand }
-                isFormattedAsText
-                mix={ {
-                    block: 'ProductCard',
-                    elem: 'BrandAttributeValue'
-                } }
+              attribute={ brand }
+              isFormattedAsText
+              mix={ {
+                  block: 'ProductCard',
+                  elem: 'BrandAttributeValue'
+              } }
             />
         );
     }
@@ -542,9 +542,9 @@ export class ProductCard extends PureComponent {
 
         return this.renderCardLinkWrapper(
             <p
-                block="ProductCard"
-                elem="Name"
-                mods={ { isLoaded: !!name } }
+              block="ProductCard"
+              elem="Name"
+              mods={ { isLoaded: !!name } }
             >
                 <TextPlaceholder content={ name } length="medium" />
             </p>
@@ -557,8 +557,8 @@ export class ProductCard extends PureComponent {
         if (!url) {
             return (
                 <div
-                    block="ProductCard"
-                    elem="Link"
+                  block="ProductCard"
+                  elem="Link"
                 >
                     { children }
                 </div>
@@ -567,11 +567,11 @@ export class ProductCard extends PureComponent {
 
         return (
             <Link
-                block="ProductCard"
-                elem="Link"
-                to={ linkTo }
-                onClick={ this.registerSharedElement }
-                mix={ mix }
+              block="ProductCard"
+              elem="Link"
+              to={ linkTo }
+              onClick={ this.registerSharedElement }
+              mix={ mix }
             >
                 { children }
             </Link>
@@ -598,12 +598,12 @@ export class ProductCard extends PureComponent {
 
         return (
             <AddToCart
-                product={ product }
-                configurableVariantIndex={ configurableVariantIndex }
-                mix={ { block: 'ProductActions', elem: 'AddToCart' } }
-                quantity={ quantity }
-                groupedProductQuantity={ groupedProductQuantity }
-                productOptionsData={ productOptionsData }
+              product={ product }
+              configurableVariantIndex={ configurableVariantIndex }
+              mix={ { block: 'ProductActions', elem: 'AddToCart' } }
+              quantity={ quantity }
+              groupedProductQuantity={ groupedProductQuantity }
+              productOptionsData={ productOptionsData }
             />
         );
     }
@@ -695,9 +695,9 @@ export class ProductCard extends PureComponent {
         if (layout === LIST_LAYOUT) {
             return (
                 <li
-                    block="ProductCard"
-                    mods={ mods }
-                    mix={ mix }
+                  block="ProductCard"
+                  mods={ mods }
+                  mix={ mix }
                 >
                     <Loader isLoading={ isLoading } />
                     { this.renderCardListContent() }
@@ -707,9 +707,9 @@ export class ProductCard extends PureComponent {
 
         return (
             <li
-                block="ProductCard"
-                mods={ mods }
-                mix={ mix }
+              block="ProductCard"
+              mods={ mods }
+              mix={ mix }
             >
                 <Loader isLoading={ isLoading } />
                 { this.renderCardContent() }

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *
@@ -221,6 +220,7 @@ export class ProductCard extends PureComponent {
         return (
             <p
               aria-label={ __(`'Maximal product price: ${ finalMaxBundlePrice }'`) }
+                // eslint-disable-next-line react/forbid-component-props
               className="ProductPrice"
               mods={ { hasDiscount: finalMaxBundlePrice !== oldMaxBundlePrice } }
               block="ProductCard"

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
@@ -213,13 +213,17 @@
         display: flex;
         flex-direction: column;
         justify-content: flex-end;
-        flex-grow: 1;
+        flex-grow: 0;
     }
 
     &-Price {
         width: 100%;
         @include after-mobile {
             font-size: 2rem;
+        }
+
+        &_hasDiscount {
+            color: var(--price-with-discount-color);
         }
     }
 


### PR DESCRIPTION
#2417
**Bundle stock status checking functionality need to be fixed to see bundle price in PLP.** 
Worked on displaying bundle products with: 
    • fixed price - bundle with fixed price and default price range does not have price badge;
    • dynamic price - From/To price badge and min/max price;
    • bundle products with price view "As Low As" only have min price;
    • discount - is displayed for every price the same style as for every product;

![bundle_price](https://user-images.githubusercontent.com/82803464/119114028-63c44080-ba2e-11eb-9a0b-339c4940e29e.png)

