### PR TITLE
#2716 Chrome & IOS autofil email check on checkout

### DIFF
--- a/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.config.js
+++ b/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.config.js
@@ -1,0 +1,15 @@
+/* eslint-disable import/prefer-default-export */
+
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export const GUEST_EMAIL_FIELD_ID = 'guest_email';
+export const AUTOFILL_CHECK_TIMER = 700;

--- a/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.js
+++ b/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.js
@@ -14,9 +14,9 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import {
-    GUEST_EMAIL_FIELD_ID,
-    AUTOFILL_CHECK_TIMER
-} from "Component/CheckoutGuestForm/CheckoutGuestForm.config";
+    AUTOFILL_CHECK_TIMER,
+    GUEST_EMAIL_FIELD_ID
+} from 'Component/CheckoutGuestForm/CheckoutGuestForm.config';
 import {
     STATE_CREATE_ACCOUNT,
     STATE_FORGOT_PASSWORD,
@@ -89,6 +89,13 @@ export class CheckoutGuestFormContainer extends PureComponent {
         setLoadingState: this.setLoadingState.bind(this)
     };
 
+    componentDidMount() {
+        setTimeout(
+            () => this.handleEmailInput(document.getElementById(GUEST_EMAIL_FIELD_ID).value),
+            AUTOFILL_CHECK_TIMER
+        );
+    }
+
     containerProps = () => {
         const { emailValue } = this.props;
         return ({
@@ -96,13 +103,6 @@ export class CheckoutGuestFormContainer extends PureComponent {
             emailValue
         });
     };
-
-    componentDidMount() {
-        setTimeout(
-            () => this.handleEmailInput(document.getElementById(GUEST_EMAIL_FIELD_ID).value),
-            AUTOFILL_CHECK_TIMER
-        );
-    }
 
     onFormError() {
         this.setState({ isLoading: false });

--- a/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.js
+++ b/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.js
@@ -14,6 +14,10 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import {
+    GUEST_EMAIL_FIELD_ID,
+    AUTOFILL_CHECK_TIMER
+} from "Component/CheckoutGuestForm/CheckoutGuestForm.config";
+import {
     STATE_CREATE_ACCOUNT,
     STATE_FORGOT_PASSWORD,
     STATE_SIGN_IN
@@ -92,6 +96,13 @@ export class CheckoutGuestFormContainer extends PureComponent {
             emailValue
         });
     };
+
+    componentDidMount() {
+        setTimeout(
+            () => this.handleEmailInput(document.getElementById(GUEST_EMAIL_FIELD_ID).value),
+            AUTOFILL_CHECK_TIMER
+        );
+    }
 
     onFormError() {
         this.setState({ isLoading: false });


### PR DESCRIPTION
Original issue: https://github.com/scandipwa/scandipwa/issues/2716

In this PR: Added delayed check for filled form

react, chrome & IOS doesn't support any kind of event triggering for auto-filled form elements, thus value is not passed to react and onValueChanged is not triggered,... to resolve this requires direct data access from DOM element, ether by delay or loop check.