### PR TITLE
#3098 Multistore RVP widget crash when one store has and other dont

### DIFF
--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.dispatcher.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.dispatcher.js
@@ -49,8 +49,18 @@ export class RecentlyViewedProductsDispatcher extends QueryDispatcher {
      * @param recentlyViewedProducts
      */
     prepareRequest(options, dispatch) {
-        const { recentProducts, store } = options;
-        const recentlyViewedProductsSKUs = recentProducts[store].reduce((productSKUs, item) => {
+        const { store } = options;
+        const {
+            recentProducts: {
+                [store]: storeRecentProducts
+            } = {}
+        } = options;
+
+        if (!Array.isArray(storeRecentProducts)) {
+            return null;
+        }
+
+        const recentlyViewedProductsSKUs = storeRecentProducts.reduce((productSKUs, item) => {
             const { sku } = item;
 
             return [...productSKUs, `${ sku.replace(/ /g, '%20') }`];


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3098

**Problem:**
* No check if store exist in `localStoreage.recentProducts`

**In this PR:**
* Added check