### PR TITLE
Bundle Grouped Out Of Stock Fix

### DIFF
--- a/packages/scandipwa/src/component/ProductBundleItem/ProductBundleItem.container.js
+++ b/packages/scandipwa/src/component/ProductBundleItem/ProductBundleItem.container.js
@@ -187,7 +187,7 @@ export class ProductBundleItemContainer extends ProductCustomizableOptionContain
             currencyCode
         } = this.props;
 
-        return values.reduce((acc, {
+        return values.filter(({ product }) => !!product).reduce((acc, {
             id,
             label,
             price_type,

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.container.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.container.js
@@ -166,8 +166,12 @@ export class ProductCustomizableOptionContainer extends PureComponent {
     }
 
     getDropdownOptions(values) {
-        return values.reduce((acc, {
-            option_type_id, title, price, price_type, currency
+        return values.filter(({ product }) => !!product).reduce((acc, {
+            option_type_id,
+            title,
+            price,
+            price_type,
+            currency
         }) => {
             acc.push({
                 id: option_type_id,


### PR DESCRIPTION
Fixes #2266
Hid out of stock subproducts of bundled or grouped product if they are out of stock, like this is done in luma.