### PR TITLE
fix storing menu state

### DIFF
--- a/packages/scandipwa/src/component/Menu/Menu.component.js
+++ b/packages/scandipwa/src/component/Menu/Menu.component.js
@@ -96,6 +96,10 @@ export class Menu extends PureComponent {
         );
     }
 
+    stopPropagation(e) {
+        e.stopPropagation();
+    }
+
     renderSubLevelItems = (item, isSecondLevel) => {
         const {
             handleSubcategoryClick,
@@ -138,6 +142,9 @@ export class Menu extends PureComponent {
               block="Menu"
               elem="SubItemWrapper"
               key={ item_id }
+              onClick={ this.stopPropagation }
+              role="button"
+              tabIndex="-1"
             >
                 <MenuItem
                   activeMenuItemsStack={ activeMenuItemsStack }

--- a/packages/scandipwa/src/component/MenuItem/MenuItem.container.js
+++ b/packages/scandipwa/src/component/MenuItem/MenuItem.container.js
@@ -13,15 +13,17 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
+import history from 'Util/History';
+
 import MenuItem from './MenuItem.component';
 import { HOVER_TIMEOUT } from './MenuItem.config';
 
-/** @namespace Component/Menu/Container/mapStateToProps */
+/** @namespace Component/MenuItem/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     device: state.ConfigReducer.device
 });
 
-/** @namespace Component/Menu/Container/mapDispatchToProps */
+/** @namespace Component/MenuItem/Container/mapDispatchToProps */
 export const mapDispatchToProps = () => ({});
 
 /** @namespace Component/MenuItem/Container/menuItemContainer */
@@ -47,9 +49,13 @@ export class MenuItemContainer extends PureComponent {
     menuHoverTimeout = null;
 
     onItemClick() {
-        const { closeMenu } = this.props;
+        const { closeMenu, activeMenuItemsStack } = this.props;
         window.scrollTo({ top: 0 });
         closeMenu();
+
+        // keep the stack here, so later we can deconstruct menu out of it
+        const { pathname } = location;
+        history.push(pathname, { stack: activeMenuItemsStack });
     }
 
     handleCategoryHover() {


### PR DESCRIPTION
Fixes 2 issues:
1. Current menu stack state not saved to `location.history.state` => not restored when navigating back
2. Menu stack populated incorrectly with menu item ids: when clicking on menu item on lowest level, click on it was propagated to upper menu level, toggle state logic was mistakenly applied (+/- clicks) and id of this menu item was removed from state

Also renamed 2 namespaces as 1. they were incorrect 2. exactly same names were used in another component (I had trouble creating a plugin for this component) 

For QA: if you expand mobile menu (e.g. click Accessories -> Bags -> Handbags), then click Back arrow on Handbags category once, you will get back to menu and you will still see Accessories and Bags expanded.