### PR TITLE
#2958 - remove unneeded scroll to top

### DIFF
--- a/packages/scandipwa/src/component/ProductList/ProductList.component.js
+++ b/packages/scandipwa/src/component/ProductList/ProductList.component.js
@@ -75,7 +75,6 @@ export class ProductList extends PureComponent {
     componentDidUpdate(prevProps) {
         const { isWidget, currentPage, device } = this.props;
         const { currentPage: prevCurrentPage } = prevProps;
-        window.scrollTo({ top: 0 });
 
         // Scroll up on page change, ignore widgets
         if (prevCurrentPage !== currentPage && !isWidget && !device.isMobile) {


### PR DESCRIPTION
Revert https://github.com/scandipwa/scandipwa/pull/2809/files.

(Do `window.scrollTo({ top: 0 });` on every `componentDidUpdate` is not a good idea).

Fixes https://github.com/scandipwa/scandipwa/issues/2924, https://github.com/scandipwa/scandipwa/issues/2958 and https://github.com/scandipwa/scandipwa/issues/2968.