### PR TITLE
swipe to delete animation

### DIFF
--- a/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.component.js
+++ b/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.component.js
@@ -187,7 +187,6 @@ export class SwipeToDelete extends PureComponent {
                   mods={ { isAheadRemoveItemThreshold } }
                   mix={ rightSideMix }
                 >
-                    <div block="SwipeToDelete" elem="SafeArea" />
                     { renderRightSideContent() }
                 </div>
             </div>

--- a/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.style.scss
+++ b/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.style.scss
@@ -32,24 +32,17 @@
         width: calc(-1 * var(--translateX));
         transition: width var(--animation-speed) ease-out;
         overflow: hidden;
+        padding-inline-start: 16px;
     }
 
     &-RightSideContent {
         height: 100%;
         margin-inline-start: calc(100% - var(--end-side-content-width));
-        display: flex;
-        justify-content: flex-end;
-        align-items: center;
         width: var(--end-side-content-width);
         transition: margin-inline-start var(--right-side-content-animation-speed) ease-out;
 
         &_isAheadRemoveItemThreshold {
             margin-inline-start: 0;
         }
-    }
-
-    &-SafeArea {
-        width: 16px;
-        height: 100%;
     }
 }


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/3200

Fixed by removing `display: flex` and changing styles accordingly from a container => flexbox is too clever and always allocates space for text `Delete` first and only then to less important blocks and margins.