### PR TITLE
#2069 Compare page wishlist btn layout style fix via chunk order

### DIFF
--- a/packages/scandipwa/src/component/AddToCart/AddToCart.component.js
+++ b/packages/scandipwa/src/component/AddToCart/AddToCart.component.js
@@ -19,7 +19,7 @@ import { MixType } from 'Type/Common';
 import { LayoutType } from 'Type/Layout';
 import { ProductType } from 'Type/ProductList';
 
-import './AddToCart.style';
+import(/* webpackChunkName: "cart" */ './AddToCart.style');
 
 /**
  * Button for adding product to Cart

--- a/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.component.js
+++ b/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.component.js
@@ -25,7 +25,7 @@ import {
     PRODUCT_ADD_TO_CART_DEFAULT_VARIANT_INDEX
 } from './ProductCompareItem.config';
 
-import './ProductCompareItem.style';
+import(/* webpackChunkName: "cart" */ './ProductCompareItem.style');
 
 /** @namespace Component/ProductCompareItem/Component */
 export class ProductCompareItem extends PureComponent {


### PR DESCRIPTION
Original issue:
* https://github.com/scandipwa/scandipwa/issues/2069

Problem:
* Add to cart style is located in multiple chunks. On page change it is loaded again, thus overriding compare pages add to cart style.

In this PR:
* Moved Add to cart style to chunk 'cart' so that it is loaded only once.
* Moved Compare style to chunk 'cart' so that it is loaded after add to cart style.