### PR TITLE
2899 Recently viewd widget undefined React fix

### DIFF
--- a/packages/scandipwa/src/component/RecentlyViewedWidget/RecentlyViewedWidget.component.js
+++ b/packages/scandipwa/src/component/RecentlyViewedWidget/RecentlyViewedWidget.component.js
@@ -10,7 +10,7 @@
  */
 
 import PropTypes from 'prop-types';
-import { Component, React } from 'react';
+import React, { Component } from 'react';
 
 import ProductCard from 'Component/ProductCard';
 import { ItemsType } from 'Type/ProductList';


### PR DESCRIPTION
**Original issue**: https://github.com/scandipwa/scandipwa/issues/2899

**Problem**: Component returns React as null

**Solution**: Changed import for React