### PR TITLE
Update recentlyViewdPRoducts after fetch

### DIFF
--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
@@ -73,9 +73,16 @@ export const RecentlyViewedProductsReducer = (
         const indexedProducts = getIndexedProducts(products);
         const recentProductsFromStorage = BrowserDatabase.getItem(RECENTLY_VIEWED_PRODUCTS) || [];
 
+        // Remove product from storage if it is not available
+        recentProductsFromStorage[storeCode] = recentProductsFromStorage[storeCode]
+            .filter((storageItem) => !indexedProducts.every((indexedItem) => indexedItem.id !== storageItem.id));
+
+        BrowserDatabase.setItem(recentProductsFromStorage, RECENTLY_VIEWED_PRODUCTS);
+
         // Sort products same as it is localstorage recentlyViewedProducts
         const sortedRecentProducts = recentProductsFromStorage[storeCode].reduce((acc, { sku }) => {
             const sortedProduct = indexedProducts.find((item) => item.sku === sku);
+
             return [...acc, sortedProduct];
         }, []);
 


### PR DESCRIPTION
fixes #2673 

If product is removed from website or just disabled it won't return from BE data about it, but since we store preview of products in localstorage it is necessary to update it also so product will be removed from recently viewed. 