### PR TITLE
#3082 Ooops on select when using keyboard

### DIFF
--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.component.js
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.component.js
@@ -196,12 +196,14 @@ export class FieldSelect extends PureComponent {
             isSelectExpanded: isExpanded,
             handleSelectExpand,
             handleSelectListKeyPress,
-            handleSelectExpandedExpand
+            handleSelectExpandedExpand,
+            id
         } = this.props;
 
         return (
             <ClickOutside onClick={ handleSelectExpandedExpand }>
                 <div
+                  id={ `${id}_wrapper` }
                   block="FieldSelect"
                   mods={ { isExpanded } }
                   onClick={ handleSelectExpand }

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.container.js
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.container.js
@@ -203,8 +203,10 @@ export class FieldSelectContainer extends PureComponent {
             const { id, value } = selectOptions[valueIndex];
             // converting to string for avoiding the error with the first select option
             onChange(value.toString());
-            const selectedElement = document.querySelector(`#${selectId} + ul #o${id}`);
-            selectedElement.focus();
+            const selectedElement = document.querySelector(`#${selectId}_wrapper ul #o${id}`);
+            if (selectedElement) {
+                selectedElement.focus();
+            }
         });
     }
 


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3082

**Problem:**
* No check if element exists;
* Structure of FieldSelect component was changed ([commit](https://github.com/scandipwa/scandipwa/commit/170242e07e8e02b00e1d831514d1d1257e9dd9e4)) by moving select DOM inside div DOM, thus query  `#${selectId} + ul #o${id}` would no longer work as they are no longer together.

**In this PR**
* Added element check
* Added id for wrapper and fixed query selector.