### PR TITLE
#3142 - fix lost props

### DIFF
--- a/packages/scandipwa/src/component/Image/Image.component.js
+++ b/packages/scandipwa/src/component/Image/Image.component.js
@@ -229,7 +229,7 @@ export class Image extends PureComponent {
               ref={ imageRef }
               mods={ {
                   ratio,
-                  imageStatus,
+                  imageStatus: imageStatus.toLowerCase(),
                   isPlaceholder,
                   hasSrc: !!src
               } }

--- a/packages/scandipwa/src/component/Image/Image.container.js
+++ b/packages/scandipwa/src/component/Image/Image.container.js
@@ -40,7 +40,8 @@ export class ImageContainer extends PureComponent {
             PropTypes.func,
             PropTypes.shape({ current: PropTypes.instanceOf(Element) })
         ]),
-        title: PropTypes.string
+        title: PropTypes.string,
+        isPlain: PropTypes.bool
     };
 
     static defaultProps = {
@@ -54,7 +55,8 @@ export class ImageContainer extends PureComponent {
         style: {},
         title: null,
         className: '',
-        imageRef: () => {}
+        imageRef: () => {},
+        isPlain: false
     };
 
     containerProps() {
@@ -66,7 +68,8 @@ export class ImageContainer extends PureComponent {
             className,
             ratio,
             mix,
-            imageRef
+            imageRef,
+            isPlain
         } = this.props;
 
         return {
@@ -79,7 +82,8 @@ export class ImageContainer extends PureComponent {
             className,
             ratio,
             mix,
-            imageRef
+            imageRef,
+            isPlain
         };
     }
 

--- a/packages/scandipwa/src/component/Image/Image.style.scss
+++ b/packages/scandipwa/src/component/Image/Image.style.scss
@@ -35,7 +35,7 @@
         }
     }
 
-    &_imageStatus_0,
+    &_imageStatus_image_loading,
     &_isPlaceholder {
         background-image: var(--placeholder-image);
         background-size: var(--placeholder-size);
@@ -43,7 +43,7 @@
     }
 
     &_hasSrc,
-    &_imageStatus_1 {
+    &_imageStatus_image_loaded {
         background: none;
     }
 


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/2547

- Added back `isPlain` props lost after "no props spreading refactoring"
- Also noticed that image statuses are passed as mods to `<div>` with image => replaced `image_status_0` and `image_status_1` with correct modificators.