### PR TITLE
#3248 - no go back after popup close

### DIFF
--- a/packages/scandipwa/src/component/NewVersionPopup/NewVersionPopup.container.js
+++ b/packages/scandipwa/src/component/NewVersionPopup/NewVersionPopup.container.js
@@ -19,6 +19,7 @@ import { hideActiveOverlay } from 'Store/Overlay/Overlay.action';
 import { showPopup } from 'Store/Popup/Popup.action';
 import { DeviceType } from 'Type/Device';
 import { isCrawler, isSSR } from 'Util/Browser';
+import history from 'Util/History';
 
 import NewVersionPopup from './NewVersionPopup.component';
 import { NEW_VERSION_POPUP_ID } from './NewVersionPopup.config';
@@ -78,6 +79,7 @@ export class NewVersionPopupContainer extends PureComponent {
         const { hideActiveOverlay } = this.props;
 
         hideActiveOverlay();
+        history.goBack();
     }
 
     render() {

--- a/packages/scandipwa/src/component/Popup/Popup.component.js
+++ b/packages/scandipwa/src/component/Popup/Popup.component.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 /**
  * ScandiPWA - Progressive Web App for Magento
  *
@@ -101,7 +99,7 @@ export class Popup extends Overlay {
     hidePopupAndGoBack = () => {
         this.hidePopUp();
         history.goBack();
-    }
+    };
 
     // Same with click outside
     handleClickOutside = () => {

--- a/packages/scandipwa/src/component/Popup/Popup.component.js
+++ b/packages/scandipwa/src/component/Popup/Popup.component.js
@@ -1,4 +1,4 @@
-/* eslint-disable react/no-unused-prop-types */
+/* eslint-disable */
 
 /**
  * ScandiPWA - Progressive Web App for Magento
@@ -18,6 +18,7 @@ import ClickOutside from 'Component/ClickOutside';
 import CloseIcon from 'Component/CloseIcon';
 import NotificationList from 'Component/NotificationList';
 import Overlay from 'Component/Overlay/Overlay.component';
+import history from 'Util/History';
 
 import { ESCAPE_KEY } from './Popup.config';
 
@@ -88,6 +89,7 @@ export class Popup extends Overlay {
     hidePopUp = () => {
         const { hideActiveOverlay, goToPreviousNavigationState, onClose } = this.props;
         const isVisible = this.getIsVisible();
+
         if (isVisible) {
             this.unfreezeScroll();
             hideActiveOverlay();
@@ -96,19 +98,24 @@ export class Popup extends Overlay {
         }
     };
 
+    hidePopupAndGoBack = () => {
+        this.hidePopUp();
+        history.goBack();
+    }
+
     // Same with click outside
     handleClickOutside = () => {
         const { clickOutside } = this.props;
         if (!clickOutside) {
             return;
         }
-        this.hidePopUp();
+        this.hidePopupAndGoBack();
     };
 
     handleKeyDown = (e) => {
         switch (e.keyCode) {
         case ESCAPE_KEY:
-            this.hidePopUp();
+            this.hidePopupAndGoBack();
             break;
         default:
             break;
@@ -134,7 +141,7 @@ export class Popup extends Overlay {
               block="Popup"
               elem="CloseBtn"
               aria-label={ __('Close') }
-              onClick={ this.hidePopUp }
+              onClick={ this.hidePopupAndGoBack }
             >
                 <CloseIcon />
             </button>

--- a/packages/scandipwa/src/component/Popup/Popup.container.js
+++ b/packages/scandipwa/src/component/Popup/Popup.container.js
@@ -54,17 +54,20 @@ export class PopupContainer extends PureComponent {
         changeHeaderState: PropTypes.func.isRequired,
         onVisible: PropTypes.func,
         onClose: PropTypes.func,
+        onHide: PropTypes.func,
         isStatic: PropTypes.bool,
         children: ChildrenType,
         id: PropTypes.string.isRequired,
         shouldPopupClose: PropTypes.bool.isRequired,
         isMobile: PropTypes.bool.isRequired,
-        hideActiveOverlay: PropTypes.func.isRequired
+        hideActiveOverlay: PropTypes.func.isRequired,
+        resetHideActivePopup: PropTypes.func.isRequired
     };
 
     static defaultProps = {
         onVisible: () => {},
         onClose: () => {},
+        onHide: () => {},
         mix: {},
         contentMix: {},
         children: [],
@@ -78,10 +81,13 @@ export class PopupContainer extends PureComponent {
     onVisible() {
         const { changeHeaderState, onVisible } = this.props;
 
+        console.debug('trigger on visible');
+
         changeHeaderState({
             name: POPUP,
             title: this._getPopupTitle(),
             onCloseClick: () => {
+                console.debug('onCloseClick');
                 history.back();
             }
         });
@@ -101,8 +107,11 @@ export class PopupContainer extends PureComponent {
             mix,
             contentMix,
             onClose,
+            onHide,
             onVisible,
+            shouldPopupClose,
             hideActiveOverlay,
+            resetHideActivePopup,
             goToPreviousNavigationState
         } = this.props;
 
@@ -116,9 +125,12 @@ export class PopupContainer extends PureComponent {
             isStatic,
             mix,
             contentMix,
+            shouldPopupClose,
             onClose,
+            onHide,
             onVisible,
             hideActiveOverlay,
+            resetHideActivePopup,
             goToPreviousNavigationState,
             title: this._getPopupTitle()
         };

--- a/packages/scandipwa/src/component/Popup/Popup.container.js
+++ b/packages/scandipwa/src/component/Popup/Popup.container.js
@@ -81,13 +81,10 @@ export class PopupContainer extends PureComponent {
     onVisible() {
         const { changeHeaderState, onVisible } = this.props;
 
-        console.debug('trigger on visible');
-
         changeHeaderState({
             name: POPUP,
             title: this._getPopupTitle(),
             onCloseClick: () => {
-                console.debug('onCloseClick');
                 history.back();
             }
         });


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/3248

There is difference between closing popup via hitting BACK button in browser and closing popup via click on Cross button, click outside or Escape key.

In first case we subscribe to `popstate` event. Popstate event  is fired when the active history entry changes while the user navigates the session history ( = so it occurs naturally).
```
window.addEventListener('popstate', this.hidePopUp);
```

When we close popup in some other ways, we also need to go back through history one step.