### PR TITLE
#3296 Redirects from newsletter to dashboard on reload

### DIFF
--- a/packages/scandipwa/src/store/Config/Config.reducer.js
+++ b/packages/scandipwa/src/store/Config/Config.reducer.js
@@ -63,7 +63,6 @@ export const getInitialState = () => ({
     cartDisplayConfig,
     priceTaxDisplay: {},
     category_url_suffix: DEFAULT_CATGORY_URL_SUFFIX,
-    newsletter_general_active: false,
     device: {
         isMobile: true,
         android: true,


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3296

**Problem:**
* Default value for `newsletter_general_active` is set to false, and is updated to true only when graphql has fetched value, thus MyAccount when performing check if requires redirect will always redirect, becouse on first check `newsletter_general_active` will always be false.

**In this PR:**
* By removing default value in reducer it seems to use last retrieved value, which in the end is the best solution in this case. (works same as wishlist tab now)