### PR TITLE
#3104 - show less overlap fix

### DIFF
--- a/packages/scandipwa/src/component/ExpandableContentShowMore/ExpandableContentShowMore.component.js
+++ b/packages/scandipwa/src/component/ExpandableContentShowMore/ExpandableContentShowMore.component.js
@@ -56,10 +56,10 @@ export class ExpandableContentShowMore extends PureComponent {
     }
 
     componentDidUpdate(prevProps) {
-        const { children: { length: prevChildrenLength } } = prevProps;
-        const { children: { length: currentChildrenLength } } = this.props;
+        const { children: prevChildren } = prevProps;
+        const { children: nextChildren } = this.props;
 
-        if (prevChildrenLength !== currentChildrenLength) {
+        if (prevChildren !== nextChildren) {
             if (this.expandableRef.current) {
             // eslint-disable-next-line react/no-did-update-set-state
                 this.setState({ isOpen: true }, () => {


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/3104

ExpandableContentShowMore has logic to calculate height of container and set height for the block in order to play animation. The issue is that when layered navigation is applied number of options may change => height of block needs to be recalculated and applied. Change for the number of children has already been handled before (I was fixing this some time ago). But what was not taken into account is that you may have same number of children, but some of children will change from 1 line to 2 lines => and it is the reason to update the height of the block as well.