### PR TITLE
#2856 - Fix trailing slash homepage navigation

### DIFF
--- a/packages/scandipwa/src/component/NavigationAbstract/NavigationAbstract.container.js
+++ b/packages/scandipwa/src/component/NavigationAbstract/NavigationAbstract.container.js
@@ -81,9 +81,11 @@ export class NavigationAbstractContainer extends PureComponent {
 
         const activeRoute = Object.keys(this.routeMap)
             .find((route) => (
-                route !== '/'
+                (route !== '/' && route !== '')
                 || pathname === appendWithStoreCode('/')
                 || pathname === '/'
+                || pathname === appendWithStoreCode('')
+                || pathname === ''
             ) && pathname.includes(route));
 
         return this.routeMap[activeRoute] || this.default_state;

--- a/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.component.js
+++ b/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.component.js
@@ -13,7 +13,10 @@ import NavigationAbstract from 'Component/NavigationAbstract/NavigationAbstract.
 import { DeviceType } from 'Type/Device';
 
 import {
-    ACCOUNT_TAB, CART_TAB, HOME_TAB, MENU_TAB
+    ACCOUNT_TAB,
+    CART_TAB,
+    HOME_TAB,
+    MENU_TAB
 } from './NavigationTabs.config';
 
 import './NavigationTabs.style';

--- a/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.container.js
+++ b/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.container.js
@@ -63,7 +63,8 @@ export class NavigationTabsContainer extends NavigationAbstractContainer {
         '/my-account': { name: ACCOUNT_TAB },
         '/checkout': { name: CHECKOUT_TAB, isHidden: true },
         '/cart': { name: CART_TAB },
-        '/': { name: HOME_TAB }
+        '/': { name: HOME_TAB },
+        '': { name: HOME_TAB }
     };
 
     containerFunctions = {
@@ -212,7 +213,6 @@ export class NavigationTabsContainer extends NavigationAbstractContainer {
 
     handleMobileRouteChange(history) {
         const {
-            // hideActiveOverlay,
             setNavigationState,
             navigationState: { name }
         } = this.props;

--- a/packages/scandipwa/src/util/Url/Url.js
+++ b/packages/scandipwa/src/util/Url/Url.js
@@ -68,9 +68,8 @@ export const appendWithStoreCode = (pathname) => {
     const { ConfigReducer: { base_link_url = window.location.href } = {} } = getStore().getState() || {};
     const { pathname: storePrefix } = new URL(base_link_url);
 
-    // ignore empty URLs
     if (!pathname) {
-        return pathname;
+        return storePrefix.slice(0, -1);
     }
 
     // match URLs which have the store code in pathname

--- a/packages/scandipwa/src/util/Url/Url.js
+++ b/packages/scandipwa/src/util/Url/Url.js
@@ -65,7 +65,7 @@ export const getUrlParam = (match, location) => {
  * @namespace Util/Url/appendWithStoreCode
  */
 export const appendWithStoreCode = (pathname) => {
-    const { ConfigReducer: { base_link_url = window.location.origin } = {} } = getStore().getState() || {};
+    const { ConfigReducer: { base_link_url = window.location.href } = {} } = getStore().getState() || {};
     const { pathname: storePrefix } = new URL(base_link_url);
 
     // ignore empty URLs


### PR DESCRIPTION
Fixes https://github.com/scandipwa/scandipwa/issues/2856

**Issue 1:** wrong active menu tab, if no trailing slash

**Reason for problem:** `/default` was not treated as Home page and logic failed back to default tab, which is MENU TAB.

**Issue 2:** wrong active menu tab when cache is empty.

**Reason for problem:** default store URL is received from the server, stored to Redux store and taken from there to decide what store prefix should be used. On first page load there is no such data in the store yet. As a fallback store prefix is detected from current URL, but this piece of logic skipped the important URI part (i.e. `/default`) and detected store prefix in a wrong way.