### PR TITLE
getContainerProps utility for simple forwarding of props from container to component

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -108,6 +108,9 @@
         "env": {
             "browser": true
         },
+        "ignorePatterns": [
+            "**/*.d.ts"
+        ],
         "parser": "babel-eslint",
         "globals": {
             "window": true,

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -101,9 +101,6 @@
         ]
     },
     "eslintConfig": {
-        "ignorePatterns": [
-            "**/*.d.ts"
-        ],
         "extends": [
             "airbnb",
             "plugin:array-func/recommended"
@@ -454,5 +451,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://scandipwapmrev.indvp.com/"
+    "proxy": "https://40kskudemo.scandipwa.com/"
 }

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -101,6 +101,9 @@
         ]
     },
     "eslintConfig": {
+        "ignorePatterns": [
+            "**/*.d.ts"
+        ],
         "extends": [
             "airbnb",
             "plugin:array-func/recommended"

--- a/packages/scandipwa/src/util/ContainerProps/ContainerProps.d.ts
+++ b/packages/scandipwa/src/util/ContainerProps/ContainerProps.d.ts
@@ -1,0 +1,7 @@
+/* eslint-disable */
+import React from 'react';
+
+export function getContainerProps<
+    T extends React.ComponentClass | string[],
+    K extends Record<string, unknown>[]
+>(componentOrIncludedPropsArray: T, ...props: K): { [G in keyof K]: K[G] }

--- a/packages/scandipwa/src/util/ContainerProps/ContainerProps.js
+++ b/packages/scandipwa/src/util/ContainerProps/ContainerProps.js
@@ -1,0 +1,36 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export const getContainerProps = (componentOrIncludedPropsArray, ...props) => {
+    const allPropsObject = props.reduce((acc, prop) => ({
+        ...acc,
+        ...prop
+    }), {});
+
+    const propsFilter = (prop) => Object.prototype.hasOwnProperty.call(allPropsObject, prop);
+    const propsReducer = (acc, val) => ({
+        ...acc,
+        [val]: allPropsObject[val]
+    });
+
+    if (Array.isArray(componentOrIncludedPropsArray)) {
+        return componentOrIncludedPropsArray
+            .filter(propsFilter)
+            .reduce(propsReducer, {});
+    }
+
+    const { propTypes: requiredComponentProps = {} } = componentOrIncludedPropsArray || {};
+
+    return Object.keys(requiredComponentProps)
+        .filter(propsFilter)
+        .reduce(propsReducer, {});
+};

--- a/packages/scandipwa/src/util/ContainerProps/index.js
+++ b/packages/scandipwa/src/util/ContainerProps/index.js
@@ -1,0 +1,12 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export * from './ContainerProps';


### PR DESCRIPTION
This utility is aimed to simplify the forwarding of props from container to component.

So instead of forwarding it [like this](https://github.com/AleksandrsKondratjevs/base-theme/blob/issue-eslintEnable/packages/scandipwa/src/route/Checkout/Checkout.container.js#L383):
![Screenshot_20210726_182941](https://user-images.githubusercontent.com/18352350/127016211-ceed49c9-9869-44ac-adb3-f8ebc09ee00d.png)

> This is actual code from https://github.com/scandipwa/scandipwa/pull/2987 PR.

We can do it like this:
![Screenshot_20210726_183318](https://user-images.githubusercontent.com/18352350/127016706-dc829c2d-07d7-49aa-acf2-0b317e6d14c4.png)

---

Regarding implementation:

`getContainerProps` is accepting component class or array as the first argument.

If you pass a component class, it will look at its `propTypes` static property and get necessary props for component from container props/state/whatever you will pass as the second/third/e.t.c argument.

If you pass an array of strings as the first argument, it will use it to get props from the following props.

---

The final utility name and API can vary, it's open to discussion.

But the main point is: automate what you can automate (c).
