### PR TITLE
#2923 - fix swatches not selecting

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -112,14 +112,24 @@ export class ProductCard extends Component {
     imageRef = createRef();
 
     shouldComponentUpdate(nextProps) {
-        const { product, device, productOrVariant } = this.props;
+        const {
+            product,
+            device,
+            productOrVariant,
+            parameters
+        } = this.props;
+
         const {
             product: nextProduct,
             device: nextDevice,
-            productOrVariant: nextProductOrVariant
+            productOrVariant: nextProductOrVariant,
+            parameters: nextParameters
         } = nextProps;
 
-        return product !== nextProduct || device !== nextDevice || productOrVariant !== nextProductOrVariant;
+        return product !== nextProduct
+            || device !== nextDevice
+            || productOrVariant !== nextProductOrVariant
+            || parameters !== nextParameters;
     }
 
     registerSharedElement = () => {


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/2923

Problem appeared after migrating from `PureComponent` to `Component` with `componentShouldUpdate`. It turned out that `componentShouldUpdate` had "update component when selected configurable options changed" condition missing.