### PR TITLE
#3159 Image popup fix

### DIFF
--- a/packages/scandipwa/src/component/ImageZoomPopup/ImageZoomPopup.style.scss
+++ b/packages/scandipwa/src/component/ImageZoomPopup/ImageZoomPopup.style.scss
@@ -9,13 +9,16 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-.ImageZoomPopup {
-    height: 100%;
+ .ImageZoomPopup {
+    height: 99%;
+
+    &.Popup {
+        height: 100vh;
+    }
 
     &-PopupContent {
-        max-height: 100vh;
+        max-height: 80%;
         height: 100vh;
-        width: 100vw;
         max-width: 100vw;
     }
 

--- a/packages/scandipwa/src/component/Popup/Popup.container.js
+++ b/packages/scandipwa/src/component/Popup/Popup.container.js
@@ -42,6 +42,7 @@ export const mapDispatchToProps = (dispatch) => ({
 export class PopupContainer extends PureComponent {
     static propTypes = {
         mix: MixType,
+        contentMix: MixType,
         payload: PropTypes.objectOf(
             PropTypes.shape({
                 title: PropTypes.string
@@ -65,6 +66,7 @@ export class PopupContainer extends PureComponent {
         onVisible: () => {},
         onClose: () => {},
         mix: {},
+        contentMix: {},
         children: [],
         isStatic: false
     };
@@ -97,6 +99,7 @@ export class PopupContainer extends PureComponent {
             isMobile,
             isStatic,
             mix,
+            contentMix,
             onClose,
             onVisible,
             hideActiveOverlay,
@@ -112,6 +115,7 @@ export class PopupContainer extends PureComponent {
             isMobile,
             isStatic,
             mix,
+            contentMix,
             onClose,
             onVisible,
             hideActiveOverlay,


### PR DESCRIPTION
Original issue:
* https://github.com/scandipwa/scandipwa/issues/3159

Problem:
* property `contentMix` was not passed to `Popup.component`, thus style rules where not applied

In this PR:
* added property `contentMix` to `containerProps()` in `PopupContainer`
* Style adjustments