### PR TITLE
#2468 Search page replace none with best match sort

### DIFF
--- a/packages/scandipwa/src/component/CategorySort/CategorySort.container.js
+++ b/packages/scandipwa/src/component/CategorySort/CategorySort.container.js
@@ -76,7 +76,7 @@ export class CategorySortContainer extends PureComponent {
             };
         case 'none':
             return {
-                asc: __('- None -')
+                asc: __('Best match')
             };
         default:
             return {

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.config.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.config.js
@@ -11,6 +11,7 @@
  */
 
 export const NONE_SORT_OPTION_VALUE = 'none';
+export const BEST_MATCH_SORT_OPTION_VALUE = 'position';
 
 export const NONE_SORT_OPTION = {
     label: __('None'),

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
@@ -27,7 +27,7 @@ import { debounce } from 'Util/Request';
 import { appendWithStoreCode } from 'Util/Url';
 
 import SearchPage from './SearchPage.component';
-import { NONE_SORT_OPTION } from './SearchPage.config';
+import { BEST_MATCH_SORT_OPTION_VALUE, NONE_SORT_OPTION } from './SearchPage.config';
 
 export const BreadcrumbsDispatcher = import(
     /* webpackMode: "lazy", webpackChunkName: "dispatchers" */
@@ -197,10 +197,12 @@ export class SearchPageContainer extends CategoryPageContainer {
             } = {}
         } = this.props;
 
+        const filteredOptions = options.filter(({ value }) => value !== BEST_MATCH_SORT_OPTION_VALUE);
+
         return {
             options: [
                 NONE_SORT_OPTION,
-                ...options
+                ...filteredOptions
             ]
         };
     }


### PR DESCRIPTION
**Original issue:**
* #2468 

**Requirements:**
* Replace best match with none in search page, while keeping label as 'best match'

**In this PR:**
* Changed label from '- None -' to 'Best match'
* Removed position filter from search page