### PR TITLE
#3267 Fallback label for bundle options

### DIFF
--- a/packages/scandipwa/src/component/ProductBundleItem/ProductBundleItem.component.js
+++ b/packages/scandipwa/src/component/ProductBundleItem/ProductBundleItem.component.js
@@ -72,9 +72,13 @@ export class ProductBundleItem extends ProductCustomizableOption {
             price_type,
             quantity,
             finalOptionPrice,
-            price
+            price,
+            product: {
+                name
+            } = {}
         } = item;
 
+        const optionLabel = label || name || '';
         const priceLabel = renderOptionLabel(price_type, finalOptionPrice, price, currencyCode);
         const isCheckboxSelected = getIsCheckboxSelected(id);
 
@@ -82,7 +86,7 @@ export class ProductBundleItem extends ProductCustomizableOption {
             <div key={ id }>
                 <Field
                   type="checkbox"
-                  label={ this.renderHeading(label, priceLabel, quantity) }
+                  label={ this.renderHeading(optionLabel, priceLabel, quantity) }
                   id={ `option-${ id }` }
                   name={ `option-${ id }` }
                   value={ id }

--- a/packages/scandipwa/src/component/ProductBundleItem/ProductBundleItem.container.js
+++ b/packages/scandipwa/src/component/ProductBundleItem/ProductBundleItem.container.js
@@ -194,14 +194,18 @@ export class ProductBundleItemContainer extends ProductCustomizableOptionContain
             can_change_quantity,
             finalOptionPrice,
             price,
-            position
+            position,
+            product: {
+                name
+            } = {}
         }) => {
+            const optionLabel = label || name || '';
             const subLabel = this.renderOptionLabel(price_type, finalOptionPrice, price, currencyCode);
-            const dropdownLabel = !can_change_quantity ? `${ quantity } x ${ label } ` : `${ label } `;
+            const dropdownLabel = !can_change_quantity ? `${ quantity } x ${ optionLabel } ` : `${ optionLabel } `;
 
             acc.push({
                 id,
-                name: label,
+                name: optionLabel,
                 value: id,
                 label: dropdownLabel,
                 subLabel,


### PR DESCRIPTION
Original Issue:
* https://github.com/scandipwa/scandipwa/issues/3267

BE fixes:
* https://github.com/scandipwa/catalog-graphql/pull/119
(Will work also without this, but this solves be issue for returning null)

In this PR:
* Added fallback for bundle label.