### PR TITLE
#3274 Display correct cms in checkout

### DIFF
--- a/packages/scandipwa/src/component/CmsBlock/CmsBlock.container.js
+++ b/packages/scandipwa/src/component/CmsBlock/CmsBlock.container.js
@@ -36,6 +36,15 @@ export class CmsBlockContainer extends DataContainer {
         this._getCmsBlock();
     }
 
+    componentDidUpdate(prevProps) {
+        const { identifier } = this.props;
+        const { identifier: prevIdentifier } = prevProps;
+
+        if (identifier !== prevIdentifier) {
+            this._getCmsBlock();
+        }
+    }
+
     _getCmsBlock() {
         const { identifier } = this.props;
 

--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -367,7 +367,7 @@ export class Checkout extends PureComponent {
         const { checkoutStep, isMobile } = this.props;
         const isBilling = checkoutStep === BILLING_STEP;
 
-        if (!showOnMobile && isMobile) {
+        if ((!showOnMobile && isMobile) || checkoutStep === DETAILS_STEP) {
             return null;
         }
 


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3274

**Problem:**
* No check for `DETAILS_STEP`, so on order success outputs cms block for shipping step
* CmsBlock fetches content only on func `componentDidMount`, this function will be called only once after first render... so if identifier is change method will not be called, because component already is mounted.

**In this PR:**
* Added check for `DETAILS_STEP`.
* Added updating of CmsBlock content on identifier change.