### PR TITLE
#1864 - price filter wrong products

### DIFF
--- a/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.container.js
+++ b/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.container.js
@@ -54,14 +54,45 @@ export class ResetAttributesContainer extends PureComponent {
         };
     }
 
-    getFilterOptionsForPrice = (options) => options.map((option) => {
-        const { currency_code } = this.props;
+    getFilterOptionsForPrice = (values, options) => {
+        // no multiselect for price, always 1 selected value
+        const [fromValue, toValue] = values[0].split('_');
 
-        const [from, to] = option.split('_');
-        const label = getPriceFilterLabel(from, to, currency_code);
+        return options
+            .filter(({ value_string }) => value_string.startsWith(fromValue))
+            .map((option) => {
+                const { currency_code } = this.props;
+                const { label: initialLabel, value_string } = option;
 
-        return { value_string: option, label };
-    });
+                const [from, to] = initialLabel.split('~');
+                const rangeEnd = toValue === '*' ? toValue : to;
+
+                const label = getPriceFilterLabel(from, rangeEnd, currency_code);
+
+                return { value_string, label };
+            });
+    };
+
+    getFilterOptionsForPrice2 = (values, options) => options
+        .filter((option) => values.some((v) => option.value_string.startsWith(v.replace(/(\d_).*/, '$1'))))
+        .map((option) => {
+            const { currency_code } = this.props;
+
+            const [fromLabel, toLabel] = option.label.split('~');
+            const [fromValue, toValue] = values[0].split('_');
+
+            console.debug({
+                option, values, toLabel, toValue
+            });
+
+            const label = getPriceFilterLabel(
+                fromValue === '*' ? fromValue : fromLabel,
+                toValue === '*' ? toValue : toLabel,
+                currency_code
+            );
+
+            return { value_string: options.value_string, label };
+        });
 
     getFilterOptionsDefault = (values, options) => options.filter((option) => values.includes(option.value_string));
 

--- a/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.container.js
+++ b/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.container.js
@@ -73,27 +73,6 @@ export class ResetAttributesContainer extends PureComponent {
             });
     };
 
-    getFilterOptionsForPrice2 = (values, options) => options
-        .filter((option) => values.some((v) => option.value_string.startsWith(v.replace(/(\d_).*/, '$1'))))
-        .map((option) => {
-            const { currency_code } = this.props;
-
-            const [fromLabel, toLabel] = option.label.split('~');
-            const [fromValue, toValue] = values[0].split('_');
-
-            console.debug({
-                option, values, toLabel, toValue
-            });
-
-            const label = getPriceFilterLabel(
-                fromValue === '*' ? fromValue : fromLabel,
-                toValue === '*' ? toValue : toLabel,
-                currency_code
-            );
-
-            return { value_string: options.value_string, label };
-        });
-
     getFilterOptionsDefault = (values, options) => options.filter((option) => values.includes(option.value_string));
 
     getResetData = (attrCode, attrValues) => {


### PR DESCRIPTION
Issue 1 from https://github.com/scandipwa/scandipwa/issues/1864, i.e. Not all products displayed belong to the specific price step that is selected.

BE PR: https://github.com/scandipwa/catalog-graphql/pull/115

The problem was that labels range was used instead of values range for price filter. If search is in non base currency, values in base currency should still be used for search. In this case labels and values will be different.