### PR TITLE
issue-2628 - Rework adding to localstorage products data

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -425,21 +425,21 @@ export class ProductCard extends PureComponent {
     }
 
     renderMainDetails() {
-        const { product: { name }, layout } = this.props;
+        const { layout } = this.props;
 
         if (layout === GRID_LAYOUT) {
-            return (
-            <p
-              block="ProductCard"
-              elem="Name"
-              mods={ { isLoaded: !!name } }
-            >
-                <TextPlaceholder content={ name } length="medium" />
-            </p>
-            );
+            return this.renderProductName();
         }
 
         return this.renderCardLinkWrapper(
+            this.renderProductName()
+        );
+    }
+
+    renderProductName() {
+        const { product: { name } } = this.props;
+
+        return (
             <p
               block="ProductCard"
               elem="Name"

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -71,7 +71,8 @@ export class ProductCard extends PureComponent {
         setSiblingsHaveTierPrice: PropTypes.func,
         siblingsHaveConfigurableOptions: PropTypes.bool,
         setSiblingsHaveConfigurableOptions: PropTypes.func,
-        layout: PropTypes.string
+        layout: PropTypes.string,
+        isPreview: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -259,8 +260,13 @@ export class ProductCard extends PureComponent {
             siblingsHaveConfigurableOptions,
             setSiblingsHaveConfigurableOptions,
             availableVisualOptions,
-            device
+            device,
+            isPreview
         } = this.props;
+
+        if (isPreview) {
+            return <TextPlaceholder />;
+        }
 
         if (device.isMobile || !availableVisualOptions.length) {
             return <div block="ProductCard" elem="ConfigurableOptions" />;
@@ -419,7 +425,19 @@ export class ProductCard extends PureComponent {
     }
 
     renderMainDetails() {
-        const { product: { name } } = this.props;
+        const { product: { name }, layout } = this.props;
+
+        if (layout === GRID_LAYOUT) {
+            return (
+            <p
+              block="ProductCard"
+              elem="Name"
+              mods={ { isLoaded: !!name } }
+            >
+                <TextPlaceholder content={ name } length="medium" />
+            </p>
+            );
+        }
 
         return this.renderCardLinkWrapper(
             <p

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -208,6 +208,10 @@ export class ProductCardContainer extends PureComponent {
     isConfigurableProductOutOfStock() {
         const { product: { variants } } = this.props;
 
+        if (!variants) {
+            return true;
+        }
+
         const variantsInStock = variants.filter((productVariant) => productVariant.stock_status === IN_STOCK);
 
         return variantsInStock.length === 0;

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -48,12 +48,14 @@ export class ProductCardContainer extends PureComponent {
         product: ProductType,
         selectedFilters: FilterType,
         device: DeviceType.isRequired,
-        isWishlistEnabled: PropTypes.bool.isRequired
+        isWishlistEnabled: PropTypes.bool.isRequired,
+        isPreview: PropTypes.bool
     };
 
     static defaultProps = {
         product: {},
-        selectedFilters: {}
+        selectedFilters: {},
+        isPreview: false
     };
 
     containerFunctions = {
@@ -206,9 +208,9 @@ export class ProductCardContainer extends PureComponent {
     }
 
     isConfigurableProductOutOfStock() {
-        const { product: { variants } } = this.props;
+        const { product: { variants }, isPreview } = this.props;
 
-        if (!variants) {
+        if (isPreview) {
             return true;
         }
 

--- a/packages/scandipwa/src/component/RecentlyViewedWidget/RecentlyViewedWidget.component.js
+++ b/packages/scandipwa/src/component/RecentlyViewedWidget/RecentlyViewedWidget.component.js
@@ -23,7 +23,8 @@ export class RecentlyViewedWidget extends PureComponent {
         pageSize: PropTypes.number,
         products: ItemsType.isRequired,
         productCardProps: PropTypes.object.isRequired,
-        productCardFunctions: PropTypes.object.isRequired
+        productCardFunctions: PropTypes.object.isRequired,
+        shouldBeUpdated: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -45,7 +46,8 @@ export class RecentlyViewedWidget extends PureComponent {
     renderProductCard(product) {
         const {
             productCardProps,
-            productCardFunctions
+            productCardFunctions,
+            shouldBeUpdated
         } = this.props;
         const { id, selectedFilters } = product;
 
@@ -54,6 +56,7 @@ export class RecentlyViewedWidget extends PureComponent {
               selectedFilters={ selectedFilters }
               product={ product }
               key={ id }
+              isPreview={ shouldBeUpdated }
               { ...productCardProps }
               { ...productCardFunctions }
             />

--- a/packages/scandipwa/src/component/RecentlyViewedWidget/RecentlyViewedWidget.container.js
+++ b/packages/scandipwa/src/component/RecentlyViewedWidget/RecentlyViewedWidget.container.js
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
+import RecentlyViewedProductsDispatcher from 'Store/RecentlyViewedProducts/RecentlyViewedProducts.dispatcher';
 import { ItemsType } from 'Type/ProductList';
 
 import RecentlyViewedWidget from './RecentlyViewedWidget.component';
@@ -20,17 +21,23 @@ import RecentlyViewedWidget from './RecentlyViewedWidget.component';
 /** @namespace Component/RecentlyViewedWidget/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     recentProducts: state.RecentlyViewedProductsReducer.recentlyViewedProducts,
+    shouldBeUpdated: state.RecentlyViewedProductsReducer.shouldBeUpdated,
     store: state.ConfigReducer.code
 });
 
-/** @namespace Component/Slider/Container/mapDispatchToProps */
+/** @namespace Component/RecentlyViewedWidget/Container/mapDispatchToProps */
 // eslint-disable-next-line no-unused-vars
-export const mapDispatchToProps = (dispatch) => ({});
+export const mapDispatchToProps = (dispatch) => ({
+    updateRecentViewedProductsInfo:
+        (options) => RecentlyViewedProductsDispatcher.handleData(dispatch, options)
+});
 
 /** @namespace Component/RecentlyViewedWidget/Container */
 export class RecentlyViewedWidgetContainer extends PureComponent {
     static propTypes = {
+        updateRecentViewedProductsInfo: PropTypes.func.isRequired,
         recentProducts: PropTypes.objectOf(ItemsType).isRequired,
+        shouldBeUpdated: PropTypes.bool.isRequired,
         store: PropTypes.string.isRequired
     };
 
@@ -40,6 +47,21 @@ export class RecentlyViewedWidgetContainer extends PureComponent {
         siblingsHaveTierPrice: false,
         siblingsHaveConfigurableOptions: false
     };
+
+    componentDidMount() {
+        const {
+            shouldBeUpdated,
+            updateRecentViewedProductsInfo,
+            recentProducts,
+            store
+        } = this.props;
+
+        console.log(recentProducts);
+
+        if (shouldBeUpdated) {
+            updateRecentViewedProductsInfo({ recentProducts, store });
+        }
+    }
 
     containerProps() {
         const {

--- a/packages/scandipwa/src/component/RecentlyViewedWidget/RecentlyViewedWidget.container.js
+++ b/packages/scandipwa/src/component/RecentlyViewedWidget/RecentlyViewedWidget.container.js
@@ -56,9 +56,7 @@ export class RecentlyViewedWidgetContainer extends PureComponent {
             store
         } = this.props;
 
-        console.log(recentProducts);
-
-        if (shouldBeUpdated) {
+        if (shouldBeUpdated && Object.entries(recentProducts).length !== 0) {
             updateRecentViewedProductsInfo({ recentProducts, store });
         }
     }

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -21,7 +21,7 @@ import { LOADING_TIME } from 'Route/CategoryPage/CategoryPage.config';
 import { changeNavigationState, goToPreviousNavigationState } from 'Store/Navigation/Navigation.action';
 import { BOTTOM_NAVIGATION_TYPE, TOP_NAVIGATION_TYPE } from 'Store/Navigation/Navigation.reducer';
 import { setBigOfflineNotice } from 'Store/Offline/Offline.action';
-import { updateRecentlyViewedProducts } from 'Store/RecentlyViewedProducts/RecentlyViewedProducts.action';
+import { addRecentlyViewedProduct } from 'Store/RecentlyViewedProducts/RecentlyViewedProducts.action';
 import { HistoryType, LocationType, MatchType } from 'Type/Common';
 import { ProductType } from 'Type/ProductList';
 import { getVariantIndex } from 'Util/Product';
@@ -78,7 +78,7 @@ export const mapDispatchToProps = (dispatch) => ({
         ({ default: dispatcher }) => dispatcher.updateWithProduct(product, dispatch)
     ),
     goToPreviousNavigationState: (state) => dispatch(goToPreviousNavigationState(TOP_NAVIGATION_TYPE, state)),
-    updateRecentlyViewedProducts: (products, store) => dispatch(updateRecentlyViewedProducts(products, store))
+    addRecentlyViewedProduct: (product, store) => dispatch(addRecentlyViewedProduct(product, store))
 });
 
 /** @namespace Route/ProductPage/Container */
@@ -121,7 +121,7 @@ export class ProductPageContainer extends PureComponent {
         goToPreviousNavigationState: PropTypes.func.isRequired,
         navigation: PropTypes.shape(PropTypes.shape).isRequired,
         metaTitle: PropTypes.string,
-        updateRecentlyViewedProducts: PropTypes.func.isRequired,
+        addRecentlyViewedProduct: PropTypes.func.isRequired,
         store: PropTypes.string.isRequired
     };
 
@@ -316,7 +316,7 @@ export class ProductPageContainer extends PureComponent {
         const {
             product,
             product: { sku },
-            updateRecentlyViewedProducts,
+            addRecentlyViewedProduct,
             store
         } = this.props;
 
@@ -325,7 +325,24 @@ export class ProductPageContainer extends PureComponent {
             return;
         }
 
-        updateRecentlyViewedProducts(product, store);
+        const {
+            canonical_url,
+            categories,
+            configurable_options,
+            description,
+            items,
+            meta_description,
+            meta_keyword,
+            meta_title,
+            options,
+            product_links,
+            reviews,
+            short_description,
+            variants,
+            ...productPreview
+        } = product;
+
+        addRecentlyViewedProduct(productPreview, store);
     }
 
     scrollTop() {

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -325,6 +325,7 @@ export class ProductPageContainer extends PureComponent {
             return;
         }
 
+        // push into localstorage only preview of product (image, name and etc)
         const {
             canonical_url,
             categories,

--- a/packages/scandipwa/src/store/Cart/Cart.reducer.js
+++ b/packages/scandipwa/src/store/Cart/Cart.reducer.js
@@ -22,8 +22,8 @@ export const updateCartTotals = (action) => {
 
     if (Object.hasOwnProperty.call(cartTotals, 'items')) {
         const normalizedItemsProduct = cartTotals.items.map((item) => {
-            const normalizedItem = item;
-            normalizedItem.product = getIndexedProduct(item.product);
+            const { variants, ...normalizedItem } = item;
+            normalizedItem.product = getIndexedProduct(item.product, item.sku);
 
             return normalizedItem;
         });

--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.action.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.action.js
@@ -31,7 +31,8 @@ export const addRecentlyViewedProduct = (product, store) => ({
  * @return {void}
  * @namespace Store/RecentlyViewedProducts/Action/updateRecentlyViewedProducts
  */
-export const updateRecentlyViewedProducts = (products) => ({
+export const updateRecentlyViewedProducts = (products, storeCode) => ({
     type: UPDATE_RECENTLY_VIEWED_PRODUCTS,
-    products
+    products,
+    storeCode
 });

--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.action.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.action.js
@@ -10,16 +10,28 @@
  */
 
 export const UPDATE_RECENTLY_VIEWED_PRODUCTS = 'UPDATE_RECENTLY_VIEWED_PRODUCTS';
+export const ADD_RECENTLY_VIEWED_PRODUCT = 'ADD_RECENTLY_VIEWED_PRODUCT';
+
+/**
+ * Add RecentlyViewed product into list.
+ * @param  {Object} product Product returned from fetch
+ * @param  {String} store code
+ * @return {void}
+ * @namespace Store/RecentlyViewedProducts/Action/addRecentlyViewedProduct
+ */
+export const addRecentlyViewedProduct = (product, store) => ({
+    type: ADD_RECENTLY_VIEWED_PRODUCT,
+    product,
+    store
+});
 
 /**
  * Update RecentlyViewed products list.
  * @param  {Object} product Product returned from fetch
- * @param  {String} store code
  * @return {void}
  * @namespace Store/RecentlyViewedProducts/Action/updateRecentlyViewedProducts
  */
-export const updateRecentlyViewedProducts = (product, store) => ({
+export const updateRecentlyViewedProducts = (products) => ({
     type: UPDATE_RECENTLY_VIEWED_PRODUCTS,
-    product,
-    store
+    products
 });

--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.dispatcher.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.dispatcher.js
@@ -15,21 +15,26 @@ import {
     updateRecentlyViewedProducts
 } from 'Store/RecentlyViewedProducts/RecentlyViewedProducts.action';
 import { QueryDispatcher } from 'Util/Request';
+import getStore from 'Util/Store';
 
 /**
- * Product List Info Dispatcher
- * @class ProductListInfoDispatcher
+ * RecentlyViewedProducts Dispatcher
+ * @class RecentlyViewedProductsDispatcher
  * @extends QueryDispatcher
- * @namespace Store/ProductListInfo/Dispatcher
+ * @namespace Store/RecentlyViewedProducts/Dispatcher
  */
 export class RecentlyViewedProductsDispatcher extends QueryDispatcher {
     __construct() {
         super.__construct('recentlyViewedProducts');
     }
 
-    onSuccess({ products }, dispatch) {
-        const { items = {} } = products;
-        dispatch(updateRecentlyViewedProducts(items));
+    onSuccess({ products: { items } }, dispatch) {
+        const state = getStore().getState();
+        const {
+            code: storeCode
+        } = state.ConfigReducer;
+
+        dispatch(updateRecentlyViewedProducts(items, storeCode));
     }
 
     onError(error, dispatch) {
@@ -38,7 +43,7 @@ export class RecentlyViewedProductsDispatcher extends QueryDispatcher {
 
     /**
      * Prepare recentlyViewedProducts query
-     * @return {Query} ProductList query
+     * @return {Query} RecentlyViewedProducts query
      * @memberof recentlyViewedProductsDispatcher
      * @param recentlyViewedProducts
      */

--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.dispatcher.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.dispatcher.js
@@ -1,0 +1,65 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+import ProductListQuery from 'Query/ProductList.query';
+import { showNotification } from 'Store/Notification/Notification.action';
+import {
+    updateRecentlyViewedProducts
+} from 'Store/RecentlyViewedProducts/RecentlyViewedProducts.action';
+import { QueryDispatcher } from 'Util/Request';
+
+/**
+ * Product List Info Dispatcher
+ * @class ProductListInfoDispatcher
+ * @extends QueryDispatcher
+ * @namespace Store/ProductListInfo/Dispatcher
+ */
+export class RecentlyViewedProductsDispatcher extends QueryDispatcher {
+    __construct() {
+        super.__construct('recentlyViewedProducts');
+    }
+
+    onSuccess({ products }, dispatch) {
+        const { items = {} } = products;
+        dispatch(updateRecentlyViewedProducts(items));
+    }
+
+    onError(error, dispatch) {
+        dispatch(showNotification('error', __('Error fetching Recently Viewed Products Information!'), error));
+    }
+
+    /**
+     * Prepare recentlyViewedProducts query
+     * @return {Query} ProductList query
+     * @memberof recentlyViewedProductsDispatcher
+     * @param recentlyViewedProducts
+     */
+    prepareRequest(options) {
+        const { recentProducts, store } = options;
+        const recentlyViewedProductsSKUs = recentProducts[store].reduce((productSKUs, item) => {
+            const { sku } = item;
+            return [...productSKUs, `${ sku.replace(/ /g, '%20') }`];
+        }, []);
+
+        return [
+            ProductListQuery.getQuery({
+                args: {
+                    filter: {
+                        productsSkuArray: recentlyViewedProductsSKUs
+                    }
+                },
+                notRequireInfo: true
+            })
+        ];
+    }
+}
+
+export default new RecentlyViewedProductsDispatcher();

--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
@@ -18,6 +18,7 @@ import {
     UPDATE_RECENTLY_VIEWED_PRODUCTS
 } from 'Store/RecentlyViewedProducts/RecentlyViewedProducts.action';
 import BrowserDatabase from 'Util/BrowserDatabase';
+import { getIndexedProducts } from 'Util/Product';
 
 /** @namespace Store/RecentlyViewedProducts/Reducer/getInitialState */
 export const getInitialState = () => ({
@@ -64,16 +65,22 @@ export const RecentlyViewedProductsReducer = (
 
     case UPDATE_RECENTLY_VIEWED_PRODUCTS:
         const {
-            products
+            products,
+            storeCode
         } = action;
         const { recentlyViewedProducts: recent = {} } = state;
 
-        console.log(products);
+        const indexedProducts = getIndexedProducts(products);
+        const recentProductsFromStorage = BrowserDatabase.getItem(RECENTLY_VIEWED_PRODUCTS) || [];
+
+        const sortedRecentProducts = recentProductsFromStorage[storeCode].reduce((acc, { sku }) => {
+            const sortedProduct = indexedProducts.find((item) => item.sku === sku);
+            return [...acc, sortedProduct];
+        }, []);
 
         const newRecentProducts1 = {
             ...recent,
-            // eslint-disable-next-line quote-props
-            'default': products
+            [storeCode]: sortedRecentProducts
         };
 
         return {

--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
@@ -14,13 +14,15 @@ import {
     RECENTLY_VIEWED_PRODUCTS
 } from 'Component/RecentlyViewedWidget/RecentlyViewedWidget.config';
 import {
+    ADD_RECENTLY_VIEWED_PRODUCT,
     UPDATE_RECENTLY_VIEWED_PRODUCTS
 } from 'Store/RecentlyViewedProducts/RecentlyViewedProducts.action';
 import BrowserDatabase from 'Util/BrowserDatabase';
 
 /** @namespace Store/RecentlyViewedProducts/Reducer/getInitialState */
 export const getInitialState = () => ({
-    recentlyViewedProducts: BrowserDatabase.getItem(RECENTLY_VIEWED_PRODUCTS) || {}
+    recentlyViewedProducts: BrowserDatabase.getItem(RECENTLY_VIEWED_PRODUCTS) || {},
+    shouldBeUpdated: true
 });
 
 /** @namespace Store/RecentlyViewedProducts/Reducer/recentlyViewedProductsReducer */
@@ -29,7 +31,7 @@ export const RecentlyViewedProductsReducer = (
     action
 ) => {
     switch (action.type) {
-    case UPDATE_RECENTLY_VIEWED_PRODUCTS:
+    case ADD_RECENTLY_VIEWED_PRODUCT:
         const {
             product,
             product: { sku: newSku }
@@ -54,8 +56,31 @@ export const RecentlyViewedProductsReducer = (
 
         BrowserDatabase.setItem(newRecentProducts, RECENTLY_VIEWED_PRODUCTS);
 
-        return { ...state, recentlyViewedProducts: newRecentProducts };
+        return {
+            ...state,
+            recentlyViewedProducts: newRecentProducts,
+            shouldBeUpdated: true
+        };
 
+    case UPDATE_RECENTLY_VIEWED_PRODUCTS:
+        const {
+            products
+        } = action;
+        const { recentlyViewedProducts: recent = {} } = state;
+
+        console.log(products);
+
+        const newRecentProducts1 = {
+            ...recent,
+            // eslint-disable-next-line quote-props
+            'default': products
+        };
+
+        return {
+            ...state,
+            recentlyViewedProducts: newRecentProducts1,
+            shouldBeUpdated: false
+        };
     default:
         return state;
     }

--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
@@ -73,19 +73,20 @@ export const RecentlyViewedProductsReducer = (
         const indexedProducts = getIndexedProducts(products);
         const recentProductsFromStorage = BrowserDatabase.getItem(RECENTLY_VIEWED_PRODUCTS) || [];
 
+        // Sort products same as it is localstorage recentlyViewedProducts
         const sortedRecentProducts = recentProductsFromStorage[storeCode].reduce((acc, { sku }) => {
             const sortedProduct = indexedProducts.find((item) => item.sku === sku);
             return [...acc, sortedProduct];
         }, []);
 
-        const newRecentProducts1 = {
+        const updatedRecentViewedProducts = {
             ...recent,
             [storeCode]: sortedRecentProducts
         };
 
         return {
             ...state,
-            recentlyViewedProducts: newRecentProducts1,
+            recentlyViewedProducts: updatedRecentViewedProducts,
             shouldBeUpdated: false
         };
     default:

--- a/packages/scandipwa/src/util/Product/Product.js
+++ b/packages/scandipwa/src/util/Product/Product.js
@@ -98,6 +98,22 @@ export const getIndexedVariants = (variants) => variants.map(({ product }) => {
     };
 });
 
+/** @namespace Util/Product/getIndexedSingleVariant */
+export const getIndexedSingleVariant = (variants, itemSku) => {
+    const index = variants.findIndex(({ product: { sku } }) => sku === itemSku || itemSku.includes(sku));
+
+    if (index < 0) {
+        return getIndexedVariants(variants);
+    }
+
+    const indexedProduct = variants[index].product;
+    const { attributes } = indexedProduct;
+
+    return [
+        { ...indexedProduct, attributes: getIndexedAttributes(attributes || []) }
+    ];
+};
+
 /**
  * Get product variant index by options
  * @param {Object[]} variants
@@ -235,7 +251,7 @@ export const getBundleOptions = (options, items) => {
 };
 
 /** @namespace Util/Product/getIndexedProduct */
-export const getIndexedProduct = (product) => {
+export const getIndexedProduct = (product, itemSku) => {
     const {
         variants: initialVariants = [],
         configurable_options: initialConfigurableOptions = [],
@@ -254,7 +270,7 @@ export const getIndexedProduct = (product) => {
     const updatedProduct = {
         ...product,
         configurable_options: getIndexedConfigurableOptions(initialConfigurableOptions, attributes),
-        variants: getIndexedVariants(initialVariants),
+        variants: itemSku ? getIndexedSingleVariant(initialVariants, itemSku) : getIndexedVariants(initialVariants),
         options: getIndexedCustomOptions(initialOptions || []),
         attributes,
         // Magento 2.4.1 review endpoint compatibility
@@ -273,7 +289,7 @@ export const getIndexedProduct = (product) => {
 };
 
 /** @namespace Util/Product/getIndexedProducts */
-export const getIndexedProducts = (products) => products.map(getIndexedProduct);
+export const getIndexedProducts = (products) => products.map((product) => getIndexedProduct(product));
 
 /** @namespace Util/Product/getIndexedParameteredProducts */
 export const getIndexedParameteredProducts = (products) => Object.entries(products)


### PR DESCRIPTION
Fixes #2628

Localstorage max size is 5mb. In case if we add https://master.d25kd40decjpue.amplifyapp.com/default/ciunas.html into cart or just visit it so it is automatically added into recentView we are getting error, because localstorage is overcrowded. Products has a lot of options to select from => a lot of variations is added into cart_totals for this products. 
![localstorage](https://user-images.githubusercontent.com/68007919/119132614-988ec280-ba43-11eb-9e64-15559ad8a2eb.png)

1. Add into cart_totals not all variants, but only 1 that is shows in cart, since we don't use others.
2. For recently viewed products we can save only preview of product, when we enter page with recently viewed product widget we can see those products, we can click on them, but options are loading from BE, because we are not holding them in localstorage. (while we waiting for full product data, we are just showing placeholders under name/price)