### PR TITLE
GraphQL Log Proposal

### DIFF
--- a/packages/scandipwa/src/util/Query/PrepareDocument.js
+++ b/packages/scandipwa/src/util/Query/PrepareDocument.js
@@ -82,6 +82,18 @@ export const prepareRequest = (fields, type) => {
     // Wrap arguments with "()" and join using ","
     const formattedArgs = resolvedArgs.length ? `(${resolvedArgs.join(',')})` : '';
 
+    if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.log(
+            '%cGraphQL Request',
+            'background-color: #ff00ff; color: #ffffff; font-weight: bold; border-radius: 5px; padding: 2px 5px',
+            {
+                query: `${type}${formattedArgs}{${fieldStrings}}`,
+                variables
+            }
+        );
+    }
+
     return {
         // format like "query($var_1:String){test(arg: $var_1){id}}"
         query: `${type}${formattedArgs}{${fieldStrings}}`,


### PR DESCRIPTION
Sometimes we have to examine GraphQL requests outside the page context.
1. When we need to make a single request instead of loading all requests on page reload.
2. When we need to reduce the field amount in order to see less distracting info.
3. When the request is cached.

Normally the request can be seen on the Networks tab in the DevTools. But if the request is cached, we see only it's hash id.
In order to solve this issue, i add the code i provided in this PR.
After that i can see all requests in the console in the same order they appear on the Network tab.
Then i can find the request i need, copy it's query to the GraphQL Playground, prettify it, copy variables and launch it.
Pretty useful when investigating backend issues.

I'd like to add it to the project, so everyone can use it. And i don't have to write this code again and again when i need it. :)

The result can be seen on the screenshot.
![image](https://user-images.githubusercontent.com/73945186/124422980-edc13200-dd6c-11eb-8a10-54e3d6103d4b.png)
