### PR TITLE
#2977 Double sample & link title in PDP

### DIFF
--- a/packages/scandipwa/src/component/ExpandableContent/ExpandableContent.component.js
+++ b/packages/scandipwa/src/component/ExpandableContent/ExpandableContent.component.js
@@ -15,7 +15,8 @@ import TextPlaceholder from 'Component/TextPlaceholder';
 import { ChildrenType, MixType } from 'Type/Common';
 import { getFixedElementHeight } from 'Util/CSS';
 
-import './ExpandableContent.style';
+import(/* webpackChunkName: "expandable-content" */ './ExpandableContent.style');
+
 /** @namespace Component/ExpandableContent/Component */
 export class ExpandableContent extends PureComponent {
     static propTypes = {

--- a/packages/scandipwa/src/component/MyAccountTabList/MyAccountTabList.component.js
+++ b/packages/scandipwa/src/component/MyAccountTabList/MyAccountTabList.component.js
@@ -17,7 +17,7 @@ import MyAccountTabListItem from 'Component/MyAccountTabListItem';
 import { activeTabType, tabMapType } from 'Type/Account';
 import { isSignedIn } from 'Util/Auth';
 
-import './MyAccountTabList.style';
+import(/* webpackChunkName: "expandable-content" */ './MyAccountTabList.style');
 
 /** @namespace Component/MyAccountTabList/Component */
 export class MyAccountTabList extends PureComponent {

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
@@ -16,7 +16,7 @@ import Field from 'Component/Field';
 import Link from 'Component/Link';
 import { formatPrice } from 'Util/Price';
 
-import './ProductDownloadableLinks.style.scss';
+import(/* webpackChunkName: "expandable-content" */ './ProductDownloadableLinks.style');
 
 /** @namespace Component/ProductDownloadableLinks/Component */
 export class ProductDownloadableLinks extends PureComponent {

--- a/packages/scandipwa/src/component/ProductDownloadableSamples/ProductDownloadableSamples.component.js
+++ b/packages/scandipwa/src/component/ProductDownloadableSamples/ProductDownloadableSamples.component.js
@@ -15,7 +15,7 @@ import ExpandableContent from 'Component/ExpandableContent';
 import Link from 'Component/Link';
 import { DownloadableSamplesType } from 'Type/ProductList';
 
-import './ProductDownloadableSamples.style.scss';
+import(/* webpackChunkName: "expandable-content" */ './ProductDownloadableSamples.style');
 
 /** @namespace Component/ProductDownloadableSamples/Component */
 export class ProductDownloadableSamples extends PureComponent {


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/2977

**Problem:**
* Expandable content style is located in multiple chunks, thus on page switch expandable content style overrides previous style.

**In this PR:**
* Moved expandable content into single chunk 'expandable-content', thus only loading it once + fixing order for styles.
