### PR TITLE
Multistore Fix

### DIFF
--- a/packages/m2-theme/public/index.php
+++ b/packages/m2-theme/public/index.php
@@ -1,74 +1,75 @@
 <?php
-    $colorConfig = $this->getThemeConfiguration('color_customization');
-    $contentConfig = $this->getThemeConfiguration('content_customization');
-    $icons = $this->getAppIconData();
+$colorConfig = $this->getThemeConfiguration('color_customization');
+$contentConfig = $this->getThemeConfiguration('content_customization');
+$icons = $this->getAppIconData();
 ?>
 <!DOCTYPE html>
 <html lang="<?= $this->getLanguageCode() ?>">
-    <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
 
-        <!-- Muli font import from Abode -->
-        <link rel="stylesheet" href="https://use.typekit.net/gbk7rfi.css">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
 
-        <script>
-            (function() {
-                if (typeof globalThis === 'object') return;
-                Object.prototype.__defineGetter__('__magic__', function() {
-                    return this;
-                });
-                __magic__.globalThis = __magic__;
-                delete Object.prototype.__magic__;
-            }());
+    <!-- Muli font import from Abode -->
+    <link rel="stylesheet" href="https://use.typekit.net/gbk7rfi.css">
 
-            // Locale
-            window.defaultLocale = `<?= $this->getLocaleCode() ?>`;
+    <script>
+        (function() {
+            if (typeof globalThis === 'object') return;
+            Object.prototype.__defineGetter__('__magic__', function() {
+                return this;
+            });
+            __magic__.globalThis = __magic__;
+            delete Object.prototype.__magic__;
+        }());
 
-            // Misc
-            window.actionName = { type: `<?= $this->getAction(); ?>` };
-            window.contentConfiguration = <?= json_encode($contentConfig) ?> || {};
+        // Locale
+        window.defaultLocale = `<?= $this->getLocaleCode() ?>`;
 
-            // Multistore
-            window.storeList = JSON.parse(`<?= $this->getStoreListJson() ?>`);
-            window.storeRegexText = `/(${window.storeList.join('|')})?`;
-        </script>
+        // Misc
+        window.actionName = {
+            type: `<?= $this->getAction(); ?>`
+        };
+        window.contentConfiguration = <?= json_encode($contentConfig) ?> || {};
 
-        <!-- Preload i18n chunk for the store -->
-        <link rel="preload" as="script" href="<?= $this->getLocaleChunkUrl() ?>">
+        // Multistore
+        // do reverse sort in order prevent an issue like store code `en` replaces store code `en_us`
+        window.storeList = JSON.parse(`<?= $this->getStoreListJson() ?>`).sort().reverse();
+        window.storeRegexText = `/(${window.storeList.join('|')})?`;
+    </script>
 
-        <!-- Icons -->
-        <link rel="shortcut icon" href="/pub/media/favicon/favicon.png">
+    <!-- Preload i18n chunk for the store -->
+    <link rel="preload" as="script" href="<?= $this->getLocaleChunkUrl() ?>">
 
-        <?php foreach ($icons['ios_startup'] as $icon): ?>
-            <?= sprintf('<link rel="apple-touch-startup-image" sizes="%s" href="%s">', $icon["sizes"], $icon["href"]); ?>
-        <?php endforeach; ?>
+    <!-- Icons -->
+    <link rel="shortcut icon" href="/pub/media/favicon/favicon.png">
 
-        <?php foreach ($icons['ios'] as $icon): ?>
-            <?= sprintf('<link rel="apple-touch-icon" sizes="%s" href="%s">', $icon["sizes"], $icon["href"]); ?>
-        <?php endforeach; ?>
+    <?php foreach ($icons['ios_startup'] as $icon) : ?>
+        <?= sprintf('<link rel="apple-touch-startup-image" sizes="%s" href="%s">', $icon["sizes"], $icon["href"]); ?>
+    <?php endforeach; ?>
 
-        <?php foreach ($icons['icon'] as $icon): ?>
-            <?= sprintf('<link rel="icon" sizes="%s" href="%s">', $icon["sizes"], $icon["href"]); ?>
-        <?php endforeach; ?>
+    <?php foreach ($icons['ios'] as $icon) : ?>
+        <?= sprintf('<link rel="apple-touch-icon" sizes="%s" href="%s">', $icon["sizes"], $icon["href"]); ?>
+    <?php endforeach; ?>
 
-        <!-- Manifest -->
-        <link rel="manifest" href="/pub/media/webmanifest/manifest.json">
+    <?php foreach ($icons['icon'] as $icon) : ?>
+        <?= sprintf('<link rel="icon" sizes="%s" href="%s">', $icon["sizes"], $icon["href"]); ?>
+    <?php endforeach; ?>
+
+    <!-- Manifest -->
+    <link rel="manifest" href="/pub/media/webmanifest/manifest.json">
     <style>
-        <?php if ($colorConfig['enable_color_customization']['enable_custom_colors'] !== "0"): ?>
-            <?php $colorArray = $colorConfig['primary_colors'] + $colorConfig['secondary_colors']; ?>
-            :root {
-                <?php foreach ($colorArray as $code => $color): ?>
-                    <?php if (strpos($code, 'color') !== false): ?>
-                        <?= sprintf('--imported_%s: #%s;', $code, $color); ?>
-                    <?php endif; ?>
-                <?php endforeach; ?>
-            }
+        <?php if ($colorConfig['enable_color_customization']['enable_custom_colors'] !== "0") : ?><?php $colorArray = $colorConfig['primary_colors'] + $colorConfig['secondary_colors']; ?> :root {
+            <?php foreach ($colorArray as $code => $color) : ?><?php if (strpos($code, 'color') !== false) : ?><?= sprintf('--imported_%s: #%s;', $code, $color); ?><?php endif; ?><?php endforeach; ?>
+        }
+
         <?php endif; ?>
     </style>
 </head>
+
 <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
 </body>
+
 </html>

--- a/packages/scandipwa/public/index.html
+++ b/packages/scandipwa/public/index.html
@@ -24,7 +24,8 @@
             }());
 
         window.contentConfiguration = {};
-        window.storeList = ['default'];
+        // do reverse sort in order prevent an issue like store code `en` replaces store code `en_us`
+        window.storeList = ['default'].sort().reverse();
         window.storeRegexText = `/(${window.storeList.join('|')})?`;
     </script>
 </head>

--- a/packages/scandipwa/src/component/Link/Link.container.js
+++ b/packages/scandipwa/src/component/Link/Link.container.js
@@ -58,7 +58,9 @@ export class LinkContainer extends PureComponent {
     };
 
     getTo() {
-        const { to } = this.props;
+        const { to: toProp } = this.props;
+        // fix null, undefined and empty links
+        const to = toProp || '/';
 
         if (typeof to === 'string') {
             // in case this URL is absolute, do not append store
@@ -69,11 +71,11 @@ export class LinkContainer extends PureComponent {
             return appendWithStoreCode(to);
         }
 
-        const { pathname } = to;
+        const pathname = to.pathname || '/';
 
         return {
-            pathname: appendWithStoreCode(pathname),
-            ...to
+            ...to,
+            pathname: appendWithStoreCode(pathname)
         };
     }
 


### PR DESCRIPTION
Fixes #2818

1. Added reverse sort to `storeList` in order to prevent the issue when some store codes are part of order and replace works incorrectly, like `en` and `en_us`.
2. Fixed `getTo` method.
3. Fixed `storeList` regexp issues, when store code was searched in the middle of the url.
4. Fixed some eslint errors.