### PR TITLE
#2863 Correct coupon field colors.

### DIFF
--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.component.js
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.component.js
@@ -17,7 +17,6 @@ import { VALIDATION_STATUS } from 'Component/Field/Field.config';
 import Loader from 'Component/Loader';
 
 import './CartCoupon.style';
-import { VALIDATION_STATUS } from 'Component/Field/Field.config';
 
 /** @namespace Component/CartCoupon/Component */
 export class CartCoupon extends PureComponent {

--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.component.js
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.component.js
@@ -13,9 +13,11 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import Field from 'Component/Field';
+import { VALIDATION_STATUS } from 'Component/Field/Field.config';
 import Loader from 'Component/Loader';
 
 import './CartCoupon.style';
+import { VALIDATION_STATUS } from 'Component/Field/Field.config';
 
 /** @namespace Component/CartCoupon/Component */
 export class CartCoupon extends PureComponent {
@@ -78,6 +80,7 @@ export class CartCoupon extends PureComponent {
 
     renderApplyCoupon() {
         const { enteredCouponCode } = this.state;
+        const { skip, success } = VALIDATION_STATUS;
 
         return (
             <>
@@ -88,6 +91,7 @@ export class CartCoupon extends PureComponent {
                   value={ enteredCouponCode }
                   placeholder={ __('Your discount code') }
                   onChange={ this.handleCouponCodeChange }
+                  customValidationStatus={ !enteredCouponCode ? skip : success }
                   mix={ { block: 'CartCoupon', elem: 'Input' } }
                   aria-label={ __('Your discount code') }
                 />

--- a/packages/scandipwa/src/component/Field/Field.config.js
+++ b/packages/scandipwa/src/component/Field/Field.config.js
@@ -20,3 +20,9 @@ export const SELECT_TYPE = 'select';
 export const FILE_TYPE = 'file';
 
 export const ENTER_KEY_CODE = 13;
+
+export const VALIDATION_STATUS = {
+    success: true,
+    error: false,
+    skip: 'skip'
+};

--- a/packages/scandipwa/src/component/Field/Field.container.js
+++ b/packages/scandipwa/src/component/Field/Field.container.js
@@ -24,7 +24,8 @@ import {
     RADIO_TYPE,
     SELECT_TYPE,
     TEXT_TYPE,
-    TEXTAREA_TYPE
+    TEXTAREA_TYPE,
+    VALIDATION_STATUS
 } from './Field.config';
 
 /** @namespace Component/Field/Container */
@@ -59,7 +60,7 @@ export class FieldContainer extends PureComponent {
         max: PropTypes.number,
         validation: PropTypes.arrayOf(PropTypes.string),
         message: PropTypes.string,
-        customValidationStatus: PropTypes.bool,
+        customValidationStatus: PropTypes.oneOf(Object.values(VALIDATION_STATUS)),
         id: PropTypes.string,
         formRef: PropTypes.oneOfType([
             PropTypes.func,


### PR DESCRIPTION
Original issue: https://github.com/scandipwa/scandipwa/issues/2863

In this PR:
* Added new option for field to hide both valid and invalid validation statues by passing to ```customValidationStatus``` value ```VALIDATION_STATUS.skip```
* Changed logic in coupon field to show valid field only when something is entered otherwise no color effect, via new validation status