### PR TITLE
#3306 Redirect fix for myaccount

### DIFF
--- a/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
@@ -48,7 +48,8 @@ export const mapStateToProps = (state) => ({
     isWishlistEnabled: state.ConfigReducer.wishlist_general_active,
     wishlistItems: state.WishlistReducer.productsInWishlist,
     isSignedIn: state.MyAccountReducer.isSignedIn,
-    newsletterActive: state.ConfigReducer.newsletter_general_active
+    newsletterActive: state.ConfigReducer.newsletter_general_active,
+    baseLinkUrl: state.ConfigReducer.base_link_url
 });
 
 /** @namespace Route/MyAccount/Container/mapDispatchToProps */
@@ -79,7 +80,8 @@ export class MyAccountContainer extends PureComponent {
         wishlistItems: PropTypes.object,
         newsletterActive: PropTypes.bool.isRequired,
         isWishlistEnabled: PropTypes.bool.isRequired,
-        isSignedIn: PropTypes.bool.isRequired
+        isSignedIn: PropTypes.bool.isRequired,
+        baseLinkUrl: PropTypes.string.isRequired
     };
 
     static defaultProps = {
@@ -201,13 +203,16 @@ export class MyAccountContainer extends PureComponent {
 
         const {
             wishlistItems,
-            isSignedIn: currIsSignedIn
+            isSignedIn: currIsSignedIn,
+            baseLinkUrl
         } = this.props;
 
         const { activeTab: prevActiveTab } = prevState;
         const { activeTab } = this.state;
 
-        this.redirectIfNotSignedIn();
+        if (baseLinkUrl) {
+            this.redirectIfNotSignedIn();
+        }
 
         if (prevIsSignedIn !== currIsSignedIn) {
             this.changeHeaderState();
@@ -391,7 +396,7 @@ export class MyAccountContainer extends PureComponent {
             return;
         }
 
-        history.push({ pathname: appendWithStoreCode('/') });
+        history.push({ pathname: appendWithStoreCode('/account/login') });
     }
 
     render() {


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3306

**Problem:**
* User is redirected to homepage instead of login page
* When opening MyAccount page directly from icognito mode, there will be no graphql responses yet, thus `base_link_url` will be null. Due to that we have loop in method `componentDidUpdate` where prop for history is updated to the same URL (thus invoking componentDidUpdate again, and again). We are getting error: Max update count exceeded. 

**In this PR:**
* Checking for prop `base_link_url` to be loaded, and then redirecting.