### PR TITLE
#2798 Hide product samples title when empty

### DIFF
--- a/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
@@ -614,18 +614,18 @@ export class ProductActions extends PureComponent {
             product: {
                 type_id,
                 samples_title,
-                downloadable_product_samples
+                downloadable_product_samples: samples
             }
         } = this.props;
 
-        if (type_id !== DOWNLOADABLE || !downloadable_product_samples) {
+        if (type_id !== DOWNLOADABLE || !samples || Array.isArray(samples) && !samples.length) {
             return null;
         }
 
         return (
             <ProductDownloadableSamples
               title={ samples_title }
-              samples={ downloadable_product_samples }
+              samples={ samples }
             />
         );
     }

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
@@ -618,7 +618,7 @@ export class ProductActions extends PureComponent {
             }
         } = this.props;
 
-        if (type_id !== DOWNLOADABLE || !samples || Array.isArray(samples) && !samples.length) {
+        if (type_id !== DOWNLOADABLE || !samples || (Array.isArray(samples) && !samples.length)) {
             return null;
         }
 


### PR DESCRIPTION
Original issue: https://github.com/scandipwa/scandipwa/issues/2798

In this PR: Added array size check, so that title is not visible, when array is empty.