### PR TITLE
#3176 - fix save shipping address error

### DIFF
--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
@@ -246,8 +246,6 @@ export class CheckoutShippingContainer extends PureComponent {
             shipping_method_code
         };
 
-        console.debug({ selectedStoreAddress, storeAddress: this.getStoreAddress(shippingAddress), shippingAddress });
-
         saveAddressInformation(data);
         const shippingMethod = `${shipping_carrier_code}_${shipping_method_code}`;
         updateShippingFields({ ...fields, shippingMethod });

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
@@ -237,12 +237,16 @@ export class CheckoutShippingContainer extends PureComponent {
             method_code: shipping_method_code
         } = selectedShippingMethod;
 
+        const isInStoreDelivery = Object.keys(selectedStoreAddress).length > 0;
+
         const data = {
-            billing_address: selectedStoreAddress ? this.getStoreAddress(shippingAddress, true) : shippingAddress,
-            shipping_address: selectedStoreAddress ? this.getStoreAddress(shippingAddress) : shippingAddress,
+            billing_address: isInStoreDelivery ? this.getStoreAddress(shippingAddress, true) : shippingAddress,
+            shipping_address: isInStoreDelivery ? this.getStoreAddress(shippingAddress) : shippingAddress,
             shipping_carrier_code,
             shipping_method_code
         };
+
+        console.debug({ selectedStoreAddress, storeAddress: this.getStoreAddress(shippingAddress), shippingAddress });
 
         saveAddressInformation(data);
         const shippingMethod = `${shipping_carrier_code}_${shipping_method_code}`;


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/3176

Continue to enlarge my collection of bugs caused by "no props spreading fix" :)

Problem caused by defaultProps value for store address set to `{}` => `{}` evaluated to `true`  and caused wrong data to be populated to shipping and billing addresses.

