### PR TITLE
#3031 Fix long name for wishlist item in mobile

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -132,6 +132,10 @@
             text-overflow: ellipsis;
             overflow: hidden;
             white-space: nowrap;
+
+            @include mobile {
+                white-space: normal;
+            }
         }
     }
 

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -135,6 +135,7 @@
 
             @include mobile {
                 white-space: normal;
+                max-width: calc(100% - 24px);
             }
         }
     }


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3031

**Problem:**
* Long names aren't wrapped on mobile, thus creates page wide horizontal scroll.
