### PR TITLE
#3036 MyWishlist short name breaks by itself

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
@@ -299,7 +299,7 @@ export class WishlistItem extends PureComponent {
                 ), { block: 'WishlistItem', elem: 'ImageWrapper' }) }
                 <div block="WishlistItem" elem="InformationWrapper">
                     <div block="WishlistItem" elem="RowWrapper">
-                        <div>
+                        <div block="WishlistItem" elem="NameAndOptions">
                             { this.renderName() }
                             { this.renderOptions() }
                         </div>

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -339,4 +339,10 @@
         font-size: 12px;
         min-height: 20px;
     }
+
+    &-NameAndOptions {
+        @include mobile {
+            width: 100%;
+        }
+    }
 }


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3036

**Problem:**
* DIV containing name & options isn't occupying whole given space.

**In this PR:**
* Added class to DIV containing name & options so that it can be targeted via sass
* Added style rule to occupy 100% of given space.