### PR TITLE
#2925 - error on opening secondary viewed products

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -416,6 +416,10 @@
         }
     }
 
+    &_name_popup {
+        z-index: 400;
+    }
+
     &-MinicartIcon {
         @include minicart-button;
 

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -215,7 +215,7 @@ export class ProductCardContainer extends PureComponent {
     }
 
     isConfigurableProductOutOfStock() {
-        const { product: { variants }, isPreview } = this.props;
+        const { product: { variants = [] }, isPreview } = this.props;
 
         if (isPreview) {
             return true;


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/2925

Why problem appears: such data as product variants is not stored in localstorage, some time is needed for secondary product data to be requested from the server. Error `Cannot read property filter of undefined` appears due to variants being undefined during this time. So I'm just setting default value of variants to empty array to avoid errors while data is loading. 

Also fix missing curly brace in this PR.