### PR TITLE
#3010 - not smooth animation

### DIFF
--- a/packages/scandipwa/src/component/SharedTransition/SharedTransition.component.js
+++ b/packages/scandipwa/src/component/SharedTransition/SharedTransition.component.js
@@ -59,7 +59,7 @@ export class SharedTransition extends PureComponent {
                 [key]: {
                     width,
                     height,
-                    start,
+                    left,
                     top
                 }
             }
@@ -69,7 +69,7 @@ export class SharedTransition extends PureComponent {
             --shared-element-width: ${width}px;
             --shared-element-height: ${height}px;
             --shared-element-top: ${top}px;
-            --shared-element-start: ${start}px;
+            --shared-element-start: ${left}px;
             --shared-element-animation-speed: ${this.animationSpeed}ms;
         `;
     }


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/3010

Was broken after theme-redesign multiple left/right replacements. The problem was that left element position was undefined, not correct element position from the left => element jumped after animation finished.

We do need `left` here and it works for RTL mode as well, as we have the following animation logic:
1. get left and top position + its width and height for element to be animated using `getBoundingClientRect()`
2. move from starting position to the calculated one gradually until element is at its correct position

Here `left` is totally replaceable with `right` and `top` is replaceable with `bottom`, as they play role of X and Y coordinates (if element is placed 30px from the left and 60px from the right for LTR, it will be 60px from the left for RTL, but we'll be using these 60px instead of 30 for RTL calculations).