### PR TITLE
Fixed m2-theme plugin

### DIFF
--- a/packages/m2-theme/build-config/before.js
+++ b/packages/m2-theme/build-config/before.js
@@ -28,5 +28,4 @@ module.exports = () => {
 
     const { name: themeName } = require(path.join(process.cwd(), 'composer.json'));
     process.env.PUBLIC_URL = `/static/frontend/${ themeName }/en_US/Magento_Theme/`;
-    process.env.BUILD_PATH = path.join(process.cwd(), 'magento', 'Magento_Theme', 'web');
 };

--- a/packages/m2-theme/build-config/craco.js
+++ b/packages/m2-theme/build-config/craco.js
@@ -9,23 +9,21 @@ const isMagento = process.env.BUILD_MODE === 'magento';
 
 module.exports = {
     plugin: {
-        overrideCracoConfig: async ({
+        overrideCracoConfig: ({
             cracoConfig
         }) => {
             if (!isMagento) {
                 return cracoConfig;
             }
 
-            const config = await cracoConfig;
-
             // For Magento, use magento/Magento_Theme folder as dist
-            config.paths.appBuild = path.join(process.cwd(), 'magento', 'Magento_Theme', 'web');
+            cracoConfig.paths.appBuild = path.join(process.cwd(), 'magento', 'Magento_Theme', 'web');
 
             // For Magento use PHP template (defined in /public/index.php)
-            config.paths.appHtml = FallbackPlugin.getFallbackPathname('./public/index.php');
+            cracoConfig.paths.appHtml = FallbackPlugin.getFallbackPathname('./public/index.php');
 
             // Always return the config object.
-            return config;
+            return cracoConfig;
         },
         overrideWebpackConfig: ({ webpackConfig }) => {
             if (!isMagento) {


### PR DESCRIPTION
Since `overrideCracoConfig` was async, craco path override function run between `overrideCracoConfig` was executed and result was returned.
Thus no paths were overrided and react scripts took `index.html` template instead of `index.php` template.