### PR TITLE
#3306 Correct URL redirect on non-logged + icognito

### DIFF
--- a/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
@@ -28,10 +28,10 @@ import { HistoryType, LocationType, MatchType } from 'Type/Common';
 import { isSignedIn } from 'Util/Auth';
 import { withReducers } from 'Util/DynamicReducer';
 import history from 'Util/History';
-import { appendWithStoreCode } from 'Util/Url';
+import { appendWithStoreCode, replace } from 'Util/Url';
 
 import MyAccount from './MyAccount.component';
-import { MY_ACCOUNT_URL } from './MyAccount.config';
+import { ACCOUNT_LOGIN_URL, MY_ACCOUNT_URL } from './MyAccount.config';
 
 export const BreadcrumbsDispatcher = import(
     /* webpackMode: "lazy", webpackChunkName: "dispatchers" */
@@ -131,6 +131,7 @@ export class MyAccountContainer extends PureComponent {
     static navigateToSelectedTab(props, state = {}) {
         const {
             history,
+            isSignedIn,
             match: {
                 params: {
                     tab: historyActiveTab
@@ -145,7 +146,7 @@ export class MyAccountContainer extends PureComponent {
             ? historyActiveTab
             : DASHBOARD;
 
-        if (historyActiveTab !== newActiveTab) {
+        if (historyActiveTab !== newActiveTab && isSignedIn) {
             history.push(appendWithStoreCode(`${ MY_ACCOUNT_URL }/${ newActiveTab }`));
         }
 
@@ -203,16 +204,13 @@ export class MyAccountContainer extends PureComponent {
 
         const {
             wishlistItems,
-            isSignedIn: currIsSignedIn,
-            baseLinkUrl
+            isSignedIn: currIsSignedIn
         } = this.props;
 
         const { activeTab: prevActiveTab } = prevState;
         const { activeTab } = this.state;
 
-        if (baseLinkUrl) {
-            this.redirectIfNotSignedIn();
-        }
+        this.redirectIfNotSignedIn();
 
         if (prevIsSignedIn !== currIsSignedIn) {
             this.changeHeaderState();
@@ -379,7 +377,8 @@ export class MyAccountContainer extends PureComponent {
         const {
             history,
             location: { pathname },
-            isMobile
+            isMobile,
+            baseLinkUrl
         } = this.props;
 
         if (isSignedIn()) { // do nothing for signed-in users
@@ -396,7 +395,11 @@ export class MyAccountContainer extends PureComponent {
             return;
         }
 
-        history.push({ pathname: appendWithStoreCode('/account/login') });
+        const path = baseLinkUrl
+            ? appendWithStoreCode(ACCOUNT_LOGIN_URL)
+            : replace(/\/my-account\/.*/, ACCOUNT_LOGIN_URL);
+
+        history.push({ pathname: path });
     }
 
     render() {

--- a/packages/scandipwa/src/util/Url/Url.js
+++ b/packages/scandipwa/src/util/Url/Url.js
@@ -59,6 +59,17 @@ export const getUrlParam = (match, location) => {
 export const trimEndSlash = (str) => (str.endsWith('/') ? str.slice(0, -1) : str);
 
 /**
+ * Replaces section of URL with passed path value
+ * @param {RegExp} regex replacement rule
+ * @param {String} path replacement element
+ * @returns {*}
+ */
+export const replace = (regex, path) => {
+    const { pathname = '' } = new URL(window.location.href);
+    return pathname.replace(regex, path);
+};
+
+/**
  * Append store code to URL
  * @param {String} pathname the URL to append store code to
  * @namespace Util/Url/appendWithStoreCode

--- a/packages/scandipwa/src/util/Url/Url.js
+++ b/packages/scandipwa/src/util/Url/Url.js
@@ -63,6 +63,7 @@ export const trimEndSlash = (str) => (str.endsWith('/') ? str.slice(0, -1) : str
  * @param {RegExp} regex replacement rule
  * @param {String} path replacement element
  * @returns {*}
+ * @namespace Util/Url/replace
  */
 export const replace = (regex, path) => {
     const { pathname = '' } = new URL(window.location.href);


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3306

**Problem**
* Due to base URL not  existing on first open in icognito mode _(due to graphql still fetching it)_, redirectred URL in header will contain original URL + '/account/login', due to how `appendWithStoreCode` function works.
* `navigateToSelectedTab` will be always executed so it will always append `my-account/{ active-tab }` to end of URL.

**In this PR**
* Added new URL function that replaces path section based on regex rule
* If URL is not yet fetched use replace to redirect from my-account
* Redirect to different my-account tabs only if signed-in