### PR TITLE
fix stretched logo

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -490,10 +490,6 @@
         &_isVisible {
             @include logo-visible;
         }
-
-        .Image-Image {
-            object-fit: fill;
-        }
     }
 
     &-Title {


### PR DESCRIPTION

<img width="289" alt="Pre | Homepage | Suff 2021-06-10 13-07-19" src="https://user-images.githubusercontent.com/79456428/121522293-9fcf3d80-c9fd-11eb-8dd1-6a66766122de.png">
