### PR TITLE
#2735 getting compare list items ids on PDP and PLP load

### DIFF
--- a/packages/scandipwa/src/component/Router/Router.container.js
+++ b/packages/scandipwa/src/component/Router/Router.container.js
@@ -76,6 +76,9 @@ export const mapDispatchToProps = (dispatch) => ({
         CartDispatcher.then(
             ({ default: dispatcher }) => dispatcher.updateInitialCartData(dispatch)
         );
+        ProductCompareDispatcher.then(
+            ({ default: dispatcher }) => dispatcher.updateInitialProductCompareData(dispatch)
+        );
     }
 });
 

--- a/packages/scandipwa/src/query/ProductCompare.query.js
+++ b/packages/scandipwa/src/query/ProductCompare.query.js
@@ -68,6 +68,12 @@ export class ProductCompareQuery extends ProductListQuery {
             .addFieldList(this._getCompareListFields());
     }
 
+    getCompareListIds(uid) {
+        return new Field('compareList')
+            .addArgument('uid', 'ID!', uid)
+            .addField(this._getComparableItemIdsField());
+    }
+
     _getCompareListFields() {
         return [
             'uid',
@@ -108,15 +114,37 @@ export class ProductCompareQuery extends ProductListQuery {
         ];
     }
 
+    _getComparableItemIdsFields() {
+        return [
+            this._getProductIdsField()
+        ];
+    }
+
     _getProductField() {
         return new Field('product')
             .addFieldList(this._getProductInterfaceFields(true, false))
             .addFieldList(['url']);
     }
 
+    _getProductIdsField() {
+        return new Field('product')
+            .addFieldList(this._getProductIdsFields());
+    }
+
     _getComparableItemField() {
         return new Field('items')
             .addFieldList(this._getComparableItemFields());
+    }
+
+    _getComparableItemIdsField() {
+        return new Field('items')
+            .addFieldList(this._getComparableItemIdsFields());
+    }
+
+    _getProductIdsFields() {
+        return [
+            'id'
+        ];
     }
 }
 

--- a/packages/scandipwa/src/store/ProductCompare/ProductCompare.action.js
+++ b/packages/scandipwa/src/store/ProductCompare/ProductCompare.action.js
@@ -40,7 +40,7 @@ export const clearComparedProducts = () => ({
 });
 
 /** @namespace Store/ProductCompare/Action/clearComparedProducts/setComparedProductIds */
-export const setComparedProductIds = (productIds) => ({
+export const setCompareListIds = (productIds) => ({
     type: SET_COMPARED_PRODUCT_IDS,
     productIds
 });

--- a/packages/scandipwa/src/store/ProductCompare/ProductCompare.dispatcher.js
+++ b/packages/scandipwa/src/store/ProductCompare/ProductCompare.dispatcher.js
@@ -29,6 +29,7 @@ export const CartDispatcher = import(
 export class ProductCompareDispatcher {
     async getCompareList(dispatch) {
         const uid = getUid();
+
         if (!uid) {
             return false;
         }
@@ -105,6 +106,7 @@ export class ProductCompareDispatcher {
 
     async removeComparedProduct(productId, dispatch) {
         const uid = getUid();
+
         if (!uid) {
             return false;
         }
@@ -149,6 +151,7 @@ export class ProductCompareDispatcher {
 
     async assignCompareList(dispatch) {
         const uid = getUid();
+
         if (!uid) {
             await this.fetchCustomersList(dispatch);
 
@@ -185,6 +188,7 @@ export class ProductCompareDispatcher {
 
     async clearComparedProducts(dispatch) {
         const uid = getUid();
+
         if (!uid) {
             return false;
         }
@@ -211,6 +215,7 @@ export class ProductCompareDispatcher {
 
     async updateInitialProductCompareData(dispatch) {
         const uid = getUid();
+
         if (!uid) {
             return false;
         }

--- a/packages/scandipwa/src/store/ProductCompare/ProductCompare.dispatcher.js
+++ b/packages/scandipwa/src/store/ProductCompare/ProductCompare.dispatcher.js
@@ -14,6 +14,7 @@ import { showNotification } from 'Store/Notification/Notification.action';
 import {
     clearComparedProducts,
     setCompareList,
+    setCompareListIds,
     toggleLoader
 } from 'Store/ProductCompare/ProductCompare.action';
 import { getUid, removeUid, setUid } from 'Util/Compare';
@@ -206,6 +207,33 @@ export class ProductCompareDispatcher {
             dispatch(showNotification('error', __('Unable to clear product compare list'), error));
             return false;
         }
+    }
+
+    async updateInitialProductCompareData(dispatch) {
+        const uid = getUid();
+        if (!uid) {
+            return false;
+        }
+
+        dispatch(toggleLoader(true));
+
+        try {
+            const { compareList: { items } } = await fetchQuery(
+                ProductCompareQuery.getCompareListIds(uid)
+            );
+
+            const compareIds = items.map(({ product: { id } }) => id);
+
+            dispatch(toggleLoader(false));
+            dispatch(setCompareListIds(compareIds));
+        } catch (error) {
+            dispatch(toggleLoader(false));
+            dispatch(showNotification('error', __('Unable to fetch compare list'), error));
+
+            return false;
+        }
+
+        return true;
     }
 
     resetComparedProducts(dispatch) {

--- a/packages/scandipwa/src/store/ProductCompare/ProductCompare.reducer.js
+++ b/packages/scandipwa/src/store/ProductCompare/ProductCompare.reducer.js
@@ -12,6 +12,7 @@
 import {
     CLEAR_COMPARED_PRODUCTS,
     SET_COMPARE_LIST,
+    SET_COMPARED_PRODUCT_IDS,
     TOGGLE_COMPARE_LIST_LOADER
 } from './ProductCompare.action';
 
@@ -66,6 +67,15 @@ export const ProductCompareReducer = (state = getInitialState(), action) => {
             productIds: [],
             items: [],
             attributes: []
+        };
+    }
+
+    case SET_COMPARED_PRODUCT_IDS: {
+        const { productIds } = action;
+        console.log(productIds);
+        return {
+            ...state,
+            productIds
         };
     }
 

--- a/packages/scandipwa/src/store/ProductCompare/ProductCompare.reducer.js
+++ b/packages/scandipwa/src/store/ProductCompare/ProductCompare.reducer.js
@@ -72,7 +72,7 @@ export const ProductCompareReducer = (state = getInitialState(), action) => {
 
     case SET_COMPARED_PRODUCT_IDS: {
         const { productIds } = action;
-        console.log(productIds);
+
         return {
             ...state,
             productIds


### PR DESCRIPTION
https://github.com/scandipwa/scandipwa/issues/2735, issue 5.

Code fetching data on page load was removed by Richard when switching to compare-graphql module and refactoring for some reason. I added it back and made required fixes to match the updated version + rewrote logic a bit to require only product ids of products in Compare list instead of all products data for better performance.