### PR TITLE
Rate (stars) position issue fix

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
@@ -149,7 +149,8 @@
     &-FigureReview {
         display: flex;
         justify-content: center;
-        flex-direction: column;
+        //flex-direction: column;
+        align-items: flex-end;
     }
 
     &-Reviews {

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
@@ -149,7 +149,6 @@
     &-FigureReview {
         display: flex;
         justify-content: center;
-        //flex-direction: column;
         align-items: flex-end;
     }
 


### PR DESCRIPTION
An issue: https://github.com/scandipwa/scandipwa/issues/2609
There was an incorrect usage of flex container. flex-direction should not be 'column' if you want to put the block in the middle of horizontal side of an image while using display:flex. To align the "stars" to the bottom I used align-items, because it is compatible with flex.