### PR TITLE
fix compare list: price column mobile scroll

### DIFF
--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.component.js
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.component.js
@@ -129,16 +129,16 @@ export class ProductCompare extends Component {
                 </div>
                 <div
                   block="ProductCompare"
-                  elem="Row"
-                  mix={ { block: 'ProductPriceRow' } }
-                >
-                    { this.renderPriceLabel() }
-                    { this.renderProductPrices() }
-                </div>
-                <div
-                  block="ProductCompare"
                   elem="AttributeTable"
                 >
+                    <div
+                      block="ProductCompareAttributeRow"
+                    >
+                        { this.renderPriceLabel() }
+                        <div block="ProductCompareAttributeRow" elem="Values">
+                            { this.renderProductPrices() }
+                        </div>
+                    </div>
                     { this.renderAttributes() }
                 </div>
             </div>

--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.style.scss
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.style.scss
@@ -82,7 +82,6 @@
         flex: 1;
         display: flex;
         align-items: center;
-        padding-inline-end: var(--product-compare-sidebar-padding);
         position: sticky;
         inset-inline-start: 0;
         max-width: calc(var(--product-compare-sidebar-width) + var(--product-compare-item-gap));
@@ -93,6 +92,7 @@
 
         .Button {
             width: 100%;
+            margin-inline-end: var(--product-compare-sidebar-padding);
         }
     }
 
@@ -101,6 +101,11 @@
         width: 100%;
         border-block-start: 1px solid var(--secondary-base-color);
         padding-block: 24px;
+    }
+
+    &-RowPrices {
+        min-width: fit-content;
+        width: 100%;
     }
 
     .PriceLabel {


### PR DESCRIPTION
Issue: https://docs.google.com/spreadsheets/d/1xxtBOYtJdW53N-Gr7OUVnFO7qjnE0bNZKYLaMgIrO6w/edit?ts=60defb5b#gid=2035403278

Problem: Prices don't start from the 1st column in mobile view, which leads prices to be shown below wrong product titles (prices are shifted right by 1 cell)