### PR TITLE
#3026 Mobile my downloadables horizontal scroll

### DIFF
--- a/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.component.js
+++ b/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.component.js
@@ -17,6 +17,8 @@ import MyAccountDownloadableTableRow from 'Component/MyAccountDownloadableTableR
 import MyAccountOrderPopup from 'Component/MyAccountOrderPopup';
 import { downloadableType } from 'Type/Account';
 
+import './MyAccountDownloadable.style';
+
 /** @namespace Component/MyAccountDownloadable/Component */
 export class MyAccountDownloadableComponent extends Component {
     static propTypes = {

--- a/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.style.scss
+++ b/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.style.scss
@@ -9,8 +9,8 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-@include mobile {
-    .MyDownloadableOrders {
+.MyDownloadableOrders {
+    @include mobile {
         overflow-x: scroll;
         -webkit-overflow-scrolling: touch;
         width: calc(100vw - 24px);

--- a/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.style.scss
+++ b/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.style.scss
@@ -1,0 +1,18 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+@include mobile {
+    .MyDownloadableOrders {
+        overflow-x: scroll;
+        -webkit-overflow-scrolling: touch;
+        width: calc(100vw - 24px);
+    }
+}

--- a/packages/scandipwa/src/component/MyAccountMyOrders/MyAccountMyOrders.style.scss
+++ b/packages/scandipwa/src/component/MyAccountMyOrders/MyAccountMyOrders.style.scss
@@ -38,11 +38,3 @@
         }
     }
 }
-
-.MyDownloadableOrders {
-    @include mobile {
-        overflow-x: scroll;
-        -webkit-overflow-scrolling: touch;
-        width: calc(100vw - var(--my-account-wrapper-padding-mobile) * 2);
-    }
-}


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3026

**Problem:**
* Style for downloadable was in order component, thus it was only loaded when opening my orders tab.
* Style was outdated.

**In this PR:**
* Moved style to separate file
* Fixed outdated values