### PR TITLE
#3122 Out of stock checker

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.container.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.container.js
@@ -17,8 +17,8 @@ import { DEFAULT_MAX_PRODUCTS } from 'Component/ProductActions/ProductActions.co
 import SwipeToDelete from 'Component/SwipeToDelete';
 import { showNotification } from 'Store/Notification/Notification.action';
 import { CartItemType } from 'Type/MiniCart';
-import { itemIsOutOfStock } from 'Util/Cart';
 import { CONFIGURABLE } from 'Util/Product';
+import { getProductInStock } from 'Util/Product/Extract';
 import { makeCancelable } from 'Util/Promise';
 import { objectToUri } from 'Util/Url';
 
@@ -91,9 +91,9 @@ export class CartItemContainer extends PureComponent {
     }
 
     productIsInStock() {
-        const { item } = this.props;
+        const { item: { product } } = this.props;
 
-        return !itemIsOutOfStock(item);
+        return getProductInStock(product);
     }
 
     /**

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.container.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.container.js
@@ -25,10 +25,10 @@ import { isSignedIn } from 'Util/Auth';
 import {
     getCartShippingPrice,
     getCartShippingSubPrice,
-    getCartTotalSubPrice,
-    hasOutOfStockProductsInCartItems
+    getCartTotalSubPrice
 } from 'Util/Cart';
 import history from 'Util/History';
+import { getProductInStock } from 'Util/Product/Extract';
 import { appendWithStoreCode } from 'Util/Url';
 
 import CartOverlay from './CartOverlay.component';
@@ -122,9 +122,13 @@ export class CartOverlayContainer extends PureComponent {
             isMobile,
             cartShippingPrice,
             cartShippingSubPrice,
-            hasOutOfStockProductsInCart: hasOutOfStockProductsInCartItems(totals.items)
+            hasOutOfStockProductsInCart: this.hasOutOfStockProductsInCartItems(totals.items)
         };
     }
+
+    hasOutOfStockProductsInCartItems = (items) => (
+        items.some(({ product }) => !getProductInStock(product))
+    );
 
     scrollToTop() {
         window.scrollTo({ top: 0 });
@@ -143,7 +147,7 @@ export class CartOverlayContainer extends PureComponent {
         // to prevent outside-click handler trigger
         e.nativeEvent.stopImmediatePropagation();
 
-        const hasOutOfStockProductsInCart = hasOutOfStockProductsInCartItems(totals.items);
+        const hasOutOfStockProductsInCart = this.hasOutOfStockProductsInCartItems(totals.items);
 
         if (hasOutOfStockProductsInCart) {
             showNotification('error', __('Cannot proceed to checkout. Remove out of stock products first.'));

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
@@ -18,7 +18,7 @@ import GroupedProductList from 'Component/GroupedProductList';
 import Html from 'Component/Html';
 import ProductAlerts from 'Component/ProductAlerts';
 import ProductBundleItems from 'Component/ProductBundleItems';
-import { IN_STOCK } from 'Component/ProductCard/ProductCard.config';
+import { IN_STOCK, OUT_OF_STOCK } from 'Component/ProductCard/ProductCard.config';
 import ProductCompareButton from 'Component/ProductCompareButton';
 import ProductConfigurableAttributes from 'Component/ProductConfigurableAttributes';
 import ProductCustomizableOptions from 'Component/ProductCustomizableOptions';
@@ -83,7 +83,8 @@ export class ProductActions extends PureComponent {
         isWishlistEnabled: PropTypes.bool.isRequired,
         displayProductStockStatus: PropTypes.bool.isRequired,
         setRefs: PropTypes.func.isRequired,
-        areReviewsEnabled: PropTypes.bool.isRequired
+        areReviewsEnabled: PropTypes.bool.isRequired,
+        inStock: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -113,14 +114,14 @@ export class ProductActions extends PureComponent {
         }
     }
 
-    renderStock(stockStatus) {
-        const { displayProductStockStatus } = this.props;
+    renderStock() {
+        const { displayProductStockStatus, inStock } = this.props;
 
         if (!displayProductStockStatus) {
             return null;
         }
 
-        const stockStatusLabel = stockStatus === IN_STOCK ? __('In stock') : __('Out of stock');
+        const stockStatusLabel = inStock ? __('In stock') : __('Out of stock');
 
         return <span block="ProductActions" elem="Stock">{ stockStatusLabel }</span>;
     }
@@ -155,7 +156,7 @@ export class ProductActions extends PureComponent {
             ? variants[configurableVariantIndex]
             : product;
 
-        const { sku, stock_status } = productOrVariant;
+        const { sku } = productOrVariant;
 
         return (
             <section
@@ -171,7 +172,7 @@ export class ProductActions extends PureComponent {
                             <span block="ProductActions" elem="Sku" itemProp="sku">
                                 { __('SKU: %s', sku) }
                             </span>
-                            { this.renderStock(stock_status) }
+                            { this.renderStock() }
                         </>
                     ),
                     <TextPlaceholder />
@@ -379,9 +380,7 @@ export class ProductActions extends PureComponent {
             groupedProductQuantity,
             onProductValidationError,
             productOptionsData,
-            product: {
-                stock_status
-            } = {}
+            inStock
         } = this.props;
 
         return (
@@ -393,7 +392,7 @@ export class ProductActions extends PureComponent {
               groupedProductQuantity={ groupedProductQuantity }
               onProductValidationError={ onProductValidationError }
               productOptionsData={ productOptionsData }
-              disabled={ stock_status !== IN_STOCK }
+              disabled={ !inStock }
               isWithIcon
             />
         );
@@ -458,12 +457,10 @@ export class ProductActions extends PureComponent {
         const {
             productPrice,
             offerCount,
-            productOrVariant: {
-                stock_status
-            }
+            inStock
         } = this.props;
 
-        if (stock_status !== IN_STOCK) {
+        if (!inStock) {
             return null;
         }
 
@@ -691,6 +688,7 @@ export class ProductActions extends PureComponent {
             isInStockAlertEnabled,
             isPriceAlertEnabled,
             product,
+            inStock,
             product: { variants }
         } = this.props;
 
@@ -705,7 +703,7 @@ export class ProductActions extends PureComponent {
             ? variants[configurableVariantIndex]
             : product;
 
-        const { id, stock_status } = productOrVariant;
+        const { id } = productOrVariant;
 
         return (
             <section
@@ -715,7 +713,7 @@ export class ProductActions extends PureComponent {
             >
                 <ProductAlerts
                   productId={ id }
-                  stockStatus={ stock_status }
+                  stockStatus={ inStock ? IN_STOCK : OUT_OF_STOCK }
                 />
             </section>
         );

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.container.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.container.js
@@ -24,6 +24,7 @@ import {
     SIMPLE,
     VIRTUAL
 } from 'Util/Product';
+import { getProductInStock } from 'Util/Product/Extract';
 
 import ProductActions from './ProductActions.component';
 import { DEFAULT_MAX_PRODUCTS, ONE_HUNDRED_PERCENT } from './ProductActions.config';
@@ -284,7 +285,8 @@ export class ProductActionsContainer extends PureComponent {
             offerCount: this.getOfferCount(),
             offerType: this.getOfferType(),
             stockMeta: this.getStockMeta(),
-            metaLink: this.getMetaLink()
+            metaLink: this.getMetaLink(),
+            inStock: getProductInStock(product, configurableVariantIndex)
         };
     }
 

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -391,7 +391,8 @@ export class ProductCard extends Component {
             product,
             product: {
                 type_id,
-                options = []
+                options = [],
+                configurable_options: confOptions = {}
             },
             configurableVariantIndex,
             layout,
@@ -414,7 +415,10 @@ export class ProductCard extends Component {
             requiredOptions
         };
 
-        if (type_id === BUNDLE || type_id === GROUPED) {
+        const redirectOnConfig = type_id === CONFIGURABLE
+            && Object.keys(confOptions).length !== Object.keys(this.getAttributesToShow()).length;
+
+        if (type_id === BUNDLE || type_id === GROUPED || redirectOnConfig) {
             return (
                 <button
                   block="Button AddToCart"

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -35,8 +35,6 @@ import {
     GROUPED
 } from 'Util/Product';
 
-import { IN_STOCK } from './ProductCard.config';
-
 import './ProductCard.style';
 
 /**
@@ -71,7 +69,8 @@ export class ProductCard extends Component {
         configurableVariantIndex: PropTypes.number,
         parameters: PropTypes.shape({}).isRequired,
         showSelectOptionsNotification: PropTypes.func.isRequired,
-        productOrVariant: ProductType.isRequired
+        productOrVariant: ProductType.isRequired,
+        inStock: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -392,12 +391,12 @@ export class ProductCard extends Component {
             product,
             product: {
                 type_id,
-                stock_status,
                 options = []
             },
             configurableVariantIndex,
             layout,
-            showSelectOptionsNotification
+            showSelectOptionsNotification,
+            inStock
         } = this.props;
 
         const quantity = 1;
@@ -435,7 +434,7 @@ export class ProductCard extends Component {
               quantity={ quantity }
               groupedProductQuantity={ groupedProductQuantity }
               productOptionsData={ productOptionsData }
-              disabled={ stock_status !== IN_STOCK }
+              disabled={ !inStock }
               layout={ layout }
             />
         );

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -28,6 +28,7 @@ import {
     getVariantIndex,
     getVariantsIndexes
 } from 'Util/Product';
+import { getProductInStock } from 'Util/Product/Extract';
 import { appendWithStoreCode, objectToUri } from 'Util/Url';
 
 import ProductCard from './ProductCard.component';
@@ -174,7 +175,8 @@ export class ProductCardContainer extends PureComponent {
             currentVariantIndex: this._getCurrentVariantIndex(),
             productOrVariant: this._getProductOrVariant(),
             thumbnail: this._getThumbnail(),
-            linkTo: this._getLinkTo()
+            linkTo: this._getLinkTo(),
+            inStock: getProductInStock(product, configurableVariantIndex)
         };
     }
 

--- a/packages/scandipwa/src/util/Product/Extract.js
+++ b/packages/scandipwa/src/util/Product/Extract.js
@@ -1,0 +1,50 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+import { IN_STOCK } from 'Component/ProductCard/ProductCard.config';
+import { BUNDLE, CONFIGURABLE, GROUPED } from 'Util/Product/Types';
+
+/**
+ * Returns whether or not product is in stock (true if in stock | false if out of stock)
+ * @param product
+ * @param configIndex
+ * @returns {boolean}
+ */
+export const getProductInStock = (product, configIndex = -1) => {
+    if (!product) {
+        return false;
+    }
+
+    const { type_id, variants = [], items = [] } = product;
+
+    if (type_id === BUNDLE) {
+        const { items = [] } = product;
+        const requiredItems = items.filter(({ required }) => required);
+        const requiredItemsInStock = requiredItems.filter(
+            ({ options }) => options.some(({ product }) => getProductInStock(product))
+        );
+
+        return requiredItemsInStock.length === requiredItems.length;
+    }
+
+    if (type_id === CONFIGURABLE && configIndex === -1) {
+        return !!variants.some(({ product }) => getProductInStock(product));
+    }
+
+    if (type_id === GROUPED) {
+        return !!items.some(({ product }) => getProductInStock(product));
+    }
+
+    const { stock_status } = variants[configIndex] || product;
+
+    return stock_status === IN_STOCK;
+};


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3122
* https://github.com/scandipwa/scandipwa/issues/3123

**Problem:**
* Not all products store their stock status value inside product: stock_status, products with type group, config, bundle require to check their children products.
* For config products only swatch option are displayed on product card, thus when config product contains non-swatch value it is impossible to select active product variant.

**In this PR:**
* Created function that checks stock status based on their type.
* Added check for config product to redirect if contains non-swatch options.