### PR TITLE
#2468 Same results in search page as in search bar

### DIFF
--- a/packages/scandipwa/src/component/CategorySort/CategorySort.container.js
+++ b/packages/scandipwa/src/component/CategorySort/CategorySort.container.js
@@ -56,6 +56,10 @@ export class CategorySortContainer extends PureComponent {
                 asc: __('%s: Low to High', label),
                 desc: __('%s: High to Low', label)
             };
+        case 'none':
+            return {
+                asc: __('- None -')
+            };
         default:
             return {
                 asc: __('%s: Ascending', label),

--- a/packages/scandipwa/src/query/ProductList.query.js
+++ b/packages/scandipwa/src/query/ProductList.query.js
@@ -9,6 +9,7 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+import { NONE_SORT_OPTION_VALUE } from 'Route/SearchPage/SearchPage.config';
 import { CUSTOMER } from 'Store/MyAccount/MyAccount.dispatcher';
 import BrowserDatabase from 'Util/BrowserDatabase';
 import { Field, Fragment } from 'Util/Query';
@@ -122,7 +123,13 @@ export class ProductListQuery {
             },
             sort: {
                 type: 'ProductAttributeSortInput!',
-                handler: ({ sortKey, sortDirection }) => ({ [sortKey]: sortDirection || 'ASC' })
+                handler: ({ sortKey, sortDirection }) => {
+                    if (sortKey === NONE_SORT_OPTION_VALUE) {
+                        return {};
+                    }
+
+                    return { [sortKey]: sortDirection || 'ASC' };
+                }
             },
             filter: {
                 type: 'ProductAttributeFilterInput!',

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.config.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.config.js
@@ -1,0 +1,18 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export const NONE_SORT_OPTION_VALUE = 'none';
+
+export const NONE_SORT_OPTION = {
+    label: __('None'),
+    value: NONE_SORT_OPTION_VALUE
+};

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
@@ -27,6 +27,7 @@ import { debounce } from 'Util/Request';
 import { appendWithStoreCode } from 'Util/Url';
 
 import SearchPage from './SearchPage.component';
+import { NONE_SORT_OPTION } from './SearchPage.config';
 
 export const BreadcrumbsDispatcher = import(
     /* webpackMode: "lazy", webpackChunkName: "dispatchers" */
@@ -94,6 +95,11 @@ export class SearchPageContainer extends CategoryPageContainer {
     static defaultProps = {
         ...this.defaultProps,
         isSearchPage: true
+    };
+
+    config = {
+        sortKey: 'none',
+        sortDirection: 'ASC'
     };
 
     updateMeta() {
@@ -183,6 +189,21 @@ export class SearchPageContainer extends CategoryPageContainer {
         return query;
     }
 
+    getSortFields() {
+        const {
+            sortFields: {
+                options = []
+            } = {}
+        } = this.props;
+
+        return {
+            options: [
+                NONE_SORT_OPTION,
+                ...options
+            ]
+        };
+    }
+
     render() {
         return (
             <SearchPage
@@ -191,6 +212,7 @@ export class SearchPageContainer extends CategoryPageContainer {
               { ...this.containerProps() }
               // addded here to not override the container props
               search={ this.getSearchParam() }
+              sortFields={ this.getSortFields() }
             />
         );
     }


### PR DESCRIPTION
Original issue: https://github.com/scandipwa/scandipwa/issues/2468

In this PR:
* Added option to remove sort from search page to mach same results as in search bar
* Set default search result sort as 'none'