### PR TITLE
#2850 Compare page price fixes

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -27,6 +27,7 @@ import { GRID_LAYOUT, LIST_LAYOUT } from 'Route/CategoryPage/CategoryPage.config
 import { DeviceType } from 'Type/Device';
 import { LayoutType } from 'Type/Layout';
 import { ProductType } from 'Type/ProductList';
+import { getPriceLabel } from 'Util/Price';
 import {
     BUNDLE,
     CONFIGURABLE,
@@ -34,9 +35,10 @@ import {
     GROUPED
 } from 'Util/Product';
 
-import { IN_STOCK, TIER_PRICES } from './ProductCard.config';
+import { IN_STOCK } from './ProductCard.config';
 
 import './ProductCard.style';
+
 /**
  * Product card
  * @class ProductCard
@@ -103,13 +105,6 @@ export class ProductCard extends Component {
         }
     };
 
-    productTypeRenderMap = {
-        [BUNDLE]: __('Starting from'),
-        [GROUPED]: __('Starting from'),
-        [CONFIGURABLE]: __('As Low as'),
-        [TIER_PRICES]: __('As Low as')
-    };
-
     imageRef = createRef();
 
     shouldComponentUpdate(nextProps) {
@@ -148,14 +143,8 @@ export class ProductCard extends Component {
             setSiblingsHavePriceBadge
         } = this.props;
 
-        const typeId = price_tiers.length ? TIER_PRICES : type_id;
-
-        const label = this.productTypeRenderMap[typeId];
-        if (!label) {
-            return null;
-        }
-
-        if (!siblingsHavePriceBadge) {
+        const label = getPriceLabel(type_id, price_tiers);
+        if (label && siblingsHavePriceBadge) {
             setSiblingsHavePriceBadge();
         }
 

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -144,7 +144,7 @@ export class ProductCard extends Component {
         } = this.props;
 
         const label = getPriceLabel(type_id, price_tiers);
-        if (label && siblingsHavePriceBadge) {
+        if (label && !siblingsHavePriceBadge) {
             setSiblingsHavePriceBadge();
         }
 

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.config.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.config.js
@@ -18,5 +18,3 @@ export const validOptionTypes = [OPTION_TYPE_TEXT, OPTION_TYPE_COLOR, OPTION_TYP
 
 export const IN_STOCK = 'IN_STOCK';
 export const OUT_OF_STOCK = 'OUT_OF_STOCK';
-
-export const TIER_PRICES = 'TIER_PRICES';

--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.component.js
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.component.js
@@ -17,7 +17,11 @@ import ProductCompareItem from 'Component/ProductCompareItem';
 import ProductPrice from 'Component/ProductPrice';
 import { DeviceType } from 'Type/Device';
 import { ProductItemsType } from 'Type/ProductList';
-import { BUNDLE, CONFIGURABLE, GROUPED } from 'Util/Product';
+import { getPriceLabel } from 'Util/Price';
+import {
+    BUNDLE,
+    CONFIGURABLE
+} from 'Util/Product';
 
 import './ProductCompare.style';
 
@@ -26,6 +30,7 @@ export class ProductCompare extends Component {
     static propTypes = {
         clearCompareList: PropTypes.func.isRequired,
         getAttributes: PropTypes.func.isRequired,
+        isOutOfStock: PropTypes.func.isRequired,
         isLoading: PropTypes.bool,
         products: ProductItemsType,
         device: DeviceType.isRequired
@@ -34,12 +39,6 @@ export class ProductCompare extends Component {
     static defaultProps = {
         isLoading: false,
         products: []
-    };
-
-    productTypeLabelMap = {
-        [BUNDLE]: __('Starting from'),
-        [GROUPED]: __('Starting from'),
-        [CONFIGURABLE]: __('As Low as')
     };
 
     shouldComponentUpdate(nextProps) {
@@ -105,15 +104,31 @@ export class ProductCompare extends Component {
     }
 
     renderProductPrices() {
-        const { products } = this.props;
+        const { products, isOutOfStock } = this.props;
 
-        return products.map(({ id, price_range, type_id }) => (
-            <ProductPrice
-              price={ price_range }
-              key={ id }
-              label={ this.productTypeLabelMap[type_id] }
-            />
-        ));
+        return products.map((product) => {
+            const {
+                id,
+                price_range,
+                price_tiers = [],
+                type_id
+            } = product;
+
+            if ((type_id === CONFIGURABLE || type_id === BUNDLE) && isOutOfStock(product)) {
+                return null;
+            }
+
+            const label = getPriceLabel(type_id, price_tiers);
+
+            return (
+                <ProductPrice
+                  price={ price_range }
+                  price_tiers={ price_tiers }
+                  key={ id }
+                  label={ label }
+                />
+            );
+        });
     }
 
     renderAttributes() {

--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.container.js
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.container.js
@@ -63,7 +63,8 @@ export class ProductCompareContainer extends PureComponent {
 
     containerFunctions = {
         getAttributes: this.getAttributes.bind(this),
-        clearCompareList: this.clearCompareList.bind(this)
+        clearCompareList: this.clearCompareList.bind(this),
+        isOutOfStock: this.isOutOfStock.bind(this)
     };
 
     componentDidMount() {
@@ -111,6 +112,26 @@ export class ProductCompareContainer extends PureComponent {
                 ({ attributes }) => attributes.find((attribute) => attribute.code === code).value
             )
         }));
+    }
+
+    isOutOfStock(product) {
+        const {
+            price_range: {
+                minimum_price: {
+                    final_price: {
+                        value: minimalPriceValue = 0
+                    } = {},
+                    regular_price: {
+                        value: regularPriceValue = 0
+                    } = {},
+                    default_price: {
+                        value: defaultPriceValue = 0
+                    } = {}
+                } = {}
+            } = {}
+        } = product;
+
+        return (!minimalPriceValue || !regularPriceValue) && !defaultPriceValue;
     }
 
     render() {

--- a/packages/scandipwa/src/util/Price/Price.config.js
+++ b/packages/scandipwa/src/util/Price/Price.config.js
@@ -8,6 +8,17 @@
  * @package scandipwa/base-theme
  * @link https://github.com/scandipwa/base-theme
  */
+import { BUNDLE, CONFIGURABLE, GROUPED } from 'Util/Product';
+
+export const TIER_PRICES = 'TIER_PRICES';
+
+export const PRICE_LABEL_MAP = {
+    [BUNDLE]: __('Starting from'),
+    [GROUPED]: __('Starting from'),
+    [CONFIGURABLE]: __('As Low as'),
+    [TIER_PRICES]: __('As Low as')
+};
+
 export default {
     AED: 'د.إ',
     AFN: '؋',

--- a/packages/scandipwa/src/util/Price/Price.js
+++ b/packages/scandipwa/src/util/Price/Price.js
@@ -9,7 +9,7 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-import currencyMap from './Price.config';
+import currencyMap, { PRICE_LABEL_MAP, TIER_PRICES } from './Price.config';
 
 /** @namespace Util/Price/formatCurrency */
 export const formatCurrency = (currency = 'USD') => currencyMap[currency];
@@ -45,4 +45,16 @@ export const getLowestPriceTiersPrice = (price_tiers, currency) => {
         .reduce((acc, { final_price: { value } }) => (acc < value ? acc : value), price_tiers[0].final_price.value);
 
     return formatPrice(lowestValue, currency);
+};
+
+/** @namespace Util/Price/getPriceLabel */
+export const getPriceLabel = (type_id, price_tiers) => {
+    const typeId = price_tiers.length ? TIER_PRICES : type_id;
+
+    const label = PRICE_LABEL_MAP[typeId];
+    if (!label) {
+        return null;
+    }
+
+    return label;
 };


### PR DESCRIPTION
Original issue:
* https://github.com/scandipwa/scandipwa/issues/2850

Problem:
* Tier prices aren't included in ProductCompare, thus label is not showing for them

In this PR:
* Moved label rendering logic to `util\price`, to remove recurrence in `ProductCompare` and `ProductCard`
* Added price tiers to `ProductCompare` to output correct price.
* Added out of stock check to remove "always loading" price labels.