### PR TITLE
#3035 Wishlist on moblie - image too large

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -35,7 +35,7 @@ import {
 
 import { OUT_OF_STOCK, TIER_PRICES } from './ProductCard.config';
 
-import './ProductCard.style';
+import(/* webpackChunkName: "product-item" */'./ProductCard.style');
 /**
  * Product card
  * @class ProductCard

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
@@ -19,7 +19,7 @@ import ProductReviewRating from 'Component/ProductReviewRating';
 import { ProductType } from 'Type/ProductList';
 import { BUNDLE, CONFIGURABLE, GROUPED } from 'Util/Product';
 
-import './WishlistItem.style';
+import(/* webpackChunkName: "product-item" */ './WishlistItem.style');
 
 /** @namespace Component/WishlistItem/Component */
 export class WishlistItem extends PureComponent {


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3035

**Problem:**
Product card style was in multiple chunks, thus when changing page the wishlist style is overwritten due to priority.

**In this PR:**
Moved style to one chunk, so that they are only loaded once.