### PR TITLE
Fix description rendering on in-delivery

### DIFF
--- a/packages/scandipwa/src/component/StoreInPickUpStore/StoreInPickUpStore.component.js
+++ b/packages/scandipwa/src/component/StoreInPickUpStore/StoreInPickUpStore.component.js
@@ -54,7 +54,7 @@ export class StoreInPickUpStore extends PureComponent {
                     <p>{ `${city}, ${region} ${postcode}` }</p>
                     <p>{ country }</p>
                     <a href={ `tel:${phone}` }>{ phone }</a>
-                    <Html content={ description } />
+                    <Html content={ description || '' } />
                 </div>
                 <div block="StoreInPickUpStore" elem="StoreActions">
                     <button


### PR DESCRIPTION
fixes #2774 

If description is empty for store it brings null as description. 