### PR TITLE
3155/mini cart no update on login

### DIFF
--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.container.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.container.js
@@ -126,7 +126,7 @@ export class CartOverlayContainer extends PureComponent {
         };
     }
 
-    hasOutOfStockProductsInCartItems = (items) => (
+    hasOutOfStockProductsInCartItems = (items = []) => (
         items.some(({ product }) => !getProductInStock(product))
     );
 

--- a/packages/scandipwa/src/component/Header/Header.container.js
+++ b/packages/scandipwa/src/component/Header/Header.container.js
@@ -419,8 +419,6 @@ export class HeaderContainer extends NavigationAbstractContainer {
             device
         } = this.props;
 
-        console.debug('onMinicartButtonClick', name);
-
         if (name === CART_OVERLAY) {
             return;
         }

--- a/packages/scandipwa/src/component/Header/Header.container.js
+++ b/packages/scandipwa/src/component/Header/Header.container.js
@@ -355,7 +355,10 @@ export class HeaderContainer extends NavigationAbstractContainer {
     }
 
     onMyAccountButtonClick() {
-        const { showOverlay } = this.props;
+        const {
+            showOverlay,
+            setNavigationState
+        } = this.props;
 
         if (isSignedIn()) {
             history.push({ pathname: appendWithStoreCode('/my-account/dashboard') });
@@ -365,6 +368,11 @@ export class HeaderContainer extends NavigationAbstractContainer {
 
         this.setState({ showMyAccountLogin: true }, () => {
             showOverlay(CUSTOMER_ACCOUNT_OVERLAY_KEY);
+            setNavigationState({
+                name: CHECKOUT_ACCOUNT,
+                title: 'Sign in',
+                onCloseClick: this.closeOverlay
+            });
         });
     }
 
@@ -410,6 +418,8 @@ export class HeaderContainer extends NavigationAbstractContainer {
             navigationState: { name },
             device
         } = this.props;
+
+        console.debug('onMinicartButtonClick', name);
 
         if (name === CART_OVERLAY) {
             return;

--- a/packages/scandipwa/src/component/Header/Header.container.js
+++ b/packages/scandipwa/src/component/Header/Header.container.js
@@ -355,10 +355,7 @@ export class HeaderContainer extends NavigationAbstractContainer {
     }
 
     onMyAccountButtonClick() {
-        const {
-            showOverlay,
-            setNavigationState
-        } = this.props;
+        const { showOverlay } = this.props;
 
         if (isSignedIn()) {
             history.push({ pathname: appendWithStoreCode('/my-account/dashboard') });
@@ -368,11 +365,6 @@ export class HeaderContainer extends NavigationAbstractContainer {
 
         this.setState({ showMyAccountLogin: true }, () => {
             showOverlay(CUSTOMER_ACCOUNT_OVERLAY_KEY);
-            setNavigationState({
-                name: CHECKOUT_ACCOUNT,
-                title: 'Sign in',
-                onCloseClick: this.closeOverlay
-            });
         });
     }
 

--- a/packages/scandipwa/src/store/MyAccount/MyAccount.dispatcher.js
+++ b/packages/scandipwa/src/store/MyAccount/MyAccount.dispatcher.js
@@ -18,6 +18,8 @@ import {
     updateCustomerSignInStatus,
     updateIsLoading
 } from 'Store/MyAccount/MyAccount.action';
+import { goToPreviousNavigationState } from 'Store/Navigation/Navigation.action';
+import { TOP_NAVIGATION_TYPE } from 'Store/Navigation/Navigation.reducer';
 import { showNotification } from 'Store/Notification/Notification.action';
 import { ORDERS } from 'Store/Order/Order.reducer';
 import { hideActiveOverlay } from 'Store/Overlay/Overlay.action';
@@ -245,6 +247,7 @@ export class MyAccountDispatcher {
 
         dispatch(updateCustomerSignInStatus(true));
         dispatch(updateIsLoading(false));
+        dispatch(goToPreviousNavigationState(TOP_NAVIGATION_TYPE));
         dispatch(hideActiveOverlay());
         dispatch(showNotification('success', __('You are successfully logged in!')));
 


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/3155

Click on minicart icon actually makes `<CartOverlay>` appear, yet it is being hidden before user is even able to notice it. The reason for this is trigger of `hideActiveOverlay()` via the following code:
```
if (device.isMobile || ![CUSTOMER_ACCOUNT, CUSTOMER_SUB_ACCOUNT, CHECKOUT_ACCOUNT].includes(name)) {
            return;
 }

 hideActiveOverlay();
```

It is custom logic that should work only for customer related navigation states (CUSTOMER_ACCOUNT, CUSTOMER_SUB_ACCOUNT and CHECKOUT_ACCOUNT), not for home page. But this code is being triggered, as navigation state is incorrect at the moment when you click cart icon just after login (navigation state name equals CHECKOUT_ACCOUNT). So in order to fix the issue you need to get rid of wrong navigation state => the appropriate solution is to change navigation state on successful sign in.

Also added fix for https://github.com/scandipwa/scandipwa/issues/3191, as constant errors on login/logout made debugging impossible.

 