### PR TITLE
[chunk-opt] Fixed plugin style loading issue.

### DIFF
--- a/packages/chunk-optimizer/build-config/craco.js
+++ b/packages/chunk-optimizer/build-config/craco.js
@@ -16,6 +16,10 @@ const fetchModuleParent = (issuer) => {
 const isPlugin = (module) => {
     const name = (module.nameForCondition && module.nameForCondition()) || module.resource;
 
+    if (!name) {
+        return false;
+    }
+
     // Name based check
     if (!name.endsWith('.plugin.css') && !name.endsWith('.plugin.scss')) {
         // Path based check

--- a/packages/chunk-optimizer/build-config/craco.js
+++ b/packages/chunk-optimizer/build-config/craco.js
@@ -10,6 +10,28 @@ const fetchModuleParent = (issuer) => {
     return issuer;
 };
 
+// Styles for plugins are loaded differently into react project,
+// because of the way that they are injected, webpack requires them to be stored into main style
+// otherwise there will be multiple chunks that are added to header. (all that contain plugin styles).
+const isPlugin = (module) => {
+    const name = (module.nameForCondition && module.nameForCondition()) || module.resource;
+
+    // Name based check
+    if (!name.endsWith('.plugin.css') && !name.endsWith('.plugin.scss')) {
+        // Path based check
+        if (!name.indexOf('/plugin/') || name.indexOf('/plugin/') < name.indexOf('/src/')) {
+            return false;
+        }
+    }
+
+    const {
+        _chunks: chunks
+    } = fetchModuleParent(module);
+
+    // Check if plugin need to go to the main chunk.
+    return Array.from(chunks).some(({ name: chunkName = '' }) => chunkName === 'main');
+};
+
 // Disables chunk-optimizer rules for specific files and uses Rect/Webpack specific chunks:
 // * if file name follows: [name].manual.style.[scss/css] or [name].manual.extended.style.[scss/css]
 // * if file is imported via webpackChunkName
@@ -120,13 +142,16 @@ module.exports = {
                 webpackConfig.optimization.splitChunks.cacheGroups[`${name}_style`] = {
                     name: `${name}_style`,
                     test(module) {
+                        if (isPlugin(module) && name !== 'main') {
+                            return false;
+                        }
+
                         if (isChunkOptimizationDisabled(module)) {
                             return false;
                         }
 
-                        const name = (module.nameForCondition && module.nameForCondition()) || module.resource;
-
-                        return !!match.exec(name);
+                        const fileName = (module.nameForCondition && module.nameForCondition()) || module.resource;
+                        return !!match.exec(fileName);
                     },
                     chunks: 'all',
                     minChunks: 1,


### PR DESCRIPTION
**Original issue:**
* Chunks break with plugins: https://github.com/scandipwa/scandipwa/pull/3144

**Problem:**
* Due to the way in which we are adding plugins into project, webpack thinks that all of their styles require primary mounting _(meaning that on build they will be attached to <head> in template.php)_, because we are spiting chunks based on their category we are moving those mounting points to different chunks and due to that all those chunks/files are attached to header _(instead there should be only one file in header - main_style.css)_.

**In this PR:**
* Added check if file is for plugin (by name & path)
* Added check whether or not file should be moved to main chunk.