### PR TITLE
#2616 - no error message inside mobile pop-up

### DIFF
--- a/packages/scandipwa/src/component/Popup/Popup.component.js
+++ b/packages/scandipwa/src/component/Popup/Popup.component.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import { createPortal } from 'react-dom';
 
 import ClickOutside from 'Component/ClickOutside';
+import NotificationList from 'Component/NotificationList';
 import Overlay from 'Component/Overlay/Overlay.component';
 
 import { ESCAPE_KEY } from './Popup.config';
@@ -152,6 +153,7 @@ export class Popup extends Overlay {
                         { this.renderTitle() }
                         { this.renderCloseButton() }
                     </header>
+                    <NotificationList />
                     { children }
                 </div>
             </ClickOutside>

--- a/packages/scandipwa/src/component/Popup/Popup.component.js
+++ b/packages/scandipwa/src/component/Popup/Popup.component.js
@@ -17,6 +17,7 @@ import { createPortal } from 'react-dom';
 import ClickOutside from 'Component/ClickOutside';
 import NotificationList from 'Component/NotificationList';
 import Overlay from 'Component/Overlay/Overlay.component';
+import { DeviceType } from 'Type/Device';
 
 import { ESCAPE_KEY } from './Popup.config';
 
@@ -27,7 +28,8 @@ export class Popup extends Overlay {
     static propTypes = {
         ...Overlay.propTypes,
         clickOutside: PropTypes.bool,
-        title: PropTypes.string
+        title: PropTypes.string,
+        device: DeviceType.isRequired
     };
 
     static defaultProps = {
@@ -138,6 +140,16 @@ export class Popup extends Overlay {
         );
     }
 
+    renderNotifications() {
+        const { device: { isMobile } } = this.props;
+
+        if (!isMobile) {
+            return null;
+        }
+
+        return <NotificationList />;
+    }
+
     renderContent() {
         const { children, contentMix } = this.props;
         const isVisible = this.getIsVisible();
@@ -153,7 +165,7 @@ export class Popup extends Overlay {
                         { this.renderTitle() }
                         { this.renderCloseButton() }
                     </header>
-                    <NotificationList />
+                    { this.renderNotifications() }
                     { children }
                 </div>
             </ClickOutside>

--- a/packages/scandipwa/src/component/Popup/Popup.style.scss
+++ b/packages/scandipwa/src/component/Popup/Popup.style.scss
@@ -102,6 +102,15 @@
             position: fixed;
         }
     }
+
+    .NotificationList {
+
+        @include desktop {
+            display: none;
+        }
+
+        top: 0;
+    }
 }
 
 .scrollDisabled {

--- a/packages/scandipwa/src/component/Popup/Popup.style.scss
+++ b/packages/scandipwa/src/component/Popup/Popup.style.scss
@@ -109,7 +109,10 @@
             display: none;
         }
 
+        width: 100vw;
         top: 0;
+        left: calc(0px - var(--popup-content-padding));
+        position: relative;
     }
 }
 

--- a/packages/scandipwa/src/component/Popup/Popup.style.scss
+++ b/packages/scandipwa/src/component/Popup/Popup.style.scss
@@ -104,11 +104,6 @@
     }
 
     .NotificationList {
-
-        @include desktop {
-            display: none;
-        }
-
         width: 100vw;
         top: 0;
         left: calc(0px - var(--popup-content-padding));


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/2616

Error message is displayed BELOW popup and invisible, as the popup is fullscreen. The solution here is to show the message inside popup as well, so that user sees it. Only applicable to mobile. 