### PR TITLE
App Build Fix

### DIFF
--- a/packages/m2-theme/build-config/before.js
+++ b/packages/m2-theme/build-config/before.js
@@ -28,4 +28,5 @@ module.exports = () => {
 
     const { name: themeName } = require(path.join(process.cwd(), 'composer.json'));
     process.env.PUBLIC_URL = `/static/frontend/${ themeName }/en_US/Magento_Theme/`;
+    process.env.BUILD_PATH = path.join(process.cwd(), 'magento', 'Magento_Theme', 'web');
 };


### PR DESCRIPTION
There is an issue when theme doesn't build in magento mode.
This happens because we override default build directory in the webpack configuration, but CRA doesn't get this change and after the build it tries to lookup files in the default directory.
Setting `BUILD_PATH` can override the default path for CRA.

For more info see scandipwa/create-scandipwa-app/issues/68