### PR TITLE
Add To Cart Button Fix On Compare Page

### DIFF
--- a/packages/scandipwa/src/component/AddToCart/AddToCart.component.js
+++ b/packages/scandipwa/src/component/AddToCart/AddToCart.component.js
@@ -12,7 +12,6 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-import { OUT_OF_STOCK } from 'Component/ProductCard/ProductCard.config';
 import { MixType } from 'Type/Common';
 import { ProductType } from 'Type/ProductList';
 
@@ -28,13 +27,15 @@ export class AddToCart extends PureComponent {
         isLoading: PropTypes.bool,
         product: ProductType,
         mix: MixType,
-        buttonClick: PropTypes.func.isRequired
+        buttonClick: PropTypes.func.isRequired,
+        disabled: PropTypes.bool
     };
 
     static defaultProps = {
         product: {},
         mix: {},
-        isLoading: false
+        isLoading: false,
+        disabled: false
     };
 
     renderPlaceholder() {
@@ -52,9 +53,10 @@ export class AddToCart extends PureComponent {
     render() {
         const {
             mix,
-            product: { type_id, stock_status },
+            product: { type_id },
             isLoading,
-            buttonClick
+            buttonClick,
+            disabled
         } = this.props;
 
         if (!type_id) {
@@ -67,7 +69,7 @@ export class AddToCart extends PureComponent {
               block="Button AddToCart"
               mix={ mix }
               mods={ { isLoading } }
-              disabled={ isLoading || stock_status === OUT_OF_STOCK }
+              disabled={ isLoading || disabled }
             >
                 <span>{ __('Add to cart') }</span>
                 <span>{ __('Adding...') }</span>

--- a/packages/scandipwa/src/component/AddToCart/AddToCart.container.js
+++ b/packages/scandipwa/src/component/AddToCart/AddToCart.container.js
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 
 import { IN_STOCK } from 'Component/ProductCard/ProductCard.config';
 import { showNotification } from 'Store/Notification/Notification.action';
+import { MixType } from 'Type/Common';
 import { ProductType } from 'Type/ProductList';
 import { isSignedIn } from 'Util/Auth';
 import {
@@ -66,7 +67,9 @@ export class AddToCartContainer extends PureComponent {
         wishlistItems: PropTypes.objectOf(ProductType).isRequired,
         onProductValidationError: PropTypes.func,
         productOptionsData: PropTypes.object.isRequired,
-        disableHandler: PropTypes.bool
+        disableHandler: PropTypes.bool,
+        mix: MixType,
+        disabled: PropTypes.bool
     };
 
     static defaultProps = {
@@ -75,14 +78,12 @@ export class AddToCartContainer extends PureComponent {
         setQuantityToDefault: () => {},
         onProductValidationError: () => {},
         isLoading: false,
-        disableHandler: false
+        disableHandler: false,
+        mix: {},
+        disabled: false
     };
 
     state = { isLoading: false };
-
-    containerFunctions = {
-        buttonClick: this.buttonClick.bind(this)
-    };
 
     validationMap = {
         [CONFIGURABLE]: this.validateConfigurableProduct.bind(this),
@@ -94,6 +95,22 @@ export class AddToCartContainer extends PureComponent {
         [CONFIGURABLE]: this.addConfigurableProductToCart.bind(this),
         [GROUPED]: this.addGroupedProductToCart.bind(this)
     };
+
+    containerFunctions = {
+        buttonClick: this.buttonClick.bind(this)
+    };
+
+    containerProps() {
+        const { product, mix, disabled } = this.props;
+        const { isLoading } = this.state;
+
+        return {
+            isLoading,
+            product,
+            mix,
+            disabled
+        };
+    }
 
     validateConfigurableProduct() {
         const {
@@ -377,8 +394,7 @@ export class AddToCartContainer extends PureComponent {
     render() {
         return (
             <AddToCart
-              { ...this.props }
-              { ...this.state }
+              { ...this.containerProps() }
               { ...this.containerFunctions }
             />
         );

--- a/packages/scandipwa/src/component/AddToCart/AddToCart.container.js
+++ b/packages/scandipwa/src/component/AddToCart/AddToCart.container.js
@@ -141,7 +141,7 @@ export class AddToCartContainer extends PureComponent {
             groupedProductQuantity,
             showNotification,
             product: {
-                items
+                items = []
             }
         } = this.props;
 

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
@@ -350,7 +350,10 @@ export class ProductActions extends PureComponent {
             quantity,
             groupedProductQuantity,
             onProductValidationError,
-            productOptionsData
+            productOptionsData,
+            product: {
+                stock_status
+            } = {}
         } = this.props;
 
         return (
@@ -362,6 +365,7 @@ export class ProductActions extends PureComponent {
               groupedProductQuantity={ groupedProductQuantity }
               onProductValidationError={ onProductValidationError }
               productOptionsData={ productOptionsData }
+              disabled={ stock_status === OUT_OF_STOCK }
             />
         );
     }

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -31,6 +31,7 @@ import { BUNDLE, CONFIGURABLE, GROUPED } from 'Util/Product';
 import {
     OPTION_TYPE_COLOR,
     OPTION_TYPE_IMAGE,
+    OUT_OF_STOCK,
     validOptionTypes
 } from './ProductCard.config';
 
@@ -481,7 +482,8 @@ export class ProductCard extends PureComponent {
         const {
             product,
             product: {
-                type_id
+                type_id,
+                stock_status
             }
         } = this.props;
         const configurableVariantIndex = -1;
@@ -503,6 +505,7 @@ export class ProductCard extends PureComponent {
               quantity={ quantity }
               groupedProductQuantity={ groupedProductQuantity }
               productOptionsData={ productOptionsData }
+              disabled={ stock_status === OUT_OF_STOCK }
             />
         );
     }

--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.container.js
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.container.js
@@ -48,8 +48,8 @@ export class ProductCompareContainer extends PureComponent {
         clearCompareList: PropTypes.func.isRequired,
         isLoading: PropTypes.bool,
         products: ProductItemsType,
-        items: PropTypes.object,
-        attributes: PropTypes.object
+        items: PropTypes.array,
+        attributes: PropTypes.array
     };
 
     static defaultProps = {

--- a/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.container.js
+++ b/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.container.js
@@ -16,7 +16,7 @@ import { connect } from 'react-redux';
 import { showNotification } from 'Store/Notification/Notification.action';
 import { DeviceType } from 'Type/Device';
 import { ProductType } from 'Type/ProductList';
-import { BUNDLE, CONFIGURABLE } from 'Util/Product';
+import { BUNDLE, CONFIGURABLE, GROUPED } from 'Util/Product';
 
 import ProductCompareItem from './ProductCompareItem.component';
 
@@ -131,7 +131,7 @@ export class ProductCompareItemContainer extends PureComponent {
 
     getOverrideAddToCartBtnBehavior() {
         const { product: { type_id, options } } = this.props;
-        const types = [BUNDLE, CONFIGURABLE];
+        const types = [BUNDLE, CONFIGURABLE, GROUPED];
 
         return !!(types.indexOf(type_id) !== -1 || options?.length);
     }

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.container.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.container.js
@@ -36,11 +36,15 @@ export class ProductCustomizableOptionContainer extends PureComponent {
         productOptionsData: PropTypes.object.isRequired,
         setSelectedCheckboxValues: PropTypes.func.isRequired,
         setCustomizableOptionTextFieldValue: PropTypes.func.isRequired,
-        setCustomizableOptionFileFieldValue: PropTypes.func.isRequired,
+        setCustomizableOptionFileFieldValue: PropTypes.func,
         setSelectedDropdownValue: PropTypes.func.isRequired,
         showNotification: PropTypes.func.isRequired,
         price_range: PriceType.isRequired,
         type_id: PropTypes.string.isRequired
+    };
+
+    static defaultProps = {
+        setCustomizableOptionFileFieldValue: () => null
     };
 
     state = {
@@ -192,8 +196,7 @@ export class ProductCustomizableOptionContainer extends PureComponent {
         }
 
         const reader = new FileReader();
-        // eslint-disable-next-line func-names
-        reader.onloadend = function () {
+        reader.onloadend = () => {
             setCustomizableOptionFileFieldValue(reader.result, option, name);
         };
 

--- a/packages/scandipwa/src/component/ProductInformation/ProductInformation.component.js
+++ b/packages/scandipwa/src/component/ProductInformation/ProductInformation.component.js
@@ -30,7 +30,7 @@ export class ProductInformation extends PureComponent {
         const { product: { description: { html } = {} } } = this.props;
 
         if (!html) {
-            return null;
+            return '';
         }
 
         const cleanDescription = html.replace(/<\/?[^>]+(>|$)/g, '');

--- a/packages/scandipwa/src/component/SharedWishlistItem/SharedWishlistItem.component.js
+++ b/packages/scandipwa/src/component/SharedWishlistItem/SharedWishlistItem.component.js
@@ -12,6 +12,7 @@
 import AddToCart from 'Component/AddToCart';
 import Field from 'Component/Field';
 import ProductCard from 'Component/ProductCard';
+import { OUT_OF_STOCK } from 'Component/ProductCard/ProductCard.config';
 import SourceWishlistItem from 'Component/WishlistItem/WishlistItem.component';
 
 import './SharedWishlistItem.style';
@@ -23,7 +24,10 @@ export class SharedWishlistItem extends SourceWishlistItem {
             product,
             quantity,
             changeQuantity,
-            configurableVariantIndex
+            configurableVariantIndex,
+            product: {
+                stock_status
+            } = {}
         } = this.props;
 
         return (
@@ -46,6 +50,7 @@ export class SharedWishlistItem extends SourceWishlistItem {
                   quantity={ quantity }
                   configurableVariantIndex={ configurableVariantIndex }
                   mix={ { block: 'WishlistItem', elem: 'AddToCart' } }
+                  disabled={ stock_status === OUT_OF_STOCK }
                 />
             </div>
         );

--- a/packages/scandipwa/src/store/ProductCompare/ProductCompare.dispatcher.js
+++ b/packages/scandipwa/src/store/ProductCompare/ProductCompare.dispatcher.js
@@ -223,10 +223,10 @@ export class ProductCompareDispatcher {
         dispatch(toggleLoader(true));
 
         try {
-            const { compareList: { items } } = await fetchQuery(
+            const { compareList } = await fetchQuery(
                 ProductCompareQuery.getCompareListIds(uid)
             );
-
+            const { items = [] } = compareList || {};
             const compareIds = items.map(({ product: { id } }) => id);
 
             dispatch(toggleLoader(false));


### PR DESCRIPTION
Fixes #2821
Fixed Add To Cart Button on Compare Page.
Added explicit `disabled` attribute so there is no magic why the button is disabled on the certain pages, but enabled on others.