### PR TITLE
#2896 Fixed import order for overlays

### DIFF
--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -22,7 +22,7 @@ import { DeviceType } from 'Type/Device';
 import { TotalsType } from 'Type/MiniCart';
 import { formatPrice } from 'Util/Price';
 
-import './CartOverlay.style';
+import(/* webpackChunkName: "overlays" */ './CartOverlay.style');
 
 /** @namespace Component/CartOverlay/Component */
 export class CartOverlay extends PureComponent {

--- a/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
+++ b/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
@@ -20,7 +20,7 @@ import ResetButton from 'Component/ResetButton';
 
 import { CATEGORY_FILTER_OVERLAY_ID } from './CategoryFilterOverlay.config';
 
-import './CategoryFilterOverlay.style';
+import(/* webpackChunkName: "overlays-category" */ './CategoryFilterOverlay.style');
 
 /** @namespace Component/CategoryFilterOverlay/Component */
 export class CategoryFilterOverlay extends PureComponent {

--- a/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.component.js
+++ b/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.component.js
@@ -33,7 +33,7 @@ import {
     STATE_SIGN_IN
 } from './MyAccountOverlay.config';
 
-import './MyAccountOverlay.style';
+import(/* webpackChunkName: "overlays" */ './MyAccountOverlay.style');
 
 /** @namespace Component/MyAccountOverlay/Component */
 export class MyAccountOverlay extends PureComponent {

--- a/packages/scandipwa/src/component/Overlay/Overlay.component.js
+++ b/packages/scandipwa/src/component/Overlay/Overlay.component.js
@@ -19,7 +19,7 @@ import { ChildrenType, MixType } from 'Type/Common';
 import { DeviceType } from 'Type/Device';
 import { toggleScroll } from 'Util/Browser';
 
-import './Overlay.style';
+import(/* webpackChunkName: "overlay" */ './Overlay.style');
 
 /** @namespace Component/Overlay/Component */
 export class Overlay extends PureComponent {

--- a/packages/scandipwa/src/component/PopupSuspense/PopupSuspense.component.js
+++ b/packages/scandipwa/src/component/PopupSuspense/PopupSuspense.component.js
@@ -20,8 +20,8 @@ import { OVERLAY_PLACEHOLDER } from './PopupSuspense.config';
 
 import './PopupSuspense.style';
 // Import styles from different bundles
-import 'Component/CartOverlay/CartOverlay.style';
-import 'Component/MyAccountOverlay/MyAccountOverlay.style';
+import(/* webpackChunkName: "overlays" */ 'Component/CartOverlay/CartOverlay.style');
+import(/* webpackChunkName: "overlays" */ 'Component/MyAccountOverlay/MyAccountOverlay.style');
 
 /** @namespace Component/PopupSuspense/Component */
 export class PopupSuspense extends PureComponent {

--- a/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.component.js
+++ b/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.component.js
@@ -21,7 +21,7 @@ import {
     SEARCH_TIMEOUT
 } from './SearchOverlay.config';
 
-import './SearchOverlay.style';
+import(/* webpackChunkName: "overlays" */ './SearchOverlay.style');
 
 /** @namespace Component/SearchOverlay/Component */
 export class SearchOverlay extends PureComponent {

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
@@ -10,41 +10,41 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
- import PropTypes from 'prop-types';
- import { lazy, PureComponent, Suspense } from 'react';
- 
- import CategoryDetails from 'Component/CategoryDetails';
- import { CATEGORY_FILTER_OVERLAY_ID } from 'Component/CategoryFilterOverlay/CategoryFilterOverlay.config';
- import CategoryItemsCount from 'Component/CategoryItemsCount';
- import CategoryProductList from 'Component/CategoryProductList';
- import CategorySort from 'Component/CategorySort';
- import ContentWrapper from 'Component/ContentWrapper';
- import Html from 'Component/Html';
- import Image from 'Component/Image/Image.container';
- import Loader from 'Component/Loader';
- import grid from 'Style/icons/grid.svg';
- import list from 'Style/icons/list.svg';
- import { CategoryTreeType } from 'Type/Category';
- import { DeviceType } from 'Type/Device';
- import { FilterInputType, FilterType } from 'Type/ProductList';
- import { isCrawler, isSSR } from 'Util/Browser';
- import BrowserDatabase from 'Util/BrowserDatabase';
- 
- import filterIcon from '../../style/icons/filter.svg';
- import {
-     DISPLAY_MODE_BOTH,
-     DISPLAY_MODE_CMS_BLOCK,
-     DISPLAY_MODE_PRODUCTS,
-     GRID_LAYOUT,
-     LAYOUT_KEY,
-     LIST_LAYOUT
- } from './CategoryPage.config';
- 
- import './CategoryPage.style';
- 
- export const CategoryFilterOverlay = lazy(() => import(
-     /* webpackMode: "lazy", webpackChunkName: "overlays-category" */ 'Component/CategoryFilterOverlay'
- ));
+import PropTypes from 'prop-types';
+import { lazy, PureComponent, Suspense } from 'react';
+
+import CategoryDetails from 'Component/CategoryDetails';
+import { CATEGORY_FILTER_OVERLAY_ID } from 'Component/CategoryFilterOverlay/CategoryFilterOverlay.config';
+import CategoryItemsCount from 'Component/CategoryItemsCount';
+import CategoryProductList from 'Component/CategoryProductList';
+import CategorySort from 'Component/CategorySort';
+import ContentWrapper from 'Component/ContentWrapper';
+import Html from 'Component/Html';
+import Image from 'Component/Image/Image.container';
+import Loader from 'Component/Loader';
+import grid from 'Style/icons/grid.svg';
+import list from 'Style/icons/list.svg';
+import { CategoryTreeType } from 'Type/Category';
+import { DeviceType } from 'Type/Device';
+import { FilterInputType, FilterType } from 'Type/ProductList';
+import { isCrawler, isSSR } from 'Util/Browser';
+import BrowserDatabase from 'Util/BrowserDatabase';
+
+import filterIcon from '../../style/icons/filter.svg';
+import {
+    DISPLAY_MODE_BOTH,
+    DISPLAY_MODE_CMS_BLOCK,
+    DISPLAY_MODE_PRODUCTS,
+    GRID_LAYOUT,
+    LAYOUT_KEY,
+    LIST_LAYOUT
+} from './CategoryPage.config';
+
+import './CategoryPage.style';
+
+export const CategoryFilterOverlay = lazy(() => import(
+    /* webpackMode: "lazy", webpackChunkName: "overlays-category" */ 'Component/CategoryFilterOverlay'
+));
 
 /** @namespace Route/CategoryPage/Component */
 export class CategoryPage extends PureComponent {

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
@@ -10,37 +10,41 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-import PropTypes from 'prop-types';
-import { PureComponent } from 'react';
-
-import CategoryDetails from 'Component/CategoryDetails';
-import CategoryFilterOverlay from 'Component/CategoryFilterOverlay';
-import { CATEGORY_FILTER_OVERLAY_ID } from 'Component/CategoryFilterOverlay/CategoryFilterOverlay.config';
-import CategoryItemsCount from 'Component/CategoryItemsCount';
-import CategoryProductList from 'Component/CategoryProductList';
-import CategorySort from 'Component/CategorySort';
-import ContentWrapper from 'Component/ContentWrapper';
-import Html from 'Component/Html';
-import Image from 'Component/Image/Image.container';
-import grid from 'Style/icons/grid.svg';
-import list from 'Style/icons/list.svg';
-import { CategoryTreeType } from 'Type/Category';
-import { DeviceType } from 'Type/Device';
-import { FilterInputType, FilterType } from 'Type/ProductList';
-import { isCrawler, isSSR } from 'Util/Browser';
-import BrowserDatabase from 'Util/BrowserDatabase';
-
-import filterIcon from '../../style/icons/filter.svg';
-import {
-    DISPLAY_MODE_BOTH,
-    DISPLAY_MODE_CMS_BLOCK,
-    DISPLAY_MODE_PRODUCTS,
-    GRID_LAYOUT,
-    LAYOUT_KEY,
-    LIST_LAYOUT
-} from './CategoryPage.config';
-
-import './CategoryPage.style';
+ import PropTypes from 'prop-types';
+ import { lazy, PureComponent, Suspense } from 'react';
+ 
+ import CategoryDetails from 'Component/CategoryDetails';
+ import { CATEGORY_FILTER_OVERLAY_ID } from 'Component/CategoryFilterOverlay/CategoryFilterOverlay.config';
+ import CategoryItemsCount from 'Component/CategoryItemsCount';
+ import CategoryProductList from 'Component/CategoryProductList';
+ import CategorySort from 'Component/CategorySort';
+ import ContentWrapper from 'Component/ContentWrapper';
+ import Html from 'Component/Html';
+ import Image from 'Component/Image/Image.container';
+ import Loader from 'Component/Loader';
+ import grid from 'Style/icons/grid.svg';
+ import list from 'Style/icons/list.svg';
+ import { CategoryTreeType } from 'Type/Category';
+ import { DeviceType } from 'Type/Device';
+ import { FilterInputType, FilterType } from 'Type/ProductList';
+ import { isCrawler, isSSR } from 'Util/Browser';
+ import BrowserDatabase from 'Util/BrowserDatabase';
+ 
+ import filterIcon from '../../style/icons/filter.svg';
+ import {
+     DISPLAY_MODE_BOTH,
+     DISPLAY_MODE_CMS_BLOCK,
+     DISPLAY_MODE_PRODUCTS,
+     GRID_LAYOUT,
+     LAYOUT_KEY,
+     LIST_LAYOUT
+ } from './CategoryPage.config';
+ 
+ import './CategoryPage.style';
+ 
+ export const CategoryFilterOverlay = lazy(() => import(
+     /* webpackMode: "lazy", webpackChunkName: "overlays-category" */ 'Component/CategoryFilterOverlay'
+ ));
 
 /** @namespace Route/CategoryPage/Component */
 export class CategoryPage extends PureComponent {
@@ -196,6 +200,14 @@ export class CategoryPage extends PureComponent {
         );
     }
 
+    renderFilterPlaceholder() {
+        return (
+            <div block="CategoryPage" elem="FilterPlaceholder">
+                <Loader isLoading />
+            </div>
+        );
+    }
+
     renderFilterOverlay() {
         const {
             filters,
@@ -210,12 +222,14 @@ export class CategoryPage extends PureComponent {
         }
 
         return (
-            <CategoryFilterOverlay
-              availableFilters={ filters }
-              customFiltersValues={ selectedFilters }
-              isMatchingInfoFilter={ isMatchingInfoFilter }
-              isCategoryAnchor={ !!is_anchor }
-            />
+            <Suspense fallback={ this.renderFilterPlaceholder() }>
+                <CategoryFilterOverlay
+                  availableFilters={ filters }
+                  customFiltersValues={ selectedFilters }
+                  isMatchingInfoFilter={ isMatchingInfoFilter }
+                  isCategoryAnchor={ !!is_anchor }
+                />
+            </Suspense>
         );
     }
 

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.style.scss
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.style.scss
@@ -78,6 +78,18 @@
 
         @include desktop {
             display: none;
+
+            &Placeholder {
+                position: relative;
+                grid-row: 1/6;
+                width: 100%;
+                opacity: 1;
+                pointer-events: all;
+                display: flex;
+                flex-direction: column;
+                height: auto;
+                overflow: visible;
+            }
         }
     }
 


### PR DESCRIPTION
**Original issues:**
* https://github.com/scandipwa/scandipwa/issues/2896
* https://github.com/scandipwa/scandipwa/issues/2933

**Problem:**
* Chunks contain multiple instances of Overlay style, so when switching to compare page _(as example)_ new overlay style is loaded and then when going back to PLP ```.Overlay``` takes priority over ```.OverlayFilterContainer``` as it's newer.

**In this PR:**
* Moved Overlay style to new chunk _(```overlay```)_ so that it is only loaded once
* Moved other overlay styles to chunks: ```overlays``` and ```overlays-category``` so that they are loaded after ```overlay``` chunk
* Moved ```CategoryFilterOverlay``` to chunk ```overlays-categry```, so that it is loaded style first.
* Added placeholder to fix glitch where overlay style is loaded, but  CategoryFilterOverlay.style & component is still loading.