### PR TITLE
2856/fix store url unneeded trim

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -418,6 +418,7 @@
 
     &_name_popup {
         z-index: 400;
+    }
 
     &-MinicartIcon {
         @include minicart-button;

--- a/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.component.js
+++ b/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.component.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import Link from 'Component/Link';
+import { STATUS_EXPIRED } from 'Component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.config';
 import { downloadableType } from 'Type/Account';
 
 import './MyAccountDownloadableTableRow.style';
@@ -42,33 +43,30 @@ export class MyAccountDownloadableTableRowComponent extends PureComponent {
         );
     }
 
-    renderTitle() {
+    renderLink() {
         const {
             order: {
                 download_url,
                 link_title,
-                title,
-                downloads
+                downloads,
+                status_label
             },
             isOpenInNewTab
         } = this.props;
 
-        if (!download_url || !downloads) {
-            return title;
+        if (!download_url || !downloads || status_label === STATUS_EXPIRED) {
+            return null;
         }
 
         return (
-            <>
-                { title }
-                <Link
-                  to={ download_url }
-                  block="MyAccountDownloadTableRow"
-                  elem="Link"
-                  isOpenInNewTab={ isOpenInNewTab }
-                >
-                    { link_title }
-                </Link>
-            </>
+            <Link
+              to={ download_url }
+              block="MyAccountDownloadTableRow"
+              elem="DownloadLink"
+              isOpenInNewTab={ isOpenInNewTab }
+            >
+                { link_title }
+            </Link>
         );
     }
 
@@ -77,11 +75,9 @@ export class MyAccountDownloadableTableRowComponent extends PureComponent {
             order: {
                 order_id,
                 downloads,
-                download_url,
                 created_at,
                 title,
-                status_label = '',
-                link_title
+                status_label = ''
             } = {}
         } = this.props;
 
@@ -91,14 +87,7 @@ export class MyAccountDownloadableTableRowComponent extends PureComponent {
                 <td>{ created_at }</td>
                 <td>
                     { title }
-                    <a
-                      href={ download_url }
-                      download
-                      block="MyAccountOrderTableRow"
-                      elem="DownloadLink"
-                    >
-                        { link_title }
-                    </a>
+                    { this.renderLink() }
                 </td>
                 <td block="MyAccountDownloadTableRow" elem="Status">{ status_label }</td>
                 <td>{ downloads }</td>

--- a/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.config.js
+++ b/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.config.js
@@ -1,0 +1,14 @@
+/* eslint-disable import/prefer-default-export */
+
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export const STATUS_EXPIRED = 'expired';

--- a/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.style.scss
+++ b/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.style.scss
@@ -29,4 +29,8 @@
             color: var(--link-hover);
         }
     }
+
+    &-DownloadLink {
+        margin-inline-start: 8px;
+    }
 }

--- a/packages/scandipwa/src/route/MyAccount/MyAccount.component.js
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.component.js
@@ -64,7 +64,11 @@ export class MyAccount extends Component {
         onSignIn: PropTypes.func.isRequired,
         onSignOut: PropTypes.func.isRequired,
         isEditingActive: PropTypes.bool.isRequired,
-        subHeading: PropTypes.func.isRequired
+        subHeading: PropTypes.string
+    };
+
+    static defaultProps = {
+        subHeading: ''
     };
 
     renderMap = {

--- a/packages/scandipwa/src/util/Url/Url.js
+++ b/packages/scandipwa/src/util/Url/Url.js
@@ -55,6 +55,9 @@ export const getUrlParam = (match, location) => {
     return currentUrl.replace(baseUrl, '').replace(/^\/*/, '');
 };
 
+/**  Util/Url/trimEndSlash */
+export const trimEndSlash = (str) => (str.endsWith('/') ? str.slice(0, -1) : str);
+
 /**
  * Append store code to URL
  * @param {String} pathname the URL to append store code to
@@ -65,7 +68,7 @@ export const appendWithStoreCode = (pathname) => {
     const { pathname: storePrefix } = new URL(base_link_url);
 
     if (!pathname) {
-        return storePrefix.slice(0, -1);
+        return trimEndSlash(storePrefix);
     }
 
     // match URLs which have the store code in pathname
@@ -74,9 +77,7 @@ export const appendWithStoreCode = (pathname) => {
     }
 
     // trim the last slash from URL, and append it to pathname
-    return storePrefix.slice(0, -1).concat(
-        !pathname.startsWith('/') ? `/${ pathname }` : pathname
-    );
+    return trimEndSlash(storePrefix).concat(!pathname.startsWith('/') ? `/${ pathname }` : pathname);
 };
 
 /**


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/2856

Problem was that `/default` was trimmed to `/defaul`, which is definitely wrong behaviour. And `isHomePageUrl` detection failed, as `/defaul` doesn't equal `/default`.