### PR TITLE
Bugfix/fix missing welcome message

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.component.js
+++ b/packages/scandipwa/src/component/Header/Header.component.js
@@ -482,7 +482,7 @@ export class Header extends NavigationAbstract {
 
         return (
             <>
-                { this.renderWelcomeMessage() }
+                { this.renderWelcomeMessage(true) }
                 <ClickOutside
                   onClick={ onMyAccountOutsideClick }
                   key="account"

--- a/packages/scandipwa/src/component/Header/Header.component.js
+++ b/packages/scandipwa/src/component/Header/Header.component.js
@@ -482,7 +482,7 @@ export class Header extends NavigationAbstract {
 
         return (
             <>
-                { this.renderWelcomeMessage(true) }
+                { this.renderWelcomeMessage() }
                 <ClickOutside
                   onClick={ onMyAccountOutsideClick }
                   key="account"
@@ -609,7 +609,7 @@ export class Header extends NavigationAbstract {
         );
     }
 
-    renderWelcomeMessage(isVisible = false) {
+    renderWelcomeMessage() {
         const { firstname } = this.props;
 
         if (!isSignedIn() || !firstname) {
@@ -620,7 +620,7 @@ export class Header extends NavigationAbstract {
             <div
               block="Header"
               elem="Welcome"
-              mods={ { type: 'Welcome', isVisible } }
+              mods={ { type: 'Welcome' } }
             >
                 { __('Welcome, %s!', firstname) }
             </div>

--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -321,11 +321,7 @@
         margin-inline-end: 16px;
         text-align: end;
 
-        @include narrow-desktop {
-            display: block;
-        }
-
-        &_isVisible {
+        @include wide-desktop {
             display: block;
         }
     }

--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -320,6 +320,10 @@
         font-size: 14px;
         margin-inline-end: 16px;
         text-align: end;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 200px;
 
         @include wide-desktop {
             display: block;


### PR DESCRIPTION
Issue: Welcome message is missing in header

It should be shown on wide desktop (it doesn't fit on narrow,  so hidden in this case) when you is logged in.
<img width="364" alt="ScandiPWA 2021-08-05 15-17-09" src="https://user-images.githubusercontent.com/79456428/128366954-a5e78081-f9a1-4a84-b1f7-bcf684c582b2.png">
