### PR TITLE
Added New Default Proxy

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -452,5 +452,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://40kskudemo.scandipwa.com/"
+    "proxy": "https://demo100-ors-1588667385-csa-qnb.scandipwa.cloud/"
 }


### PR DESCRIPTION
Fixes scandipwa/create-scandipwa-app#67
Added a new default proxy that is not connected to cloud flare.