### PR TITLE
Fixed Namespaces

### DIFF
--- a/build-packages/eslint-plugin-scandipwa-guidelines/lib/rules/use-namespace.js
+++ b/build-packages/eslint-plugin-scandipwa-guidelines/lib/rules/use-namespace.js
@@ -1,1 +1,315 @@
-module.exports = require('@tilework/eslint-plugin-mosaic/lib/rules/use-namespace');
+/**
+* @fileoverview Use namespace decorators for exports
+* @author Jegors Batovs
+*/
+
+const path = require('path');
+const { getPackageJson } = require('@tilework/mosaic-dev-utils/package-json');
+const fixNamespaceLack = require('@tilework/eslint-plugin-mosaic/lib/util/fix-namespace-lack.js');
+const getLeadingCommentsForNode = require('@tilework/eslint-plugin-mosaic/lib/util/get-leading-comments');
+
+const types = {
+    ExportedClass: [
+        'ExportNamedDeclaration',
+        'ClassDeclaration'
+    ].join(' > '),
+
+    ExportedArrowFunction: [
+        'ExportNamedDeclaration',
+        'VariableDeclaration',
+        'VariableDeclarator',
+        'ArrowFunctionExpression'
+    ].join(' > '),
+
+    ExportedFunction: [
+        'ExportNamedDeclaration',
+        'FunctionDeclaration'
+    ].join(' > '),
+
+    isExportedClass: node => node.type === 'ClassDeclaration'
+        && node.parent.type === 'ExportNamedDeclaration',
+
+    isExportedArrowFunction: node => node.type === 'ArrowFunctionExpression'
+        && node.parent.type === 'VariableDeclarator'
+        && node.parent.parent.type === 'VariableDeclaration'
+        && node.parent.parent.parent.type === 'ExportNamedDeclaration',
+
+    isExportedFunction: node => node.type === 'FunctionDeclaration'
+        && node.parent.type === 'ExportNamedDeclaration',
+
+    PromiseHandlerArrowFunction: [
+        [
+            "CallExpression",
+            "[callee.type='MemberExpression']",
+            "[callee.object.name!=/.+Dispatcher/]",
+            ":matches(",
+            [
+                "[callee.property.name='then']",
+                "[callee.property.name='catch']",
+                "[callee.property.name='finally']"
+            ].join(', '),
+            ")"
+        ].join(''),
+        'ArrowFunctionExpression'
+    ].join(' > '),
+
+    isPromiseHandlerArrowFunction: (node) => {
+        const { parent } = node;
+        const promiseHandlerNames = ['then', 'catch', 'finally'];
+
+        return (
+            node.type === 'ArrowFunctionExpression'
+            && parent.type === 'CallExpression'
+            && parent.callee.type === 'MemberExpression'
+            && !(parent.callee.object.name || "").endsWith('Dispatcher')
+            && promiseHandlerNames.includes(parent.callee.property.name)
+        );
+    },
+
+    isHandleableArrowFunction: node => types.isExportedArrowFunction(node)
+        || types.isPromiseHandlerArrowFunction(node),
+
+    detectType: node => {
+        if (types.isPromiseHandlerArrowFunction(node)) {
+            return 'promise handler arrow function';
+        }
+
+        if (types.isExportedArrowFunction(node)) {
+            return 'exported arrow function';
+        }
+
+        if (types.isExportedClass(node)) {
+            return 'exported class';
+        }
+
+        if (types.isExportedFunction(node)) {
+            return 'exported function';
+        }
+    }
+};
+
+const getProperParentNode = (node) => {
+    if (types.isExportedClass(node)) {
+        return node.parent;
+    }
+
+    if (types.isExportedArrowFunction(node)) {
+        return node.parent.parent.parent;
+    }
+
+    if (types.isPromiseHandlerArrowFunction(node)) {
+        return node;
+    }
+
+    if (types.isExportedFunction(node)) {
+        return node.parent;
+    }
+
+    return {};
+};
+
+const getNamespaceCommentForNode = (node, sourceCode) => {
+    const getNamespaceFromComments = (comments = []) => comments.find(
+        comment => comment.value.includes('@namespace')
+    );
+
+    return getNamespaceFromComments(
+        getLeadingCommentsForNode(getProperParentNode(node), sourceCode)
+    );
+};
+
+const collectFunctionNamespace = (node, stack) => {
+    const { type } = node;
+
+    switch (type) {
+        case 'ArrowFunctionExpression':
+            const name = node.body?.callee?.name;
+
+            if (node.parent?.arguments?.indexOf(node) === 1) {
+                stack.push('catch');
+            }
+
+            if (name) {
+                stack.push(name);
+            }
+
+            break;
+        case 'CallExpression':
+            if (node.callee.type === 'MemberExpression') {
+                stack.push(
+                    node.callee?.property?.name,
+                    node.callee?.object?.name
+                        || node.callee?.object?.callee?.name
+                        || node.callee?.object?.callee?.property?.name
+                );
+            } else {
+                stack.push(node.callee.name);
+            }
+
+            break;
+        case 'Identifier':
+            stack.push(node.name);
+            break;
+        case 'MethodDefinition':
+            stack.push(node.key.name);
+            break;
+        case 'VariableDeclarator':
+        case 'FunctionDeclaration':
+        case 'ClassDeclaration':
+            stack.push(node.id.name);
+    }
+
+    if (node.parent) {
+        collectFunctionNamespace(node.parent, stack);
+    }
+};
+
+const getNodeNamespace = (node) => {
+    const stack = [];
+
+    if (node.parent.type === 'VariableDeclarator') {
+        stack.push(node.parent.id.name);
+    } else if (node.type === 'ClassDeclaration') {
+        // stack.push(node.id.name);
+    } else {
+        collectFunctionNamespace(node, stack);
+    }
+
+    // not using path.sep on purpose
+    return stack.filter(Boolean).reverse().join('/');
+};
+
+const prepareFilePath = (pathname) => {
+    const {
+        name: filename,
+        dir
+    } = path.parse(pathname);
+
+    const [name, postfix = ''] = filename.split('.');
+
+    /**
+    * We do not want the \\ paths on Windows, rather / =>
+    * split and then join with correct delimiter
+    **/
+    return path.join(
+        dir,
+        // If dir name === file name without postfix => do not repeat it
+        new RegExp(`${path.sep}${name}$`).test(dir) ? '' : name,
+        postfix
+        ).split(path.sep)
+        // Filter out empty strings if they exist
+        .filter(x => !!x);
+};
+
+const preparePackageName = (packageName) => {
+    // This is on purpose not a path.sep (windows support)
+    const [org = '', name = ''] = packageName.split('/');
+
+    if (!name) {
+        // if there is no name => there is not ORG
+        if (packageName === '<%= name %>') {
+            return 'placeholder';
+        }
+
+        return packageName;
+    }
+
+    if (org === '@scandipwa') {
+        // Legacy support
+        if (name === 'scandipwa') {
+            return '';
+        }
+
+        return name;
+    }
+
+    return `${org.slice(1)}/${name}`;
+};
+
+const generateNamespace = (node, context) => {
+    const filename = context.getFilename();
+    const splitted = filename.split('src');
+    const toFile = splitted.pop();
+    const toPackage = path.normalize(splitted.join('src'));
+    const { name: packageName } = getPackageJson(toPackage);
+
+    // Not using path.join to support windows
+    const pathname = [
+        // remove @ from organization, support @scandipwa legacy namespaces
+        preparePackageName(packageName),
+        // Trim post-fixes if they are not present
+        ...prepareFilePath(toFile)
+    ].filter(Boolean).join('/').replace(
+        // Convert to pascal-case, and trim "-"
+        /\b[a-z](?=[a-z]{2})/g,
+        (letter) => letter.toUpperCase()
+        ).split('-').join('');
+
+    // Do not transform code to uppercase / lowercase it should be written alright
+    return [pathname, getNodeNamespace(node)].filter(Boolean).join('/');
+};
+
+const extractNamespaceFromComment = ({ value: comment = '' }) => {
+    const {
+        groups: {
+            namespace
+        } = {}
+    } = comment.match(/@namespace +(?<namespace>[^ ]+)/) || {};
+
+    return namespace;
+};
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'Use @namespace comment-decorators',
+            category: 'Extensibility',
+            recommended: true
+        },
+        fixable: 'code'
+    },
+
+    create: context => ({
+        [[
+            types.ExportedClass,
+            types.PromiseHandlerArrowFunction,
+            types.ExportedArrowFunction,
+            types.ExportedFunction
+        ].join(',')](node) {
+            const namespaceComment = getNamespaceCommentForNode(node, context.getSourceCode()) || { value: '' };
+            const namespaceCommentString = namespaceComment.value.split('@namespace').pop().trim();
+
+            const namespace = extractNamespaceFromComment(namespaceComment);
+            const generatedNamespace = generateNamespace(node, context);
+
+            if (!namespaceCommentString) {
+                context.report({
+                    node,
+                    message: `Provide namespace for ${types.detectType(node)} by using @namespace magic comment`,
+                    fix: fixer => fixNamespaceLack(
+                        fixer,
+                        getProperParentNode(node),
+                        context,
+                        generatedNamespace
+                        ) || []
+                });
+            } else if (generatedNamespace !== namespaceCommentString) {
+                context.report({
+                    node,
+                    message: `Namespace for this node is not valid! Consider changing it to ${generatedNamespace}`,
+                    fix: fixer => {
+                        const newNamespaceCommentContent = namespaceComment.value.replace(namespace, generatedNamespace);
+                        const newNamespaceComment = namespaceComment.type === 'Block'
+                            ? `/*${newNamespaceCommentContent}*/`
+                            : `// ${newNamespaceCommentContent}`;
+
+                        return fixer.replaceText(
+                            namespaceComment,
+                            newNamespaceComment
+                        );
+                    }
+                });
+            }
+        }
+    })
+};

--- a/build-packages/eslint-plugin-scandipwa-guidelines/lib/util/ast.js
+++ b/build-packages/eslint-plugin-scandipwa-guidelines/lib/util/ast.js
@@ -7,6 +7,12 @@ function getIdentifierOccurrences(context, name) {
         context,
         context.getSourceCode().ast,
         ({ node }) => {
+            if (!node) {
+                // if node is null, like in the code `const [, a] = b;`, then eslint-traverse crashes
+                // skip null nodes
+                return traverse.SKIP;
+            }
+
             if (
                 node.type !== 'Identifier'
                 || node.name !== name

--- a/packages/framework/src/component/App/App.component.js
+++ b/packages/framework/src/component/App/App.component.js
@@ -3,7 +3,7 @@ import { PureComponent } from 'react';
 
 import SomethingWentWrong from '../SomethingWentWrong/SomethingWentWrong.component';
 
-/** @namespace Framework/Component/App/Component/AppComponent */
+/** @namespace Framework/Component/App/Component */
 export class AppComponent extends PureComponent {
     static propTypes = {
         // eslint-disable-next-line react/forbid-prop-types

--- a/packages/framework/src/component/App/App.container.js
+++ b/packages/framework/src/component/App/App.container.js
@@ -2,7 +2,7 @@ import { PureComponent } from 'react';
 
 import App from './App.component';
 
-/** @namespace Framework/Component/App/Container/AppContainer */
+/** @namespace Framework/Component/App/Container */
 export class AppContainer extends PureComponent {
     productionFunctions = [
         this.disableReactDevTools.bind(this),

--- a/packages/framework/src/component/SomethingWentWrong/SomethingWentWrong.component.js
+++ b/packages/framework/src/component/SomethingWentWrong/SomethingWentWrong.component.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-/** @namespace Framework/Component/SomethingWentWrong/Component/SomethingWentWrongComponent */
+/** @namespace Framework/Component/SomethingWentWrong/Component */
 export class SomethingWentWrongComponent extends PureComponent {
     static propTypes = {
         onClick: PropTypes.func.isRequired,

--- a/packages/framework/src/component/SomethingWentWrong/SomethingWentWrong.container.js
+++ b/packages/framework/src/component/SomethingWentWrong/SomethingWentWrong.container.js
@@ -3,7 +3,7 @@ import { PureComponent } from 'react';
 
 import SomethingWentWrong from './SomethingWentWrong.component';
 
-/** @namespace Framework/Component/SomethingWentWrong/Container/SomethingWentWrongContainer */
+/** @namespace Framework/Component/SomethingWentWrong/Container */
 export class SomethingWentWrongContainer extends PureComponent {
     static propTypes = {
         onClick: PropTypes.func.isRequired,

--- a/packages/router/src/component/Router/Router.component.js
+++ b/packages/router/src/component/Router/Router.component.js
@@ -5,7 +5,7 @@ import { Route, Switch } from 'react-router-dom';
 
 export const history = createBrowserHistory({ basename: '/' });
 
-/** @namespace Router/Component/Router/Component/RouterComponent */
+/** @namespace Router/Component/Router/Component */
 export class RouterComponent extends PureComponent {
     static propTypes = {
     };

--- a/packages/router/src/component/Router/Router.container.js
+++ b/packages/router/src/component/Router/Router.container.js
@@ -2,7 +2,7 @@ import { PureComponent } from 'react';
 
 import Router from './Router.component';
 
-/** @namespace Router/Component/Router/Container/RouterContainer */
+/** @namespace Router/Component/Router/Container */
 export class RouterContainer extends PureComponent {
     static propTypes = {};
 

--- a/packages/scandipwa/.vscode/settings.json
+++ b/packages/scandipwa/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+    "cSpell.enableFiletypes": [
+        "!json"
+    ],
+    "cSpell.words": [
+        "Stateful",
+        "Unmount",
+        "CRACO",
+        "Magento",
+        "REBEM",
+        "Scandiweb",
+        "scandipwa"
+    ],
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
+    "search.exclude": {
+        "**/Magento_Theme": true
+    }
+}

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -166,7 +166,7 @@
             "@scandipwa/scandipwa-guidelines/derived-class-names": "off",
             "@scandipwa/scandipwa-guidelines/no-middleware": "error",
             "@scandipwa/scandipwa-guidelines/only-render-in-component": "off",
-            "@scandipwa/scandipwa-guidelines/use-namespace": "off",
+            "@scandipwa/scandipwa-guidelines/use-namespace": "error",
             "@scandipwa/scandipwa-guidelines/use-magic-construct": "error",
             "@scandipwa/scandipwa-guidelines/export-level-one": "error",
             "@scandipwa/scandipwa-guidelines/no-extensible-base": "error",

--- a/packages/scandipwa/src/component/AddToCart/AddToCart.container.js
+++ b/packages/scandipwa/src/component/AddToCart/AddToCart.container.js
@@ -315,9 +315,9 @@ export class AddToCartContainer extends PureComponent {
                 quantity
             });
         })).then(
-            /** @namespace Component/AddToCart/Container/addGroupedProductToCartPromiseAllThen */
+            /** @namespace Component/AddToCart/Container/AddToCartContainer/addGroupedProductToCart/all/then */
             () => this.afterAddToCart(),
-            /** @namespace Component/AddToCart/Container/addGroupedProductToCartPromiseAllCatch */
+            /** @namespace Component/AddToCart/Container/AddToCartContainer/addGroupedProductToCart/all/then/catch */
             () => this.resetLoading()
         );
     }
@@ -339,9 +339,9 @@ export class AddToCartContainer extends PureComponent {
             quantity,
             productOptionsData
         }).then(
-            /** @namespace Component/AddToCart/Container/addConfigurableProductToCartAddProductThen */
+            /** @namespace Component/AddToCart/Container/AddToCartContainer/addConfigurableProductToCart/addProduct/then */
             () => this.afterAddToCart(),
-            /** @namespace Component/AddToCart/Container/addConfigurableProductToCartAddProductCatch */
+            /** @namespace Component/AddToCart/Container/AddToCartContainer/addConfigurableProductToCart/addProduct/then/catch */
             () => this.resetLoading()
         );
     }
@@ -359,9 +359,9 @@ export class AddToCartContainer extends PureComponent {
             quantity,
             productOptionsData
         }).then(
-            /** @namespace Component/AddToCart/Container/addSimpleProductToCartAddProductThen */
+            /** @namespace Component/AddToCart/Container/AddToCartContainer/addSimpleProductToCart/addProduct/then */
             () => this.afterAddToCart(),
-            /** @namespace Component/AddToCart/Container/addSimpleProductToCartAddProductCatch */
+            /** @namespace Component/AddToCart/Container/AddToCartContainer/addSimpleProductToCart/addProduct/then/catch */
             () => this.resetLoading()
         );
     }

--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.container.js
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.container.js
@@ -78,10 +78,10 @@ export class CartCouponContainer extends PureComponent {
         this.setState({ isLoading: true });
 
         applyCouponToCart(couponCode).then(
-            /** @namespace Component/CartCoupon/Container/applyCouponToCartThen */
+            /** @namespace Component/CartCoupon/Container/CartCouponContainer/handleApplyCouponToCart/then/finally/applyCouponToCart/then/onCouponCodeUpdate */
             () => onCouponCodeUpdate()
         ).finally(
-            /** @namespace Component/CartCoupon/Container/applyCouponToCartFinally */
+            /** @namespace Component/CartCoupon/Container/CartCouponContainer/handleApplyCouponToCart/then/finally */
             () => this.setState({ isLoading: false })
         );
     }
@@ -92,10 +92,10 @@ export class CartCouponContainer extends PureComponent {
         this.setState({ isLoading: true });
 
         removeCouponFromCart().then(
-            /** @namespace Component/CartCoupon/Container/removeCouponFromCartThen */
+            /** @namespace Component/CartCoupon/Container/CartCouponContainer/handleRemoveCouponFromCart/then/finally/removeCouponFromCart/then/onCouponCodeUpdate */
             () => onCouponCodeUpdate()
         ).finally(
-            /** @namespace Component/CartCoupon/Container/removeCouponFromCartFinally */
+            /** @namespace Component/CartCoupon/Container/CartCouponContainer/handleRemoveCouponFromCart/then/finally */
             () => this.setState({ isLoading: false })
         );
     }

--- a/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.container.js
+++ b/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.container.js
@@ -48,7 +48,7 @@ export class CurrencySwitcherContainer extends DataContainer {
         const { updateCurrency } = this.props;
 
         updateCurrency({ currencyCode }).then(
-            /** @namespace Component/CurrencySwitcher/Container/updateCurrencyThen */
+            /** @namespace Component/CurrencySwitcher/Container/CurrencySwitcherContainer/_handleCurrencySelect/updateCurrency/then */
             () => location.reload()
         );
     }

--- a/packages/scandipwa/src/component/Form/Form.component.js
+++ b/packages/scandipwa/src/component/Form/Form.component.js
@@ -214,7 +214,7 @@ export class Form extends PureComponent {
         }, []));
 
         asyncData.then(
-            /** @namespace Component/Form/Component/handleFormSubmitAsyncDataThen */
+            /** @namespace Component/Form/Component/Form/asyncData/then */
             (asyncDataList) => {
                 if (!invalidFields.length) {
                     onSubmitSuccess(inputValues, asyncDataList);
@@ -224,7 +224,7 @@ export class Form extends PureComponent {
 
                 onSubmitError(inputValues, invalidFields);
             },
-            /** @namespace Component/Form/Component/handleFormSubmitAsyncDataCatch */
+            /** @namespace Component/Form/Component/Form/asyncData/then/onSubmitError/catch */
             (e) => onSubmitError(inputValues, invalidFields, e)
         );
     };

--- a/packages/scandipwa/src/component/ImageZoomPopup/ImageZoomPopup.container.js
+++ b/packages/scandipwa/src/component/ImageZoomPopup/ImageZoomPopup.container.js
@@ -31,7 +31,7 @@ export const mapDispatchToProps = (dispatch) => ({
     hideActiveOverlay: () => dispatch(hideActiveOverlay())
 });
 
-/** @namespace Component/MyAccountAddressBook/Container */
+/** @namespace Component/ImageZoomPopup/Container */
 export class ImageZoomPopupContainer extends PureComponent {
     static propTypes = {
         children: ChildrenType.isRequired,

--- a/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.container.js
+++ b/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.container.js
@@ -66,7 +66,7 @@ export class InstallPromptContainer extends PureComponent {
 
         // Wait for the user to respond to the prompt
         window.promt_event.userChoice.then(
-            /** @namespace Component/InstallPrompt/Container/then */
+            /** @namespace Component/InstallPrompt/Container/InstallPromptContainer/handleAppInstall/then */
             (choice) => {
                 if (choice.outcome === 'accepted') {
                     this.setState({ isBannerClosed: true });

--- a/packages/scandipwa/src/component/MenuItem/MenuItem.container.js
+++ b/packages/scandipwa/src/component/MenuItem/MenuItem.container.js
@@ -26,7 +26,7 @@ export const mapStateToProps = (state) => ({
 /** @namespace Component/MenuItem/Container/mapDispatchToProps */
 export const mapDispatchToProps = () => ({});
 
-/** @namespace Component/MenuItem/Container/menuItemContainer */
+/** @namespace Component/MenuItem/Container */
 export class MenuItemContainer extends PureComponent {
     static propTypes = {
         closeMenu: PropTypes.func,

--- a/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.container.js
+++ b/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.container.js
@@ -83,7 +83,7 @@ export class MyAccountAddressPopupContainer extends PureComponent {
         } = this.props;
 
         updateCustomerDetails().then(
-            /** @namespace Component/MyAccountAddressPopup/Container/updateCustomerDetailsThen */
+            /** @namespace Component/MyAccountAddressPopup/Container/MyAccountAddressPopupContainer/updateCustomerDetails/then */
             () => {
                 this.setState({ isLoading: false }, () => {
                     hideActiveOverlay();

--- a/packages/scandipwa/src/component/MyAccountCustomerPopup/MyAccountCustomerPopup.container.js
+++ b/packages/scandipwa/src/component/MyAccountCustomerPopup/MyAccountCustomerPopup.container.js
@@ -100,7 +100,7 @@ export class MyAccountCustomerPopupContainer extends PureComponent {
         this.setState({ isLoading: true });
 
         return fetchMutation(mutation).then(
-            /** @namespace Component/MyAccountCustomerPopup/Container/onCustomerSaveFetchMutationThen */
+            /** @namespace Component/MyAccountCustomerPopup/Container/MyAccountCustomerPopupContainer/onCustomerSave/fetchMutation/then */
             ({ updateCustomer: { customer } }) => {
                 BrowserDatabase.setItem(customer, CUSTOMER, ONE_MONTH_IN_SECONDS);
                 updateCustomer(customer);
@@ -128,7 +128,7 @@ export class MyAccountCustomerPopupContainer extends PureComponent {
         this.setState({ isLoading: true });
 
         return fetchMutation(mutation).then(
-            /** @namespace Component/MyAccountCustomerPopup/Container/onPasswordChangeFetchMutationThen */
+            /** @namespace Component/MyAccountCustomerPopup/Container/MyAccountCustomerPopupContainer/onPasswordChange/fetchMutation/then */
             () => {
                 showSuccessNotification(__('Your password was successfully updated!'));
                 this.setState({ isLoading: false }, () => {

--- a/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.container.js
+++ b/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.container.js
@@ -104,11 +104,13 @@ export class MyAccountDownloadableContainer extends PureComponent {
             OrderQuery.getDownloadableQuery()
         ).then(
             /** @namespace Component/MyAccountDownloadable/Container/requestDownloadable/success */
-            ((data) => {
-                const { customerDownloadableProducts: { items = [] } = {} } = data;
-                this.setState({ items, isLoading: false });
-            }),
-            /** @namespace Component/MyAccountDownloadable/Container/requestDownloadable/error */
+            (
+            /** @namespace Component/MyAccountDownloadable/Container/MyAccountDownloadableContainer/requestDownloadable/fetchQuery/then */
+                (data) => {
+                    const { customerDownloadableProducts: { items = [] } = {} } = data;
+                    this.setState({ items, isLoading: false });
+                }),
+            /** @namespace Component/MyAccountDownloadable/Container/MyAccountDownloadableContainer/requestDownloadable/fetchQuery/then/catch */
             (err) => {
                 showErrorNotification(getErrorMessage(err));
                 this.setState({ isLoading: false });

--- a/packages/scandipwa/src/component/MyAccountForgotPassword/MyAccountForgotPassword.container.js
+++ b/packages/scandipwa/src/component/MyAccountForgotPassword/MyAccountForgotPassword.container.js
@@ -77,12 +77,12 @@ export class MyAccountForgotPasswordContainer extends PureComponent {
         const { forgotPassword, setSignInState, setLoadingState } = this.props;
 
         forgotPassword(fields).then(
-            /** @namespace Component/MyAccountOverlay/Container/forgotPasswordThen */
+            /** @namespace Component/MyAccountForgotPassword/Container/MyAccountForgotPasswordContainer/onForgotPasswordSuccess/forgotPassword/then */
             () => {
                 setSignInState(STATE_FORGOT_PASSWORD_SUCCESS);
                 setLoadingState(false);
             },
-            /** @namespace Component/MyAccountForgotPassword/Container/forgotPasswordThen */
+            /** @namespace Component/MyAccountForgotPassword/Container/MyAccountForgotPasswordContainer/onForgotPasswordSuccess/forgotPassword/then/setLoadingState/catch */
             () => setLoadingState(false)
         );
     }

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.container.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.container.js
@@ -117,9 +117,9 @@ export class MyAccountMyWishlistContainer extends PureComponent {
         this.setState({ isLoading: true });
 
         return moveWishlistToCart().then(
-            /** @namespace Component/MyAccountMyWishlist/Container/moveWishlistToCartThen */
+            /** @namespace Component/MyAccountMyWishlist/Container/MyAccountMyWishlistContainer/addAllToCart/moveWishlistToCart/then */
             () => this.showNotificationAndRemoveLoading('Available items moved to cart'),
-            /** @namespace Component/MyAccountMyWishlist/Container/moveWishlistToCartCatch */
+            /** @namespace Component/MyAccountMyWishlist/Container/MyAccountMyWishlistContainer/addAllToCart/moveWishlistToCart/then/catch */
             (error) => this.showErrorAndRemoveLoading(getErrorMessage(error))
         );
     }
@@ -134,7 +134,7 @@ export class MyAccountMyWishlistContainer extends PureComponent {
         this.setState({ isLoading: true });
 
         return clearWishlist().then(
-            /** @namespace Component/MyAccountMyWishlist/Container/clearWishlistThen */
+            /** @namespace Component/MyAccountMyWishlist/Container/MyAccountMyWishlistContainer/removeAll/clearWishlist/then */
             () => this.showNotificationAndRemoveLoading('Wishlist cleared')
         );
     }

--- a/packages/scandipwa/src/component/MyAccountNewsletterSubscription/MyAccountNewsletterSubscription.container.js
+++ b/packages/scandipwa/src/component/MyAccountNewsletterSubscription/MyAccountNewsletterSubscription.container.js
@@ -117,7 +117,7 @@ export class MyAccountNewsletterSubscriptionContainer extends PureComponent {
         this.setState({ isLoading: true });
 
         return fetchMutation(mutation).then(
-            /** @namespace Component/MyAccountNewsletterSubscription/Container/fetchMutationThen */
+            /** @namespace Component/MyAccountNewsletterSubscription/Container/MyAccountNewsletterSubscriptionContainer/onCustomerSave/fetchMutation/then */
             ({ updateCustomer: { customer } }) => {
                 BrowserDatabase.setItem(customer, CUSTOMER, ONE_MONTH_IN_SECONDS);
                 const { is_subscribed } = customer;

--- a/packages/scandipwa/src/component/MyAccountSignIn/MyAccountSignIn.container.js
+++ b/packages/scandipwa/src/component/MyAccountSignIn/MyAccountSignIn.container.js
@@ -28,7 +28,7 @@ export const mapStateToProps = (state) => ({
     isEmailAvailable: state.CheckoutReducer.isEmailAvailable
 });
 
-/** @namespace Component/MyAccountSignIn/Container/mapDispatchtoProps */
+/** @namespace Component/MyAccountSignIn/Container/mapDispatchToProps */
 export const mapDispatchToProps = (dispatch) => ({
     signIn: (options) => MyAccountDispatcher.then(
         ({ default: dispatcher }) => dispatcher.signIn(options, dispatch)

--- a/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.container.js
+++ b/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.container.js
@@ -52,7 +52,7 @@ export const mapDispatchToProps = (dispatch) => ({
 
 export const DEFAULT_NAVIGATION_TABS_STATE = { name: MENU_TAB };
 
-/** @namespace Component/NavigationTabsContainer/Container */
+/** @namespace Component/NavigationTabs/Container */
 export class NavigationTabsContainer extends NavigationAbstractContainer {
     default_state = DEFAULT_NAVIGATION_TABS_STATE;
 

--- a/packages/scandipwa/src/component/NewProducts/NewProducts.container.js
+++ b/packages/scandipwa/src/component/NewProducts/NewProducts.container.js
@@ -166,11 +166,11 @@ export class NewProductsContainer extends PureComponent {
         const query = [ProductListQuery.getQuery(options)];
         executeGet(prepareQuery(query), 'NewProducts', cacheLifetime)
             .then(
-                /** @namespace Component/NewProducts/Container/executeGetThen */
+                /** @namespace Component/NewProducts/Container/NewProductsContainer/requestProducts/then/catch/executeGet/then */
                 ({ products: { items } }) => this.setState({ products: getIndexedProducts(items) })
             )
             .catch(
-                /** @namespace Component/NewProducts/Container/executeGetThenCatch */
+                /** @namespace Component/NewProducts/Container/NewProductsContainer/requestProducts/then/catch/showNotification */
                 (e) => showNotification('error', __('Error fetching NewProducts!'), e)
             );
     }

--- a/packages/scandipwa/src/component/NewsletterSubscription/NewsletterSubscription.container.js
+++ b/packages/scandipwa/src/component/NewsletterSubscription/NewsletterSubscription.container.js
@@ -22,7 +22,7 @@ export const NewsletterSubscriptionDispatcher = import(
     'Store/NewsletterSubscription/NewsletterSubscription.dispatcher'
 );
 
-/** @namespace Component/NewsletterSubscribtion/Container/mapStateToProps */
+/** @namespace Component/NewsletterSubscription/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     allowGuestSubscribe: state.ConfigReducer.newsletter_subscription_allow_guest_subscribe,
     isSignedIn: state.MyAccountReducer.isSignedIn

--- a/packages/scandipwa/src/component/ProductAlerts/ProductAlerts.container.js
+++ b/packages/scandipwa/src/component/ProductAlerts/ProductAlerts.container.js
@@ -86,7 +86,7 @@ export class ProductAlertsContainer extends PureComponent {
         const query = ProductAlertsQuery.getProductAlertSubscribeMutation(productId, type);
 
         return fetchMutation(query).then(
-            /** @namespace Component/ProductAlerts/Container/fetchMutation/then */
+            /** @namespace Component/ProductAlerts/Container/ProductAlertsContainer/handlePriceDropSubscribe/then/catch/fetchMutation/then */
             (ProductAlertSubscribe) => {
                 if (!ProductAlertSubscribe) {
                     return null;
@@ -95,7 +95,7 @@ export class ProductAlertsContainer extends PureComponent {
                 return showNotification('success', __('You saved the alert subscription'));
             }
         ).catch(
-            /** @namespace Component/ProductAlerts/Container/fetchMutation/catch */
+            /** @namespace Component/ProductAlerts/Container/ProductAlertsContainer/handlePriceDropSubscribe/then/catch */
             (error) => {
                 showErrorNotification('error', error[0].message);
             }

--- a/packages/scandipwa/src/component/ProductListPage/ProductListPage.component.js
+++ b/packages/scandipwa/src/component/ProductListPage/ProductListPage.component.js
@@ -24,8 +24,8 @@ import './ProductListPage.style';
 
 /**
  * Placeholder for List of category product
- * @namespace Component/ProductListPage/Component
  * @class ProductListPage
+ * @namespace Component/ProductListPage/Component
  */
 export class ProductListPage extends PureComponent {
     static propTypes = {

--- a/packages/scandipwa/src/component/ProductReviewForm/ProductReviewForm.container.js
+++ b/packages/scandipwa/src/component/ProductReviewForm/ProductReviewForm.container.js
@@ -147,7 +147,7 @@ export class ProductReviewFormContainer extends PureComponent {
                 product_sku,
                 rating_data
             }).then(
-                /** @namespace Component/ProductReviewForm/Container/addReviewThen */
+                /** @namespace Component/ProductReviewForm/Container/ProductReviewFormContainer/_onReviewSubmitSuccess/addReview/then */
                 (success) => {
                     if (success) {
                         this.setState({

--- a/packages/scandipwa/src/component/RadioButtonIcon/RadioButtonIcon.component.js
+++ b/packages/scandipwa/src/component/RadioButtonIcon/RadioButtonIcon.component.js
@@ -14,7 +14,7 @@ import { PureComponent } from 'react';
 
 import './RadioButtonIcon.style';
 
-/** @namespace Component/RadioButton/Component */
+/** @namespace Component/RadioButtonIcon/Component */
 export class RadioButton extends PureComponent {
     static propTypes = {
         isActive: PropTypes.bool

--- a/packages/scandipwa/src/component/RangeSelector/RangeSelector.component.js
+++ b/packages/scandipwa/src/component/RangeSelector/RangeSelector.component.js
@@ -20,8 +20,7 @@ import './RangeSelector.style';
 /**
  * Product Sort
  * @class ProductSort
- * @namespace Component/RangeSelector/Component/rangeSelector
- */
+ * @namespace Component/RangeSelector/Component */
 export class RangeSelector extends PureComponent {
     static propTypes = {
         value: PropTypes.oneOfType([
@@ -74,8 +73,7 @@ export class RangeSelector extends PureComponent {
      * Limit selected value to min and max bounds
      * @param {Object} value sliders mix and max values
      * @return {Number} value within bounds
-     * @namespace Component/RangeSelector/Component
- */
+     */
     limitValueToBounds(value) {
         const { minValue, maxValue } = this.props;
         const newValue = { ...value };

--- a/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.component.js
+++ b/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.component.js
@@ -18,7 +18,7 @@ import { getFiltersCount } from 'Util/Category';
 
 import './ResetAttributes.style';
 
-/** @namespace Component/ResetButton/Component */
+/** @namespace Component/ResetAttributes/Component */
 export class ResetAttributes extends PureComponent {
     static propTypes = {
         toggleCustomFilter: PropTypes.func.isRequired,

--- a/packages/scandipwa/src/component/ShareWishlistPopup/ShareWishlistPopup.container.js
+++ b/packages/scandipwa/src/component/ShareWishlistPopup/ShareWishlistPopup.container.js
@@ -31,7 +31,7 @@ export const mapDispatchToProps = (dispatch) => ({
 /** @namespace Component/ShareWishlistPopup/Container/mapStateToProps */
 export const mapStateToProps = () => ({});
 
-/** @namespace Component/ShareWishlistPopup/Container/shareWishlistPopupContainer */
+/** @namespace Component/ShareWishlistPopup/Container */
 export class ShareWishlistPopupContainer extends PureComponent {
     static propTypes = {
         showError: PropTypes.func.isRequired,
@@ -53,12 +53,12 @@ export class ShareWishlistPopupContainer extends PureComponent {
         }
 
         fetchMutation(WishlistQuery.getShareWishlistMutation({ message, emails })).then(
-            /** @namespace Component/ShareWishlistPopup/Container/handleFormDataFetchMutationThen */
+            /** @namespace Component/ShareWishlistPopup/Container/ShareWishlistPopupContainer/handleFormData/fetchMutation/then */
             () => {
                 showNotification(__('Wishlist has been shared'));
                 hidePopup();
             },
-            /** @namespace Component/ShareWishlistPopup/Container/handleFormDataFetchMutationCatch */
+            /** @namespace Component/ShareWishlistPopup/Container/ShareWishlistPopupContainer/handleFormData/fetchMutation/then/showError/catch */
             (error) => showError(getErrorMessage(error))
         );
     }

--- a/packages/scandipwa/src/component/SharedWishlistItem/SharedWishlistItem.container.js
+++ b/packages/scandipwa/src/component/SharedWishlistItem/SharedWishlistItem.container.js
@@ -32,7 +32,7 @@ export const mapDispatchToProps = (dispatch) => ({
     )
 });
 
-/** @namespace Component/SharedWishlistItem/Container/sharedWishlistItemContainer */
+/** @namespace Component/SharedWishlistItem/Container */
 export class SharedWishlistItemContainer extends WishlistItemContainer {
     state = {
         quantity: 1

--- a/packages/scandipwa/src/component/StoreInPickUpPopup/StoreInPickUpPopup.container.js
+++ b/packages/scandipwa/src/component/StoreInPickUpPopup/StoreInPickUpPopup.container.js
@@ -25,18 +25,18 @@ import { fetchQuery, getErrorMessage } from 'Util/Request';
 import StoreInPickUpComponent from './StoreInPickUpPopup.component';
 import { STORES_SEARCH_TIMEOUT } from './StoreInPickUpPopup.config';
 
-/** @namespace Component/StoreInPickUp/Container/mapDispatchToProps */
+/** @namespace Component/StoreInPickUpPopup/Container/mapDispatchToProps */
 export const mapDispatchToProps = (dispatch) => ({
     hideActiveOverlay: () => dispatch(hideActiveOverlay()),
     showNotification: (type, message) => dispatch(showNotification(type, message))
 });
 
-/** @namespace Component/StoreInPickUp/Container/mapStateToProps */
+/** @namespace Component/StoreInPickUpPopup/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     countries: state.ConfigReducer.countries
 });
 
-/** @namespace Component/StoreInPickUp/Container */
+/** @namespace Component/StoreInPickUpPopup/Container */
 export class StoreInPickUpContainer extends PureComponent {
     static propTypes = {
         countries: countriesType.isRequired,
@@ -155,6 +155,7 @@ export class StoreInPickUpContainer extends PureComponent {
         const { storeSearchCriteria, selectedCountryId } = this.state;
 
         fetchQuery(StoreInPickUpQuery.getStores(selectedCountryId, storeSearchCriteria)).then(
+            /** @namespace Component/StoreInPickUpPopup/Container/StoreInPickUpContainer/handleStoresSearch/fetchQuery/then */
             ({ getStores: { stores } = {} }) => {
                 if (stores) {
                     this.setState({ stores });
@@ -162,6 +163,7 @@ export class StoreInPickUpContainer extends PureComponent {
 
                 this.setState({ isLoading: false });
             },
+            /** @namespace Component/StoreInPickUpPopup/Container/StoreInPickUpContainer/handleStoresSearch/fetchQuery/then/catch */
             (error) => {
                 this.setState({ stores: [] });
                 showNotification('error', getErrorMessage(error));

--- a/packages/scandipwa/src/component/StoreItems/StoreItems.container.js
+++ b/packages/scandipwa/src/component/StoreItems/StoreItems.container.js
@@ -14,7 +14,7 @@ import { PureComponent } from 'react';
 
 import StoreItems from './StoreItems.component';
 
-/** @namespace Component/StoreItems/Container/storeItemsContainer */
+/** @namespace Component/StoreItems/Container */
 export class StoreItemsContainer extends PureComponent {
     static propTypes = {
         item: PropTypes.object.isRequired,

--- a/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.container.js
+++ b/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.container.js
@@ -26,15 +26,15 @@ import {
     DRAG_RIGHT_OPEN_TRIGGER_THRESHOLD
 } from './SwipeToDelete.config';
 
-/** @namespace Component/Link/Container/mapStateToProps */
+/** @namespace Component/SwipeToDelete/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     isMobile: state.ConfigReducer.device.isMobile
 });
 
-/** @namespace Component/Link/Container/mapDispatchToProps */
+/** @namespace Component/SwipeToDelete/Container/mapDispatchToProps */
 export const mapDispatchToProps = () => ({});
 
-/** @namespace Component/Link/Container */
+/** @namespace Component/SwipeToDelete/Container */
 export class SwipeToDeleteContainer extends PureComponent {
     static propTypes = {
         isMobile: PropTypes.bool.isRequired,

--- a/packages/scandipwa/src/component/TranslateOnCursorMove/TranslateOnCursorMove.container.js
+++ b/packages/scandipwa/src/component/TranslateOnCursorMove/TranslateOnCursorMove.container.js
@@ -13,12 +13,12 @@ import { connect } from 'react-redux';
 
 import TranslateOnCursorMove from './TranslateOnCursorMove.component';
 
-/** @namespace Component/Slider/Container/mapStateToProps */
+/** @namespace Component/TranslateOnCursorMove/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     isMobile: state.ConfigReducer.device.isMobile
 });
 
-/** @namespace Component/Slider/Container/mapDispatchToProps */
+/** @namespace Component/TranslateOnCursorMove/Container/mapDispatchToProps */
 export const mapDispatchToProps = () => ({});
 
 // eslint-disable-next-line @scandipwa/scandipwa-guidelines/always-both-mappings

--- a/packages/scandipwa/src/component/VideoPopup/VideoPopup.component.js
+++ b/packages/scandipwa/src/component/VideoPopup/VideoPopup.component.js
@@ -39,7 +39,7 @@ export class VideoPopup extends PureComponent {
             this.vimeoPromise,
             this.youTubePromise
         ]).then(
-            /** @namespace Component/VideoPopup/Component/videoLibrariesThen */
+            /** @namespace Component/VideoPopup/Component/VideoPopup/componentDidMount/all/then */
             () => this.forceUpdate()
         );
     }
@@ -103,7 +103,7 @@ export class VideoPopup extends PureComponent {
         this.vimeoPromise = makeCancelable(import('react-vimeo'));
 
         this.vimeoPromise.promise.then(
-            /** @namespace Component/VideoPopup/Component/vimeoPromisePromiseThen */
+            /** @namespace Component/VideoPopup/Component/VideoPopup/loadVimeoLibrary/then */
             ({ default: vimeo }) => {
                 this.vimeoComponent = vimeo;
             }
@@ -114,7 +114,7 @@ export class VideoPopup extends PureComponent {
         this.youTubePromise = makeCancelable(import('react-youtube'));
 
         this.youTubePromise.promise.then(
-            /** @namespace Component/VideoPopup/Component/youTubePromisePromiseThen */
+            /** @namespace Component/VideoPopup/Component/VideoPopup/loadYouTubeLibrary/then */
             ({ default: youTube }) => {
                 this.youTubeComponent = youTube;
             }

--- a/packages/scandipwa/src/component/VideoThumbnail/VideoThumbnail.component.js
+++ b/packages/scandipwa/src/component/VideoThumbnail/VideoThumbnail.component.js
@@ -22,8 +22,7 @@ import './VideoThumbnail.style';
 /**
  * VideoThumbnail component
  * @class VideoThumbnail
- * @namespace Component/VideoThumbnail/Component/videoThumbnail
- */
+ * @namespace Component/VideoThumbnail/Component */
 export class VideoThumbnail extends PureComponent {
     static propTypes = {
         media: MediaItemType.isRequired,
@@ -32,8 +31,7 @@ export class VideoThumbnail extends PureComponent {
 
     /**
      * Renders an icon indicating that the video can be played
-     * @namespace Component/VideoThumbnail/Component
- */
+     */
     renderPlayIcon() {
         return (
             <span block="VideoThumbnail" elem="PlayIcon">

--- a/packages/scandipwa/src/component/VideoThumbnail/VideoThumbnail.container.js
+++ b/packages/scandipwa/src/component/VideoThumbnail/VideoThumbnail.container.js
@@ -32,8 +32,7 @@ export const mapDispatchToProps = (dispatch) => ({
 
 /**
  * @class VideoThumbnailContainer
- * @namespace Component/VideoThumbnail/Container/videoThumbnailContainer
- */
+ * @namespace Component/VideoThumbnail/Container */
 export class VideoThumbnailContainer extends PureComponent {
     static propTypes = {
         media: MediaItemType.isRequired,

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
@@ -177,16 +177,16 @@ export class WishlistItemContainer extends PureComponent {
 
         return addProductToCart({ product: item, quantity, buyRequest: buy_request })
             .then(
-                /** @namespace Component/WishlistItem/Container/addItemToCartAddProductToCartThen */
+                /** @namespace Component/WishlistItem/Container/WishlistItemContainer/addItemToCart/then/catch/addProductToCart/then */
                 () => {
                     this.removeItem(id);
                     showNotification('success', __('Product Added To Cart'));
                 },
-                /** @namespace Component/WishlistItem/Container/addItemToCartAddProductToCartCatch */
+                /** @namespace Component/WishlistItem/Container/WishlistItemContainer/addItemToCart/then/catch/addProductToCart/then/catch */
                 () => this.showNotification('error', __('Error Adding Product To Cart'))
             )
             .catch(
-                /** @namespace Component/WishlistItem/Container/addItemToCartAddProductToCartThenThenCatch */
+                /** @namespace Component/WishlistItem/Container/WishlistItemContainer/addItemToCart/then/catch */
                 () => this.showNotification('error', __('Error cleaning wishlist'))
             );
     }

--- a/packages/scandipwa/src/query/Cart.query.js
+++ b/packages/scandipwa/src/query/Cart.query.js
@@ -13,7 +13,7 @@ import ProductListQuery from 'Query/ProductList.query';
 import { isSignedIn } from 'Util/Auth';
 import { Field } from 'Util/Query';
 
-/** @namespace Query/Cart */
+/** @namespace Query/Cart/Query */
 export class CartQuery {
     getCartQuery(quoteId) {
         const query = new Field('getCartForCustomer')

--- a/packages/scandipwa/src/query/Category.query.js
+++ b/packages/scandipwa/src/query/Category.query.js
@@ -14,7 +14,7 @@ import { Field } from 'Util/Query';
 /**
  * Category Query
  * @class CategoryQuery
- * @namespace Query/Category
+ * @namespace Query/Category/Query
  */
 export class CategoryQuery {
     __construct() {

--- a/packages/scandipwa/src/query/CheckEmail.query.js
+++ b/packages/scandipwa/src/query/CheckEmail.query.js
@@ -14,8 +14,7 @@ import { Field } from 'Util/Query';
 /**
  * Email availability check Query
  * @class CheckEmailQuery
- * @namespace Query/CheckEmail
- */
+ * @namespace Query/CheckEmail/Query */
 export class CheckEmailQuery {
     getIsEmailAvailableQuery(email) {
         const query = new Field('isEmailAvailable')

--- a/packages/scandipwa/src/query/Checkout.query.js
+++ b/packages/scandipwa/src/query/Checkout.query.js
@@ -12,7 +12,7 @@
 import { isSignedIn } from 'Util/Auth';
 import { Field } from 'Util/Query';
 
-/** @namespace Query/Checkout */
+/** @namespace Query/Checkout/Query */
 export class CheckoutQuery {
     getPaymentMethodsQuery(guestCartId) {
         const query = new Field('getPaymentMethods')

--- a/packages/scandipwa/src/query/CmsBlock.query.js
+++ b/packages/scandipwa/src/query/CmsBlock.query.js
@@ -14,8 +14,7 @@ import { Field } from 'Util/Query';
 /**
  * CMS Blocks Query
  * @class CmsBlocksQuery
- * @namespace Query/CmsBlock
- */
+ * @namespace Query/CmsBlock/Query */
 export class CmsBlockQuery {
     /**
      * get CMS Block query

--- a/packages/scandipwa/src/query/CmsPage.query.js
+++ b/packages/scandipwa/src/query/CmsPage.query.js
@@ -14,8 +14,7 @@ import { Field } from 'Util/Query';
 /**
  * CMS Page Query
  * @class CmsPageQuery
- * @namespace Query/CmsPage
- */
+ * @namespace Query/CmsPage/Query */
 export class CmsPageQuery {
     /**
      * get CMS Page query

--- a/packages/scandipwa/src/query/Config.query.js
+++ b/packages/scandipwa/src/query/Config.query.js
@@ -11,7 +11,7 @@
 
 import { Field } from 'Util/Query';
 
-/** @namespace Query/Config */
+/** @namespace Query/Config/Query */
 export class ConfigQuery {
     getStoreListField() {
         return new Field('storeList')

--- a/packages/scandipwa/src/query/ContactForm.query.js
+++ b/packages/scandipwa/src/query/ContactForm.query.js
@@ -11,7 +11,7 @@
 
 import { Field } from 'Util/Query';
 
-/** @namespace Query/ContactForm */
+/** @namespace Query/ContactForm/Query */
 export class ContactFormQuery {
     getSendContactFormMutation(options) {
         const mutation = new Field('contactForm');

--- a/packages/scandipwa/src/query/Klarna.query.js
+++ b/packages/scandipwa/src/query/Klarna.query.js
@@ -11,7 +11,7 @@
 
 import { Field } from 'Util/Query';
 
-/** @namespace Query/Klarna */
+/** @namespace Query/Klarna/Query */
 export class KlarnaQuery {
     getCreateKlarnaTokenMutation(input) {
         return new Field('createKlarnaToken')

--- a/packages/scandipwa/src/query/Menu.query.js
+++ b/packages/scandipwa/src/query/Menu.query.js
@@ -13,8 +13,7 @@ import { Field } from 'Util/Query';
 /**
  * Menu Query
  * @class MenuQuery
- * @namespace Query/Menu
- */
+ * @namespace Query/Menu/Query */
 export class MenuQuery {
     /**
      * get Menu query

--- a/packages/scandipwa/src/query/MyAccount.query.js
+++ b/packages/scandipwa/src/query/MyAccount.query.js
@@ -14,8 +14,7 @@ import { Field } from 'Util/Query';
 /**
  * MyAccount Mutations
  * @class MyAccount
- * @namespace Query/MyAccount
- */
+ * @namespace Query/MyAccount/Query */
 export class MyAccountQuery {
     /**
      * Get ResetPassword mutation

--- a/packages/scandipwa/src/query/NewsletterSubscription.query.js
+++ b/packages/scandipwa/src/query/NewsletterSubscription.query.js
@@ -14,8 +14,7 @@ import { Field } from 'Util/Query';
 /**
  * NewsletterSubscription Mutations
  * @class NewsletterSubscriptionQuery
- * @namespace Query/NewsletterSubscription
- */
+ * @namespace Query/NewsletterSubscription/Query */
 export class NewsletterSubscriptionQuery {
     getSubscribeToNewsletterMutation(email) {
         return new Field('subscribeEmailToNewsletter')

--- a/packages/scandipwa/src/query/Order.query.js
+++ b/packages/scandipwa/src/query/Order.query.js
@@ -14,8 +14,7 @@ import { Field } from 'Util/Query';
 /**
  * Order Query
  * @class OrderQuery
- * @namespace Query/Order
- */
+ * @namespace Query/Order/Query */
 export class OrderQuery {
     getOrderListQuery() {
         return new Field('getOrderList')

--- a/packages/scandipwa/src/query/ProductAlerts.query.js
+++ b/packages/scandipwa/src/query/ProductAlerts.query.js
@@ -11,7 +11,7 @@
 
 import { Field } from 'Util/Query';
 
-/** @namespace Query/ProductAlerts */
+/** @namespace Query/ProductAlerts/Query */
 export class ProductAlertsQuery {
     getProductAlertSubscribeMutation(productId, type) {
         return new Field('productAlertSubscribe')

--- a/packages/scandipwa/src/query/ProductCompare.query.js
+++ b/packages/scandipwa/src/query/ProductCompare.query.js
@@ -12,7 +12,7 @@
 import { ProductListQuery } from 'Query/ProductList.query';
 import { Field } from 'Util/Query';
 
-/** @namespace Query/ProductCompare */
+/** @namespace Query/ProductCompare/Query */
 export class ProductCompareQuery extends ProductListQuery {
     getCreateEmptyCompareList() {
         return new Field('createCompareList')

--- a/packages/scandipwa/src/query/ProductList.query.js
+++ b/packages/scandipwa/src/query/ProductList.query.js
@@ -17,8 +17,7 @@ import { Field, Fragment } from 'Util/Query';
 /**
  * Product List Query
  * @class ProductListQuery
- * @namespace Query/ProductList
- */
+ * @namespace Query/ProductList/Query */
 export class ProductListQuery {
     __construct() {
         super.__construct();

--- a/packages/scandipwa/src/query/Region.query.js
+++ b/packages/scandipwa/src/query/Region.query.js
@@ -14,8 +14,7 @@ import { Field } from 'Util/Query';
 /**
  * RegionQuery Mutations
  * @class RegionQuery
- * @namespace Query/Region
- */
+ * @namespace Query/Region/Query */
 export class RegionQuery {
     getCountriesQuery() {
         return new Field('countries')

--- a/packages/scandipwa/src/query/Review.query.js
+++ b/packages/scandipwa/src/query/Review.query.js
@@ -11,7 +11,7 @@
 
 import { Field } from 'Util/Query';
 
-/** @namespace Query/Review */
+/** @namespace Query/Review/Query */
 export class ReviewQuery {
     getAddProductReviewMutation(reviewItem) {
         return new Field('createProductReview')

--- a/packages/scandipwa/src/query/Slider.query.js
+++ b/packages/scandipwa/src/query/Slider.query.js
@@ -14,8 +14,7 @@ import { Field } from 'Util/Query';
 /**
  * Slider Query
  * @class Slider
- * @namespace Query/Slider
- */
+ * @namespace Query/Slider/Query */
 export class SliderQuery {
     getQuery(options) {
         const { sliderId } = options;

--- a/packages/scandipwa/src/query/StoreInPickUp.query.js
+++ b/packages/scandipwa/src/query/StoreInPickUp.query.js
@@ -11,7 +11,7 @@
 
 import { Field } from 'Util/Query';
 
-/** @namespace StoreinPickup/Query/StoreInPickUp/Query/StoreInPickUpQuery */
+/** @namespace Query/StoreInPickUp/Query */
 export class StoreInPickUpQuery {
     getStores(country, search = '') {
         return new Field('getStores')

--- a/packages/scandipwa/src/query/UrlRewrites.query.js
+++ b/packages/scandipwa/src/query/UrlRewrites.query.js
@@ -13,8 +13,7 @@ import { Field } from 'Util/Query';
 /**
  * UrlRewrites Query
  * @class UrlRewritesQuery
- * @namespace Query/UrlRewrites
- */
+ * @namespace Query/UrlRewrites/Query */
 export class UrlRewritesQuery {
     getQuery({ urlParam }) {
         return new Field('urlResolver')

--- a/packages/scandipwa/src/query/Wishlist.query.js
+++ b/packages/scandipwa/src/query/Wishlist.query.js
@@ -14,7 +14,7 @@ import { isSignedIn } from 'Util/Auth';
 import { getGuestQuoteId } from 'Util/Cart';
 import { Field } from 'Util/Query';
 
-/** @namespace Query/Wishlist */
+/** @namespace Query/Wishlist/Query */
 export class WishlistQuery {
     getWishlistQuery(sharingCode) {
         const field = new Field('s_wishlist')

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -292,7 +292,7 @@ export class CheckoutContainer extends PureComponent {
             address,
             guestQuoteId
         )).then(
-            /** @namespace Route/Checkout/Container/onShippingEstimationFieldsChangeFetchMutationThen */
+            /** @namespace Route/Checkout/Container/CheckoutContainer/onShippingEstimationFieldsChange/fetchMutation/then */
             ({ estimateShippingCosts: shippingMethods }) => {
                 const { requestsSent } = this.state;
 
@@ -455,7 +455,7 @@ export class CheckoutContainer extends PureComponent {
         fetchQuery(CheckoutQuery.getPaymentMethodsQuery(
             getGuestQuoteId()
         )).then(
-            /** @namespace Route/Checkout/Container/fetchQueryThen */
+            /** @namespace Route/Checkout/Container/CheckoutContainer/_getPaymentMethods/fetchQuery/then */
             ({ getPaymentMethods: paymentMethods }) => {
                 this.setState({ isLoading: false, paymentMethods });
             },
@@ -486,7 +486,7 @@ export class CheckoutContainer extends PureComponent {
         updateEmail(email);
 
         return fetchMutation(mutation).then(
-            /** @namespace Route/Checkout/Container/saveGuestEmailFetchMutationThen */
+            /** @namespace Route/Checkout/Container/CheckoutContainer/saveGuestEmail/fetchMutation/then */
             ({ setGuestEmailOnCart: data }) => {
                 if (data) {
                     this.setState({ isGuestEmailSaved: true });
@@ -590,7 +590,7 @@ export class CheckoutContainer extends PureComponent {
             this.prepareAddressInformation(addressInformation),
             getGuestQuoteId()
         )).then(
-            /** @namespace Route/Checkout/Container/saveAddressInformationFetchMutationThen */
+            /** @namespace Route/Checkout/Container/CheckoutContainer/saveAddressInformation/fetchMutation/then */
             ({ saveAddressInformation: data }) => {
                 const { payment_methods, totals } = data;
 
@@ -647,7 +647,7 @@ export class CheckoutContainer extends PureComponent {
         }
 
         await this.saveBillingAddress(paymentInformation).then(
-            /** @namespace Route/Checkout/Container/saveBillingAddressThen */
+            /** @namespace Route/Checkout/Container/CheckoutContainer/savePaymentInformation/saveBillingAddress/then */
             () => this.savePaymentMethodAndPlaceOrder(paymentInformation),
             this._handleError
         );

--- a/packages/scandipwa/src/route/ConfirmAccountPage/ConfirmAccountPage.container.js
+++ b/packages/scandipwa/src/route/ConfirmAccountPage/ConfirmAccountPage.container.js
@@ -122,7 +122,7 @@ export class ConfirmAccountPageContainer extends PureComponent {
 
         confirmAccount({ ...options, password })
             .then(
-                /** @namespace Route/ConfirmAccountPage/Container/confirmAccountThen */
+                /** @namespace Route/ConfirmAccountPage/Container/ConfirmAccountPageContainer/onConfirmSuccess/then/catch/then/then/confirmAccount/then */
                 (data) => {
                     const { msgType } = data || {};
 
@@ -136,11 +136,11 @@ export class ConfirmAccountPageContainer extends PureComponent {
                 }
             )
             .then(
-                /** @namespace Route/ConfirmAccountPage/Container/confirmAccountThenThen */
+                /** @namespace Route/ConfirmAccountPage/Container/ConfirmAccountPageContainer/onConfirmSuccess/then/catch/then/then */
                 () => this.setState({ redirect: true })
             )
             .catch(
-                /** @namespace Route/ConfirmAccountPage/Container/confirmAccountThenThenCatch */
+                /** @namespace Route/ConfirmAccountPage/Container/ConfirmAccountPageContainer/onConfirmSuccess/then/catch */
                 () => this.setState({ isLoading: false })
             );
     }

--- a/packages/scandipwa/src/route/CreateAccount/CreateAccount.component.js
+++ b/packages/scandipwa/src/route/CreateAccount/CreateAccount.component.js
@@ -19,7 +19,7 @@ import {
 
 import './CreateAccount.style';
 
-/** @namespace Scandipwa/Route/CreateAccount/Component/CreateAccountComponent */
+/** @namespace Route/CreateAccount/Component */
 export class CreateAccountComponent extends MyAccountOverlay {
     renderSignInWrapper() {
         const { onLoginClick } = this.props;

--- a/packages/scandipwa/src/route/CreateAccount/CreateAccount.container.js
+++ b/packages/scandipwa/src/route/CreateAccount/CreateAccount.container.js
@@ -22,7 +22,7 @@ import { appendWithStoreCode } from 'Util/Url';
 
 import CreateAccount from './CreateAccount.component';
 
-/** @namespace Scandipwa/Route/CreateAccount/Container/CreateAccountContainer */
+/** @namespace Route/CreateAccount/Container */
 export class CreateAccountContainer extends MyAccountOverlayContainer {
     containerProps() {
         const { device } = this.props;

--- a/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.component.js
+++ b/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.component.js
@@ -19,7 +19,7 @@ import {
 
 import './ForgotPassword.style';
 
-/** @namespace Scandipwa/Route/ForgotPassword/Component/ForgotPasswordComponent */
+/** @namespace Route/ForgotPassword/Component */
 export class ForgotPasswordComponent extends MyAccountOverlay {
     renderSignInWrapper() {
         const { onLoginClick } = this.props;

--- a/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.container.js
+++ b/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.container.js
@@ -23,7 +23,7 @@ import { appendWithStoreCode } from 'Util/Url';
 
 import ForgotPassword from './ForgotPassword.component';
 
-/** @namespace Scandipwa/Route/ForgotPassword/Container/ForgotPasswordContainer */
+/** @namespace Route/ForgotPassword/Container */
 export class ForgotPasswordContainer extends MyAccountOverlayContainer {
     containerProps() {
         const { device } = this.props;

--- a/packages/scandipwa/src/route/LoginAccount/LoginAccount.component.js
+++ b/packages/scandipwa/src/route/LoginAccount/LoginAccount.component.js
@@ -19,7 +19,7 @@ import {
 
 import './LoginAccount.style';
 
-/** @namespace Scandipwa/Route/LoginAccount/Component/LoginAccountComponent */
+/** @namespace Route/LoginAccount/Component */
 export class LoginAccountComponent extends MyAccountOverlay {
     renderSignInWrapper() {
         const { isMobile } = this.props;

--- a/packages/scandipwa/src/route/LoginAccount/LoginAccount.container.js
+++ b/packages/scandipwa/src/route/LoginAccount/LoginAccount.container.js
@@ -26,13 +26,13 @@ import { appendWithStoreCode } from 'Util/Url';
 
 import LoginAccount from './LoginAccount.component';
 
-/** @namespace Component/LoginAccount/Container/mapDispatchToProps */
+/** @namespace Route/LoginAccount/Container/mapDispatchToProps */
 export const mapDispatchToProps = (dispatch) => ({
     ...sourceMapDispatchToProps(dispatch),
     toggleBreadcrumbs: (isVisible) => dispatch(toggleBreadcrumbs(isVisible))
 });
 
-/** @namespace Scandipwa/Route/LoginAccount/Container/LoginAccountContainer */
+/** @namespace Route/LoginAccount/Container */
 export class LoginAccountContainer extends MyAccountOverlayContainer {
     static propTypes = {
         ...MyAccountOverlayContainer.propTypes,

--- a/packages/scandipwa/src/route/ProductComparePage/ProductComparePage.component.js
+++ b/packages/scandipwa/src/route/ProductComparePage/ProductComparePage.component.js
@@ -18,7 +18,7 @@ import ProductCompare from 'Component/ProductCompare';
 
 import './ProductComparePage.style';
 
-/** @namespace Route/ComparePage/Component */
+/** @namespace Route/ProductComparePage/Component */
 export class ProductComparePage extends PureComponent {
     static propTypes = {
         isLoading: PropTypes.bool.isRequired

--- a/packages/scandipwa/src/route/ProductComparePage/ProductComparePage.container.js
+++ b/packages/scandipwa/src/route/ProductComparePage/ProductComparePage.container.js
@@ -26,13 +26,13 @@ export const BreadcrumbsDispatcher = import(
     'Store/Breadcrumbs/Breadcrumbs.dispatcher'
 );
 
-/** @namespace Route/ComparePage/Container/mapStateToProps */
+/** @namespace Route/ProductComparePage/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     device: state.ConfigReducer.device,
     isLoading: state.ProductCompareReducer.isLoading
 });
 
-/** @namespace Route/ComparePage/Container/mapDispatchToProps */
+/** @namespace Route/ProductComparePage/Container/mapDispatchToProps */
 export const mapDispatchToProps = (dispatch) => ({
     showNotification: (type, message) => dispatch(showNotification(type, message)),
     updateMeta: (meta) => dispatch(updateMeta(meta)),
@@ -44,7 +44,7 @@ export const mapDispatchToProps = (dispatch) => ({
     }
 });
 
-/** @namespace Route/ComparePage/Container */
+/** @namespace Route/ProductComparePage/Container */
 export class ProductComparePageContainer extends DataContainer {
     static propTypes = {
         updateMeta: PropTypes.func.isRequired,

--- a/packages/scandipwa/src/route/StyleGuidePage/StyleGuidePage.component.js
+++ b/packages/scandipwa/src/route/StyleGuidePage/StyleGuidePage.component.js
@@ -44,7 +44,7 @@ import {
 
 import './StyleGuidePage.style';
 
-/** @namespace Base/Route/StyleGuide/Component/StyleGuideComponent */
+/** @namespace Route/StyleGuidePage/Component */
 export class StyleGuidePageComponent extends PureComponent {
     static propTypes = {
         product: ProductType.isRequired,

--- a/packages/scandipwa/src/route/StyleGuidePage/StyleGuidePage.container.js
+++ b/packages/scandipwa/src/route/StyleGuidePage/StyleGuidePage.container.js
@@ -24,17 +24,17 @@ export const ProductDispatcher = import(
     'Store/Product/Product.dispatcher'
 );
 
-/** @namespace Route/StyleGuide/Container/mapStateToProps */
+/** @namespace Route/StyleGuidePage/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     product: state.ProductReducer.product
 });
 
-/** @namespace Route/StyleGuide/Container/mapDispatchToProps */
+/** @namespace Route/StyleGuidePage/Container/mapDispatchToProps */
 export const mapDispatchToProps = (dispatch) => ({
     updateProductDetails: (product) => dispatch(updateProductDetails(product))
 });
 
-/** @namespace Route/StyleGuide/Container/StyleGuidePageContainer */
+/** @namespace Route/StyleGuidePage/Container */
 export class StyleGuidePageContainer extends PureComponent {
     static propTypes = {
         product: ProductType.isRequired,

--- a/packages/scandipwa/src/route/WishlistSharedPage/WishlistSharedPage.container.js
+++ b/packages/scandipwa/src/route/WishlistSharedPage/WishlistSharedPage.container.js
@@ -49,7 +49,7 @@ export const mapDispatchToProps = (dispatch) => ({
     )
 });
 
-/** @namespace Route/WishlistSharedPage/Container/wishlistSharedContainer */
+/** @namespace Route/WishlistSharedPage/Container */
 export class WishlistSharedPageContainer extends MyAccountMyWishlistContainer {
     static propTypes = {
         match: MatchType.isRequired,
@@ -88,9 +88,9 @@ export class WishlistSharedPageContainer extends MyAccountMyWishlistContainer {
         this.setState({ isLoading: true });
 
         return moveWishlistToCart(sharingCode).then(
-            /** @namespace Route/WishlistSharedPage/Container/moveWishlistToCartThen */
+            /** @namespace Route/WishlistSharedPage/Container/WishlistSharedPageContainer/moveWishlistToCart/then */
             () => this.showNotificationAndRemoveLoading('Wishlist moved to cart'),
-            /** @namespace Route/WishlistSharedPage/Container/moveWishlistToCartCatch */
+            /** @namespace Route/WishlistSharedPage/Container/WishlistSharedPageContainer/moveWishlistToCart/then/showError/catch */
             (error) => showError(getErrorMessage(error))
         );
     };
@@ -105,7 +105,7 @@ export class WishlistSharedPageContainer extends MyAccountMyWishlistContainer {
         this.setLoading();
 
         executeGet(query, 'SharedWishlist', FIVE_MINUTES_IN_SECONDS).then(
-            /** @namespace Route/WishlistSharedPage/Container/requestWishlistExecuteGetThen */
+            /** @namespace Route/WishlistSharedPage/Container/WishlistSharedPageContainer/requestWishlist/executeGet/then */
             ({ wishlist, wishlist: { items_count, creators_name: creatorsName } = {} }) => {
                 if (!items_count) {
                     this.setLoading(false);
@@ -151,7 +151,7 @@ export class WishlistSharedPageContainer extends MyAccountMyWishlistContainer {
                     isWishlistLoading: false
                 });
             },
-            /** @namespace Route/WishlistSharedPage/Container/executeGetCatch */
+            /** @namespace Route/WishlistSharedPage/Container/WishlistSharedPageContainer/requestWishlist/executeGet/then/catch */
             (error) => {
                 showError(getErrorMessage(error));
                 showNoMatch();

--- a/packages/scandipwa/src/store/Breadcrumbs/Breadcrumbs.reducer.js
+++ b/packages/scandipwa/src/store/Breadcrumbs/Breadcrumbs.reducer.js
@@ -17,7 +17,7 @@ export const getInitialState = () => ({
     areBreadcrumbsVisible: true
 });
 
-/** @namespace Store/Breadcrumbs/Reducer */
+/** @namespace Store/Breadcrumbs/Reducer/BreadcrumbsReducer */
 export const BreadcrumbsReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/Cart/Cart.reducer.js
+++ b/packages/scandipwa/src/store/Cart/Cart.reducer.js
@@ -66,7 +66,7 @@ export const getInitialState = () => ({
     cartTotals: BrowserDatabase.getItem(CART_TOTALS) || {}
 });
 
-/** @namespace Store/Cart/Reducer */
+/** @namespace Store/Cart/Reducer/CartReducer */
 export const CartReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/Category/Category.reducer.js
+++ b/packages/scandipwa/src/store/Category/Category.reducer.js
@@ -16,7 +16,7 @@ export const getInitialState = () => ({
     category: {}
 });
 
-/** @namespace Store/Category/Reducer */
+/** @namespace Store/Category/Reducer/CategoryReducer */
 export const CategoryReducer = (
     state = getInitialState(),
     { type, category }

--- a/packages/scandipwa/src/store/Checkout/Checkout.dispatcher.js
+++ b/packages/scandipwa/src/store/Checkout/Checkout.dispatcher.js
@@ -19,7 +19,7 @@ import { updateEmailAvailable } from './Checkout.action';
  * @class CheckoutDispatcher
  * @extends QueryDispatcher
  * @namespace Store/Checkout/Dispatcher
- *  */
+ */
 export class CheckoutDispatcher extends QueryDispatcher {
     __construct() {
         super.__construct('Checkout');

--- a/packages/scandipwa/src/store/Checkout/Checkout.reducer.js
+++ b/packages/scandipwa/src/store/Checkout/Checkout.reducer.js
@@ -21,7 +21,7 @@ export const getInitialState = () => ({
     isEmailAvailable: true
 });
 
-/** @namespace Store/Checkout/Reducer/checkoutReducer */
+/** @namespace Store/Checkout/Reducer/CheckoutReducer */
 export const CheckoutReducer = (state = getInitialState(), action) => {
     switch (action.type) {
     case UPDATE_SHIPPING_FIELDS:

--- a/packages/scandipwa/src/store/Config/Config.reducer.js
+++ b/packages/scandipwa/src/store/Config/Config.reducer.js
@@ -74,7 +74,7 @@ export const getInitialState = () => ({
     }
 });
 
-/** @namespace Store/Config/Reducer */
+/** @namespace Store/Config/Reducer/ConfigReducer */
 export const ConfigReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/ContactForm/ContactForm.dispatcher.js
+++ b/packages/scandipwa/src/store/ContactForm/ContactForm.dispatcher.js
@@ -31,14 +31,14 @@ export class ContactFormDispatcher {
 
         return fetchMutation(mutation)
             .then(
-                /** @namespace Store/ContactForm/Dispatcher/fetchMutationThen */
+                /** @namespace Store/ContactForm/Dispatcher/ContactFormDispatcher/prepareRequest/fetchMutation/then */
                 (data) => {
                     dispatch(showNotification('success', data.contactForm.message));
                     dispatch(updateContactForm({
                         isLoading: false
                     }));
                 },
-                /** @namespace Store/ContactForm/Dispatcher/fetchMutationError */
+                /** @namespace Store/ContactForm/Dispatcher/ContactFormDispatcher/prepareRequest/fetchMutation/then/catch */
                 (error) => {
                     dispatch(showNotification('error', getErrorMessage(error)));
                     dispatch(updateContactForm({

--- a/packages/scandipwa/src/store/ContactForm/ContactForm.reducer.js
+++ b/packages/scandipwa/src/store/ContactForm/ContactForm.reducer.js
@@ -15,7 +15,7 @@ export const initialState = {
     isLoading: false
 };
 
-/** @namespace Store/ContactForm/Reducer/contactFormReducer */
+/** @namespace Store/ContactForm/Reducer/ContactFormReducer */
 export const ContactFormReducer = (state = initialState, action) => {
     const {
         type,

--- a/packages/scandipwa/src/store/LinkedProducts/LinkedProducts.reducer.js
+++ b/packages/scandipwa/src/store/LinkedProducts/LinkedProducts.reducer.js
@@ -27,7 +27,7 @@ export const getInitialState = () => ({
     }
 });
 
-/** @namespace Store/LinkedProducts/Reducer */
+/** @namespace Store/LinkedProducts/Reducer/LinkedProductsReducer */
 export const LinkedProductsReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/Meta/Meta.dispatcher.js
+++ b/packages/scandipwa/src/store/Meta/Meta.dispatcher.js
@@ -14,8 +14,7 @@ import { appendWithStoreCode } from 'Util/Url';
 /**
  * Meta Dispatcher
  * @class MetaDispatcher
- * @namespace Util/Meta/Dispatcher
- */
+ * @namespace Store/Meta/Dispatcher */
 export class MetaDispatcher {
     /**
      * Set meta for category

--- a/packages/scandipwa/src/store/Meta/Meta.reducer.js
+++ b/packages/scandipwa/src/store/Meta/Meta.reducer.js
@@ -43,7 +43,7 @@ export const getInitialState = () => ({
     status_code: ''
 });
 
-/** @namespace Store/Meta/Reducer */
+/** @namespace Store/Meta/Reducer/MetaReducer */
 export const MetaReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/MyAccount/MyAccount.action.js
+++ b/packages/scandipwa/src/store/MyAccount/MyAccount.action.js
@@ -39,7 +39,7 @@ export const updateCustomerPasswordForgotStatus = () => ({
     type: UPDATE_CUSTOMER_PASSWORD_FORGOT_STATUS
 });
 
-/** @namespace Store/MyAccount/Action/updateCustomerIsLoading */
+/** @namespace Store/MyAccount/Action/updateIsLoading */
 export const updateIsLoading = (isLoading) => ({
     type: UPDATE_CUSTOMER_IS_LOADING,
     isLoading

--- a/packages/scandipwa/src/store/MyAccount/MyAccount.dispatcher.js
+++ b/packages/scandipwa/src/store/MyAccount/MyAccount.dispatcher.js
@@ -75,12 +75,12 @@ export class MyAccountDispatcher {
         }
 
         return executePost(prepareQuery([query])).then(
-            /** @namespace Store/MyAccount/Dispatcher/requestCustomerDataExecutePostThen */
+            /** @namespace Store/MyAccount/Dispatcher/MyAccountDispatcher/requestCustomerData/executePost/then */
             ({ customer }) => {
                 dispatch(updateCustomerDetails(customer));
                 BrowserDatabase.setItem(customer, CUSTOMER, ONE_MONTH_IN_SECONDS);
             },
-            /** @namespace Store/MyAccount/Dispatcher/requestCustomerDataExecutePostError */
+            /** @namespace Store/MyAccount/Dispatcher/MyAccountDispatcher/requestCustomerData/executePost/then/dispatch/catch */
             (error) => dispatch(showNotification('error', getErrorMessage(error)))
         );
     }
@@ -128,9 +128,9 @@ export class MyAccountDispatcher {
         const mutation = MyAccountQuery.getForgotPasswordMutation(options);
 
         return fetchMutation(mutation).then(
-            /** @namespace Store/MyAccount/Dispatcher/forgotPasswordFetchMutationThen */
+            /** @namespace Store/MyAccount/Dispatcher/MyAccountDispatcher/forgotPassword/fetchMutation/then/dispatch */
             () => dispatch(updateCustomerPasswordForgotStatus()),
-            /** @namespace Store/MyAccount/Dispatcher/forgotPasswordFetchMutationError */
+            /** @namespace Store/MyAccount/Dispatcher/MyAccountDispatcher/forgotPassword/fetchMutation/then/dispatch/catch */
             (error) => dispatch(showNotification('error', getErrorMessage(error)))
         );
     }
@@ -145,9 +145,9 @@ export class MyAccountDispatcher {
         const mutation = MyAccountQuery.getResetPasswordMutation(options);
 
         return fetchMutation(mutation).then(
-            /** @namespace Store/MyAccount/Dispatcher/resetPasswordFetchMutationThen */
+            /** @namespace Store/MyAccount/Dispatcher/MyAccountDispatcher/resetPassword/fetchMutation/then/dispatch */
             ({ s_resetPassword: { status } }) => dispatch(updateCustomerPasswordResetStatus(status)),
-            /** @namespace Store/MyAccount/Dispatcher/resetPasswordFetchMutationError */
+            /** @namespace Store/MyAccount/Dispatcher/MyAccountDispatcher/resetPassword/fetchMutation/then/dispatch/catch */
             (errors) => dispatch(updateCustomerPasswordResetStatus('error', getErrorMessage(errors)))
         );
     }
@@ -163,7 +163,7 @@ export class MyAccountDispatcher {
         dispatch(updateIsLoading(true));
 
         return fetchMutation(mutation).then(
-            /** @namespace Store/MyAccount/Dispatcher/createAccountFetchMutationThen */
+            /** @namespace Store/MyAccount/Dispatcher/MyAccountDispatcher/createAccount/fetchMutation/then */
             (data) => {
                 const { createCustomer: { customer } } = data;
                 const { confirmation_required } = customer;
@@ -177,7 +177,7 @@ export class MyAccountDispatcher {
                 return this.signIn({ email, password }, dispatch);
             },
 
-            /** @namespace Store/MyAccount/Dispatcher/createAccountFetchMutationError */
+            /** @namespace Store/MyAccount/Dispatcher/MyAccountDispatcher/createAccount/fetchMutation/then/catch */
             (error) => {
                 dispatch(updateIsLoading(false));
                 dispatch(showNotification('error', getErrorMessage(error)));
@@ -197,9 +197,9 @@ export class MyAccountDispatcher {
         const mutation = MyAccountQuery.getConfirmAccountMutation(options);
 
         return fetchMutation(mutation).then(
-            /** @namespace Store/MyAccount/Dispatcher/confirmAccountFetchMutationThen */
+            /** @namespace Store/MyAccount/Dispatcher/MyAccountDispatcher/confirmAccount/fetchMutation/then/dispatch */
             () => dispatch(showNotification('success', __('Your account is confirmed!'))),
-            /** @namespace Store/MyAccount/Dispatcher/confirmAccountFetchMutationError */
+            /** @namespace Store/MyAccount/Dispatcher/MyAccountDispatcher/confirmAccount/fetchMutation/then/dispatch/catch */
             (error) => dispatch(
                 showNotification(
                     'error',

--- a/packages/scandipwa/src/store/MyAccount/MyAccount.reducer.js
+++ b/packages/scandipwa/src/store/MyAccount/MyAccount.reducer.js
@@ -29,7 +29,7 @@ export const getInitialState = () => ({
     message: ''
 });
 
-/** @namespace Store/MyAccount/Reducer */
+/** @namespace Store/MyAccount/Reducer/MyAccountReducer */
 export const MyAccountReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/Navigation/Navigation.reducer.js
+++ b/packages/scandipwa/src/store/Navigation/Navigation.reducer.js
@@ -33,7 +33,7 @@ export const getInitialState = () => ({
     }
 });
 
-/** @namespace Store/Navigation/Reducer */
+/** @namespace Store/Navigation/Reducer/NavigationReducer */
 export const NavigationReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/NewsletterSubscription/NewsletterSubscription.dispatcher.js
+++ b/packages/scandipwa/src/store/NewsletterSubscription/NewsletterSubscription.dispatcher.js
@@ -23,7 +23,7 @@ export const NOT_ACTIVE = 'NOT_ACTIVE';
 export class NewsletterSubscriptionDispatcher {
     subscribeToNewsletter(dispatch, email) {
         return fetchMutation(NewsletterSubscriptionQuery.getSubscribeToNewsletterMutation(email)).then(
-            /** @namespace Store/NewsletterSubscription/Dispatcher/fetchMutationThen */
+            /** @namespace Store/NewsletterSubscription/Dispatcher/NewsletterSubscriptionDispatcher/subscribeToNewsletter/fetchMutation/then */
             ({ subscribeEmailToNewsletter: { status } }) => {
                 // `NOT_ACTIVE` response status corresponds to `newsletter_subscription_confirm` magento setting
                 const message = status === NOT_ACTIVE
@@ -32,7 +32,7 @@ export class NewsletterSubscriptionDispatcher {
 
                 return dispatch(showNotification('success', message));
             },
-            /** @namespace Store/NewsletterSubscription/Dispatcher/fetchMutationSuccess */
+            /** @namespace Store/NewsletterSubscription/Dispatcher/NewsletterSubscriptionDispatcher/subscribeToNewsletter/fetchMutation/then/dispatch/catch */
             (error) => dispatch(showNotification('error', getErrorMessage(error)))
         );
     }

--- a/packages/scandipwa/src/store/NoMatch/NoMatch.reducer.js
+++ b/packages/scandipwa/src/store/NoMatch/NoMatch.reducer.js
@@ -18,7 +18,7 @@ export const getInitialState = () => ({
     noMatch: false
 });
 
-/** @namespace Store/NoMatch/Reducer */
+/** @namespace Store/NoMatch/Reducer/NoMatchReducer */
 export const NoMatchReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/Notification/Notification.reducer.js
+++ b/packages/scandipwa/src/store/Notification/Notification.reducer.js
@@ -16,7 +16,7 @@ export const getInitialState = () => ({
     notifications: {}
 });
 
-/** @namespace Store/Notification/Reducer */
+/** @namespace Store/Notification/Reducer/NotificationReducer */
 export const NotificationReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/Offline/Offline.reducer.js
+++ b/packages/scandipwa/src/store/Offline/Offline.reducer.js
@@ -20,7 +20,7 @@ export const getInitialState = () => ({
     isBig: false
 });
 
-/** @namespace Store/Offline/Reducer */
+/** @namespace Store/Offline/Reducer/OfflineReducer */
 export const OfflineReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/Order/Order.dispatcher.js
+++ b/packages/scandipwa/src/store/Order/Order.dispatcher.js
@@ -20,11 +20,11 @@ export class OrderDispatcher {
         const query = OrderQuery.getOrderListQuery();
 
         return fetchQuery(query).then(
-            /** @namespace Store/Order/Dispatcher/requestOrdersFetchQueryThen */
+            /** @namespace Store/Order/Dispatcher/OrderDispatcher/requestOrders/fetchQuery/then */
             ({ getOrderList: orders }) => {
                 dispatch(getOrderList(orders, false));
             },
-            /** @namespace Store/Order/Dispatcher/requestOrdersFetchQueryError */
+            /** @namespace Store/Order/Dispatcher/OrderDispatcher/requestOrders/fetchQuery/then/dispatch/catch */
             (error) => dispatch(showNotification('error', getErrorMessage(error)))
         );
     }

--- a/packages/scandipwa/src/store/Order/Order.reducer.js
+++ b/packages/scandipwa/src/store/Order/Order.reducer.js
@@ -55,7 +55,7 @@ export const getInitialState = () => ({
     isLoading: !orderList.length
 });
 
-/** @namespace Store/Order/Reducer */
+/** @namespace Store/Order/Reducer/OrderReducer */
 export const OrderReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/Overlay/Overlay.reducer.js
+++ b/packages/scandipwa/src/store/Overlay/Overlay.reducer.js
@@ -22,7 +22,7 @@ export const getInitialState = () => ({
     areOtherOverlaysOpen: false
 });
 
-/** @namespace Store/Overlay/Reducer */
+/** @namespace Store/Overlay/Reducer/OverlayReducer */
 export const OverlayReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/Popup/Popup.reducer.js
+++ b/packages/scandipwa/src/store/Popup/Popup.reducer.js
@@ -19,7 +19,7 @@ export const getInitialState = () => ({
     shouldPopupClose: false
 });
 
-/** @namespace Store/Popup/Reducer */
+/** @namespace Store/Popup/Reducer/PopupReducer */
 export const PopupReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/Product/Product.reducer.js
+++ b/packages/scandipwa/src/store/Product/Product.reducer.js
@@ -36,7 +36,7 @@ export const formatConfigurableOptions = (configurable_options) => configurable_
         };
     }, {});
 
-/** @namespace Store/Product/Reducer */
+/** @namespace Store/Product/Reducer/ProductReducer */
 export const ProductReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/ProductCompare/ProductCompare.action.js
+++ b/packages/scandipwa/src/store/ProductCompare/ProductCompare.action.js
@@ -39,13 +39,13 @@ export const clearComparedProducts = () => ({
     type: CLEAR_COMPARED_PRODUCTS
 });
 
-/** @namespace Store/ProductCompare/Action/clearComparedProducts/setComparedProductIds */
+/** @namespace Store/ProductCompare/Action/setCompareListIds */
 export const setCompareListIds = (productIds) => ({
     type: SET_COMPARED_PRODUCT_IDS,
     productIds
 });
 
-/** @namespace Store/ProductCompare/Action/clearComparedProducts/addComparedProductIds */
+/** @namespace Store/ProductCompare/Action/addComparedProductIds */
 export const addComparedProductIds = (productId) => ({
     type: ADD_COMPARED_PRODUCT_ID,
     productId

--- a/packages/scandipwa/src/store/ProductCompare/ProductCompare.reducer.js
+++ b/packages/scandipwa/src/store/ProductCompare/ProductCompare.reducer.js
@@ -26,7 +26,7 @@ export const getInitialState = () => ({
     items: []
 });
 
-/** @namespace Store/ProductCompare/Reducer */
+/** @namespace Store/ProductCompare/Reducer/ProductCompareReducer */
 export const ProductCompareReducer = (state = getInitialState(), action) => {
     const { type } = action;
 

--- a/packages/scandipwa/src/store/ProductList/ProductList.reducer.js
+++ b/packages/scandipwa/src/store/ProductList/ProductList.reducer.js
@@ -30,7 +30,7 @@ export const defaultConfig = {
     itemsPerPageCount: 12
 };
 
-/** @namespace Store/ProductList/Reducer */
+/** @namespace Store/ProductList/Reducer/ProductListReducer */
 export const ProductListReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/ProductListInfo/ProductListInfo.reducer.js
+++ b/packages/scandipwa/src/store/ProductListInfo/ProductListInfo.reducer.js
@@ -64,7 +64,7 @@ export const getInitialState = () => ({
     isLoading: true
 });
 
-/** @namespace Store/ProductListInfo/Reducer */
+/** @namespace Store/ProductListInfo/Reducer/ProductListReducer */
 export const ProductListReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
@@ -27,7 +27,7 @@ export const getInitialState = () => ({
     isLoading: true
 });
 
-/** @namespace Store/RecentlyViewedProducts/Reducer/recentlyViewedProductsReducer */
+/** @namespace Store/RecentlyViewedProducts/Reducer/RecentlyViewedProductsReducer */
 export const RecentlyViewedProductsReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/Review/Review.dispatcher.js
+++ b/packages/scandipwa/src/store/Review/Review.dispatcher.js
@@ -46,9 +46,9 @@ export class ReviewDispatcher {
         return fetchMutation(ReviewQuery.getAddProductReviewMutation(
             this.prepareReviewData(options)
         )).then(
-            /** @namespace Store/Review/Dispatcher/submitProductReviewFetchMutationThen */
+            /** @namespace Store/Review/Dispatcher/ReviewDispatcher/submitProductReview/fetchMutation/then/dispatch */
             () => dispatch(showNotification('success', 'You submitted your review for moderation.')),
-            /** @namespace Store/Review/Dispatcher/submitProductReviewFetchMutationError */
+            /** @namespace Store/Review/Dispatcher/ReviewDispatcher/submitProductReview/fetchMutation/then/dispatch/catch */
             () => dispatch(showNotification('error', __('Error submitting review!')))
         );
     }

--- a/packages/scandipwa/src/store/SearchBar/SearchBar.reducer.js
+++ b/packages/scandipwa/src/store/SearchBar/SearchBar.reducer.js
@@ -23,7 +23,7 @@ export const getInitialState = () => ({
     isLoading: true
 });
 
-/** @namespace Store/SearchBar/Reducer */
+/** @namespace Store/SearchBar/Reducer/SearchBarReducer */
 export const SearchBarReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/UrlRewrites/UrlRewrites.action.js
+++ b/packages/scandipwa/src/store/UrlRewrites/UrlRewrites.action.js
@@ -19,7 +19,7 @@ export const updateUrlRewrite = (urlRewrite, requestedUrl) => ({
     requestedUrl
 });
 
-/** @namespace Store/UrlRewrites/Action/clearUrlRewrite */
+/** @namespace Store/UrlRewrites/Action/setIsUrlRewritesLoading */
 export const setIsUrlRewritesLoading = (isLoading) => ({
     type: IS_LOADING_URL_REWRITE,
     isLoading

--- a/packages/scandipwa/src/store/UrlRewrites/UrlRewrites.reducer.js
+++ b/packages/scandipwa/src/store/UrlRewrites/UrlRewrites.reducer.js
@@ -20,7 +20,7 @@ export const getInitialState = () => ({
     isLoading: false
 });
 
-/** @namespace Store/UrlRewrites/Reducer */
+/** @namespace Store/UrlRewrites/Reducer/UrlRewritesReducer */
 export const UrlRewritesReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/Wishlist/Wishlist.dispatcher.js
+++ b/packages/scandipwa/src/store/Wishlist/Wishlist.dispatcher.js
@@ -30,8 +30,7 @@ export const CartDispatcher = import(
 
 /**
  * Get wishlist setting.
- * @namespace /Store/Wishlist/Dispatcher/isWishlistEnabled
- */
+ * @namespace Store/Wishlist/Dispatcher/isWishlistEnabled */
 export const isWishlistEnabled = () => {
     const state = getStore().getState();
     const {
@@ -58,7 +57,7 @@ export class WishlistDispatcher {
     _syncWishlistWithBE(dispatch) {
         // Need to get current wishlist from BE, update wishlist
         return fetchQuery(WishlistQuery.getWishlistQuery()).then(
-            /** @namespace Store/Wishlist/Dispatcher/_syncWishlistWithBEFetchQueryThen */
+            /** @namespace Store/Wishlist/Dispatcher/WishlistDispatcher/_syncWishlistWithBE/fetchQuery/then */
             (data) => {
                 if (data && data.wishlist) {
                     const { wishlist } = data;
@@ -100,7 +99,7 @@ export class WishlistDispatcher {
                     dispatch(updateIsLoading(false));
                 }
             },
-            /** @namespace Store/Wishlist/Dispatcher/_syncWishlistWithBEFetchQueryError */
+            /** @namespace Store/Wishlist/Dispatcher/WishlistDispatcher/_syncWishlistWithBE/fetchQuery/then/catch */
             () => {
                 dispatch(updateIsLoading(false));
             }
@@ -116,9 +115,9 @@ export class WishlistDispatcher {
         dispatch(showNotification('success', __('Product added to wish-list!')));
 
         return fetchMutation(WishlistQuery.getSaveWishlistItemMutation(wishlistItem)).then(
-            /** @namespace Store/Wishlist/Dispatcher/addItemToWishlistFetchMutationThen */
+            /** @namespace Store/Wishlist/Dispatcher/WishlistDispatcher/addItemToWishlist/fetchMutation/then */
             () => this._syncWishlistWithBE(dispatch),
-            /** @namespace Store/Wishlist/Dispatcher/addItemToWishlistFetchMutationError */
+            /** @namespace Store/Wishlist/Dispatcher/WishlistDispatcher/addItemToWishlist/fetchMutation/then/catch */
             () => {
                 dispatch(showNotification('error', __('Error updating wish list!')));
             }
@@ -131,7 +130,7 @@ export class WishlistDispatcher {
         }
 
         return fetchMutation(WishlistQuery.getSaveWishlistItemMutation(options)).then(
-            /** @namespace Store/Wishlist/Dispatcher/updateWishlistItemFetchMutationThen */
+            /** @namespace Store/Wishlist/Dispatcher/WishlistDispatcher/updateWishlistItem/fetchMutation/then/dispatch */
             () => dispatch(updateItemOptions(options))
         );
     }
@@ -143,11 +142,11 @@ export class WishlistDispatcher {
 
         return fetchMutation(WishlistQuery.getClearWishlist())
             .then(
-                /** @namespace Store/Wishlist/Dispatcher/clearWishlistFetchMutationThen */
+                /** @namespace Store/Wishlist/Dispatcher/WishlistDispatcher/clearWishlist/then/catch/fetchMutation/then/dispatch */
                 () => dispatch(clearWishlist())
             )
             .catch(
-                /** @namespace Store/Wishlist/Dispatcher/clearWishlistFetchMutationThenCatch */
+                /** @namespace Store/Wishlist/Dispatcher/WishlistDispatcher/clearWishlist/then/catch/dispatch */
                 () => dispatch(showNotification('error', __('Error clearing wish list!')))
             );
     }
@@ -159,7 +158,7 @@ export class WishlistDispatcher {
 
         return fetchMutation(WishlistQuery.getMoveWishlistToCart(sharingCode))
             .then(
-                /** @namespace Store/Wishlist/Dispatcher/moveWishlistToCartFetchMutationThen */
+                /** @namespace Store/Wishlist/Dispatcher/WishlistDispatcher/moveWishlistToCart/fetchMutation/then */
                 () => {
                     this._syncWishlistWithBE(dispatch);
                     CartDispatcher.then(
@@ -175,21 +174,18 @@ export class WishlistDispatcher {
         }
         dispatch(updateIsLoading(true));
 
-        if (noMessages) {
-            return fetchMutation(WishlistQuery.getRemoveProductFromWishlistMutation(item_id)).then(
-                /** @namespace Store/Wishlist/Dispatcher/removeItemFromWishlistNoMessagesFetchMutationThen */
-                () => dispatch(removeItemFromWishlist(item_id))
-            );
+        if (!noMessages) {
+            dispatch(showNotification('info', __('Product has been removed from your Wish List!')));
         }
 
-        dispatch(showNotification('info', __('Product has been removed from your Wish List!')));
-
         return fetchMutation(WishlistQuery.getRemoveProductFromWishlistMutation(item_id)).then(
-            /** @namespace Store/Wishlist/Dispatcher/removeItemFromWishlistFetchMutationThen */
+            /** @namespace Store/Wishlist/Dispatcher/WishlistDispatcher/removeItemFromWishlist/fetchMutation/then/dispatch */
             () => dispatch(removeItemFromWishlist(item_id)),
-            /** @namespace Store/Wishlist/Dispatcher/removeItemFromWishlistFetchMutationError */
+            /** @namespace Store/Wishlist/Dispatcher/WishlistDispatcher/removeItemFromWishlist/fetchMutation/then/catch */
             () => {
-                dispatch(showNotification('error', __('Error updating wish list!')));
+                if (!noMessages) {
+                    dispatch(showNotification('error', __('Error updating wish list!')));
+                }
             }
         );
     }
@@ -202,12 +198,12 @@ export class WishlistDispatcher {
 
         return itemIdMap.map((id) => (
             fetchMutation(WishlistQuery.getRemoveProductFromWishlistMutation(id)).then(
-                /** @namespace Store/Wishlist/Dispatcher/removeItemsFromWishlistNoMessagesFetchMutationThen */
+                /** @namespace Store/Wishlist/Dispatcher/WishlistDispatcher/removeItemsFromWishlist/itemIdMap/map/fetchMutation/then */
                 () => {
                     dispatch(removeItemFromWishlist(id));
                     dispatch(showNotification('info', __('Product has been removed from your Wish List!')));
                 },
-                /** @namespace Store/Wishlist/Dispatcher/removeItemsFromWishlistFetchMutationError */
+                /** @namespace Store/Wishlist/Dispatcher/WishlistDispatcher/removeItemsFromWishlist/itemIdMap/map/fetchMutation/then/catch */
                 (error) => {
                     dispatch(showNotification('error', getErrorMessage(error, __('Error updating wishlist!'))));
                 }

--- a/packages/scandipwa/src/store/Wishlist/Wishlist.reducer.js
+++ b/packages/scandipwa/src/store/Wishlist/Wishlist.reducer.js
@@ -90,7 +90,7 @@ export const updateItemOptions = (options, { productsInWishlist }) => {
     return { productsInWishlist: products };
 };
 
-/** @namespace Store/Wishlist/Reducer */
+/** @namespace Store/Wishlist/Reducer/WishlistReducer */
 export const WishlistReducer = (
     state = getInitialState(),
     action

--- a/packages/scandipwa/src/store/index.js
+++ b/packages/scandipwa/src/store/index.js
@@ -25,7 +25,7 @@ import ProductListInfoReducer from 'Store/ProductListInfo/ProductListInfo.reduce
 import UrlRewritesReducer from 'Store/UrlRewrites/UrlRewrites.reducer';
 import WishlistReducer from 'Store/Wishlist/Wishlist.reducer';
 
-/** @namespace Store/Index/getReducers */
+/** @namespace Store/Index/getStaticReducers */
 export const getStaticReducers = () => ({
     ProductListReducer,
     ProductListInfoReducer,

--- a/packages/scandipwa/src/util/Address/index.js
+++ b/packages/scandipwa/src/util/Address/index.js
@@ -9,7 +9,7 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-/** @namespace Util/Address/trimCustomerAddress */
+/** @namespace Util/Address/Index/trimCustomerAddress */
 export const trimCustomerAddress = (customerAddress) => {
     const {
         city,
@@ -46,12 +46,13 @@ export const trimCustomerAddress = (customerAddress) => {
  * Removes null values from address.street
  * @param street
  * @returns {*}
+ * @namespace Util/Address/Index/removeEmptyStreets
  */
 export const removeEmptyStreets = (street) => (
     Array.isArray(street) ? street.filter((line) => line) : street
 );
 
-/** @namespace Util/Address/trimAddressFields */
+/** @namespace Util/Address/Index/trimAddressFields */
 export const trimAddressFields = (fields) => {
     const {
         region_string: region,
@@ -63,7 +64,7 @@ export const trimAddressFields = (fields) => {
 
 /** transforming "street[index]" entries into a single "street" object
     for checkout/billing/myAccoutAddress form fields object */
-/** @namespace Util/Address/setAddressesInFormObject */
+/** @namespace Util/Address/Index/setAddressesInFormObject */
 export const setAddressesInFormObject = (fields, numberOfLines) => {
     const addressKeys = new Array(numberOfLines)
         .fill('')
@@ -89,7 +90,7 @@ export const setAddressesInFormObject = (fields, numberOfLines) => {
 };
 
 // get Form Fields object depending on addressLinesQty
-/** @namespace Util/Address/getFormFields */
+/** @namespace Util/Address/Index/getFormFields */
 export const getFormFields = (fields, addressLinesQty) => {
     if (addressLinesQty === 1) {
         return fields;
@@ -98,7 +99,7 @@ export const getFormFields = (fields, addressLinesQty) => {
     return setAddressesInFormObject(fields, addressLinesQty);
 };
 
-/** @namespace Util/Address/getCityAndRegionFromZipcode */
+/** @namespace Util/Address/Index/getCityAndRegionFromZipcode */
 export const getCityAndRegionFromZipcode = async (countryId, value) => {
     const response = await fetch(`https://api.zippopotam.us/${countryId}/${value.split(' ')[0]}`);
     const data = await response.json();
@@ -111,7 +112,7 @@ export const getCityAndRegionFromZipcode = async (countryId, value) => {
         : [null, null];
 };
 
-/** @namespace Util/Address/getDefaultAddressLabel */
+/** @namespace Util/Address/Index/getDefaultAddressLabel */
 export const getDefaultAddressLabel = (address) => {
     const { default_billing, default_shipping } = address;
     if (!default_billing && !default_shipping) {
@@ -127,7 +128,7 @@ export const getDefaultAddressLabel = (address) => {
     return __(' (default shipping address)');
 };
 
-/** @namespace Util/Address/getAvailableRegions */
+/** @namespace Util/Address/Index/getAvailableRegions */
 export const getAvailableRegions = (country_id, countries) => {
     const country = countries.find(({ id }) => id === country_id) || {};
     const { available_regions } = country;

--- a/packages/scandipwa/src/util/Auth/Token.js
+++ b/packages/scandipwa/src/util/Auth/Token.js
@@ -18,7 +18,7 @@ export const AUTH_TOKEN = 'auth_token';
 
 export const ONE_HOUR = 3600;
 
-/** @namespace Util/Auth/setAuthorizationToken */
+/** @namespace Util/Auth/Token/setAuthorizationToken */
 export const setAuthorizationToken = (token) => {
     const state = getStore().getState();
     const {
@@ -28,19 +28,19 @@ export const setAuthorizationToken = (token) => {
     BrowserDatabase.setItem(token, AUTH_TOKEN, cookie_lifetime);
 };
 
-/** @namespace Util/Auth/deleteAuthorizationToken */
+/** @namespace Util/Auth/Token/deleteAuthorizationToken */
 export const deleteAuthorizationToken = () => BrowserDatabase.deleteItem(AUTH_TOKEN);
 
-/** @namespace Util/Auth/getAuthorizationToken */
+/** @namespace Util/Auth/Token/getAuthorizationToken */
 export const getAuthorizationToken = () => BrowserDatabase.getItem(AUTH_TOKEN);
 
-/** @namespace Util/Auth/refreshAuthorizationToken */
+/** @namespace Util/Auth/Token/refreshAuthorizationToken */
 export const refreshAuthorizationToken = () => setAuthorizationToken(getAuthorizationToken());
 
-/** @namespace Util/Auth/isInitiallySignedIn */
+/** @namespace Util/Auth/Token/isInitiallySignedIn */
 export const isInitiallySignedIn = () => !!getAuthorizationToken();
 
-/** @namespace Util/Auth/isSignedIn */
+/** @namespace Util/Auth/Token/isSignedIn */
 export const isSignedIn = () => {
     const _isSignedIn = !!getAuthorizationToken();
     const store = getStore();

--- a/packages/scandipwa/src/util/Browser/Browser.js
+++ b/packages/scandipwa/src/util/Browser/Browser.js
@@ -12,10 +12,14 @@
 // eslint-disable-next-line max-len
 export const crawlerRegEx = /(googlebot|Googlebot-Mobile|Googlebot-Image|Google favicon|Mediapartners-Google|bingbot|slurp|java|wget|curl|Commons-HttpClient|Python-urllib|libwww|httpunit|nutch|phpcrawl|msnbot|jyxobot|FAST-WebCrawler|FAST Enterprise Crawler|biglotron|teoma|convera|seekbot|gigablast|exabot|ngbot|ia_archiver|GingerCrawler|webmon |httrack|webcrawler|grub.org|UsineNouvelleCrawler|antibot|netresearchserver|speedy|fluffy|bibnum.bnf|findlink|msrbot|panscient|yacybot|AISearchBot|IOI|ips-agent|tagoobot|MJ12bot|dotbot|woriobot|yanga|buzzbot|mlbot|yandexbot|purebot|Linguee Bot|Voyager|CyberPatrol|voilabot|baiduspider|citeseerxbot|spbot|twengabot|postrank|turnitinbot|scribdbot|page2rss|sitebot|linkdex|Adidxbot|blekkobot|ezooms|dotbot|Mail.RU_Bot|discobot|heritrix|findthatfile|europarchive.org|NerdByNature.Bot|sistrix crawler|ahrefsbot|Aboundex|domaincrawler|wbsearchbot|summify|ccbot|edisterbot|seznambot|ec2linkfinder|gslfbot|aihitbot|intelium_bot|facebookexternalhit|yeti|RetrevoPageAnalyzer|lb-spider|sogou|lssbot|careerbot|wotbox|wocbot|ichiro|DuckDuckBot|lssrocketcrawler|drupact|webcompanycrawler|acoonbot|openindexspider|gnam gnam spider|web-archive-net.com.bot|backlinkcrawler|coccoc|integromedb|content crawler spider|toplistbot|seokicks-robot|it2media-domain-crawler|ip-web-crawler.com|siteexplorer.info|elisabot|proximic|changedetection|blexbot|arabot|WeSEE:Search|niki-bot|CrystalSemanticsBot|rogerbot|360Spider|psbot|InterfaxScanBot|Lipperhey SEO Service|CC Metadata Scaper|g00g1e.net|GrapeshotCrawler|urlappendbot|brainobot|fr-crawler|binlar|SimpleCrawler|Livelapbot|Twitterbot|cXensebot|smtbot|bnf.fr_bot|A6-Indexer|ADmantX|Facebot|Twitterbot|OrangeBot|memorybot|AdvBot|MegaIndex|SemanticScholarBot|ltx71|nerdybot|xovibot|BUbiNG|Qwantify|archive.org_bot|Applebot|TweetmemeBot|crawler4j|findxbot|SemrushBot|yoozBot|lipperhey|y!j-asr|Domain Re-Animator Bot|AddThis|HeadlessChrome|render|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest\/0\.|pinterestbot|slackbot|vkShare|W3C_Validator|whatsapp|scandibot)/i;
 
+/** @namespace Util/Browser/isSSR */
 export const isSSR = () => !globalThis.window || !globalThis.window.document;
 
+/** @namespace Util/Browser/isCrawler */
 export const isCrawler = () => crawlerRegEx.test(navigator.userAgent);
 
+/** @namespace Util/Browser/toggleScroll */
 export const toggleScroll = (state) => document.documentElement.classList.toggle('scrollDisabled', !state);
 
+/** @namespace Util/Browser/isScrollDisabled */
 export const isScrollDisabled = () => document.documentElement.classList.contains('scrollDisabled');

--- a/packages/scandipwa/src/util/CSS/CSS.js
+++ b/packages/scandipwa/src/util/CSS/CSS.js
@@ -31,7 +31,7 @@ export class CSS {
     }
 }
 
-/** @namespace Util/CSS/getHeight */
+/** @namespace Util/CSS/getElementHeight */
 export const getElementHeight = (id) => Array.from(
     document.getElementsByClassName(id)
 ).reduce((acc, item) => {

--- a/packages/scandipwa/src/util/Cart/Token.js
+++ b/packages/scandipwa/src/util/Cart/Token.js
@@ -14,7 +14,7 @@ import BrowserDatabase from 'Util/BrowserDatabase';
 
 export const GUEST_QUOTE_ID = 'guest_quote_id';
 
-/** @namespace Util/Token/setGuestQuoteId */
+/** @namespace Util/Cart/Token/setGuestQuoteId */
 export const setGuestQuoteId = (token) => {
     BrowserDatabase.setItem({
         token,
@@ -22,7 +22,7 @@ export const setGuestQuoteId = (token) => {
     }, GUEST_QUOTE_ID);
 };
 
-/** @namespace Util/Token/getGuestQuoteId */
+/** @namespace Util/Cart/Token/getGuestQuoteId */
 export const getGuestQuoteId = () => {
     const {
         token,
@@ -36,5 +36,5 @@ export const getGuestQuoteId = () => {
     return token;
 };
 
-/** @namespace Util/Token/deleteGuestQuoteId */
+/** @namespace Util/Cart/Token/deleteGuestQuoteId */
 export const deleteGuestQuoteId = () => BrowserDatabase.deleteItem(GUEST_QUOTE_ID);

--- a/packages/scandipwa/src/util/DynamicReducer/index.js
+++ b/packages/scandipwa/src/util/DynamicReducer/index.js
@@ -13,6 +13,7 @@ import React from 'react';
 import injectReducers from 'Util/DynamicReducer/Helper';
 import getStore from 'Util/Store';
 
+/** @namespace Util/DynamicReducer/Index/withReducers */
 export const withReducers = (reducers) => (WrappedComponent) => {
     const injectAndExecute = (props) => {
         injectReducers(getStore(), reducers);

--- a/packages/scandipwa/src/util/FormPortalCollector/index.js
+++ b/packages/scandipwa/src/util/FormPortalCollector/index.js
@@ -9,7 +9,7 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-/** @namespace Util/FormPortalCollector */
+/** @namespace Util/FormPortalCollector/Index */
 export class FormPortalCollector {
     portalsObservers = {};
 

--- a/packages/scandipwa/src/util/Manipulations/Array.js
+++ b/packages/scandipwa/src/util/Manipulations/Array.js
@@ -10,6 +10,7 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+/** @namespace Util/Manipulations/Array/range */
 export const range = (start, end) => {
     const length = end - start + 1;
     return Array.from({ length }, (_, i) => start + i);

--- a/packages/scandipwa/src/util/Menu/Menu.js
+++ b/packages/scandipwa/src/util/Menu/Menu.js
@@ -28,7 +28,6 @@ export const getSortedItems = (unsortedItems) => Array.from(unsortedItems).sort(
 ) => (PID - prevPID) || (P - prevP));
 
 /** @namespace Util/Menu */
-// eslint-disable-next-line @scandipwa/scandipwa-guidelines/derived-class-names
 export class Menu {
     getMenuUrl({ url, url_type, category_id }) {
         switch (url_type) {

--- a/packages/scandipwa/src/util/Product/Extract.js
+++ b/packages/scandipwa/src/util/Product/Extract.js
@@ -18,6 +18,7 @@ import { BUNDLE, CONFIGURABLE, GROUPED } from 'Util/Product/Types';
  * @param product
  * @param configIndex
  * @returns {boolean}
+ * @namespace Util/Product/Extract/getProductInStock
  */
 export const getProductInStock = (product, configIndex = -1) => {
     if (!product) {

--- a/packages/scandipwa/src/util/Promise/MakeCancelable.js
+++ b/packages/scandipwa/src/util/Promise/MakeCancelable.js
@@ -17,17 +17,16 @@
  * @static
  * @param  {Promise} promise promise which has to be cancelable
  * @return {Promise} Cancelable promise
- * @namespace Util/Promise/makeCancelable
- */
+ * @namespace Util/Promise/MakeCancelable/makeCancelable */
 export const makeCancelable = (promise) => {
     // eslint-disable-next-line fp/no-let
     let hasCanceled_ = false;
 
     const wrappedPromise = new Promise((resolve, reject) => {
         promise.then(
-            /** @namespace Util/Promise/MakeCancelable/promiseThen */
+            /** @namespace Util/Promise/MakeCancelable/makeCancelable/wrappedPromise/promise/then */
             (val) => (!hasCanceled_ && resolve(val)),
-            /** @namespace Util/Promise/MakeCancelable/promiseError */
+            /** @namespace Util/Promise/MakeCancelable/makeCancelable/wrappedPromise/promise/then/catch */
             (error) => (!hasCanceled_ && reject(error))
         );
     });

--- a/packages/scandipwa/src/util/Query/PrepareDocument.js
+++ b/packages/scandipwa/src/util/Query/PrepareDocument.js
@@ -16,8 +16,7 @@ export const QUERY_TYPE = 'query';
  * Prepare request body string from query list (all entries must be instances of Query).
  * @param  {Array<Field>} queries
  * @return {String} JSON String, format: `{"query":"{alias: queryName (attr:key) { field1, field2 }}"}`
- * @namespace Util/Query/prepareFieldString
- */
+ * @namespace Util/Query/PrepareDocument/prepareFieldString */
 export const prepareFieldString = (rootField, accArgs = {}) => {
     const {
         alias, name, args, children
@@ -52,7 +51,7 @@ export const prepareFieldString = (rootField, accArgs = {}) => {
     return `${alias}${name}${formattedArgs}${body}`;
 };
 
-/** @namespace Util/Query/prepareRequest */
+/** @namespace Util/Query/PrepareDocument/prepareRequest */
 export const prepareRequest = (fields, type) => {
     const fieldsArray = Array.isArray(fields) ? fields : [fields];
 
@@ -101,8 +100,8 @@ export const prepareRequest = (fields, type) => {
     };
 };
 
-/** @namespace Util/Query/prepareMutation */
+/** @namespace Util/Query/PrepareDocument/prepareMutation */
 export const prepareMutation = (mutations) => prepareRequest(mutations, MUTATION_TYPE);
 
-/** @namespace Util/Query/prepareQuery */
+/** @namespace Util/Query/PrepareDocument/prepareQuery */
 export const prepareQuery = (queries) => prepareRequest(queries, QUERY_TYPE);

--- a/packages/scandipwa/src/util/Request/DataContainer.js
+++ b/packages/scandipwa/src/util/Request/DataContainer.js
@@ -48,12 +48,12 @@ export class DataContainer extends PureComponent {
         );
 
         this.promise.promise.then(
-            /** @namespace Util/Request/DataContainer/fetchData/thisPromisePromiseThen */
+            /** @namespace Util/Request/DataContainer/DataContainer/fetchData/then */
             (response) => {
                 window.dataCache[queryHash] = response;
                 onSuccess(response);
             },
-            /** @namespace Util/Request/DataContainer/fetchData/thisPromisePromiseCatch */
+            /** @namespace Util/Request/DataContainer/DataContainer/fetchData/then/onError/catch */
             (err) => onError(err)
         );
     }

--- a/packages/scandipwa/src/util/Request/Error.js
+++ b/packages/scandipwa/src/util/Request/Error.js
@@ -16,8 +16,7 @@ export const DEFAULT_ERROR_MESSAGE = __('Something went wrong!');
  * @param array | object error
  * @param string optional default error message if couldn't get any from the given error
  * @return string message
- * @namespace Util/Request/getErrorMessage
- */
+ * @namespace Util/Request/Error/getErrorMessage */
 export const getErrorMessage = (error, defaultMessage = DEFAULT_ERROR_MESSAGE) => {
     const {
         message = defaultMessage

--- a/packages/scandipwa/src/util/Request/Hash.js
+++ b/packages/scandipwa/src/util/Request/Hash.js
@@ -25,8 +25,7 @@
  * @param {string} key ASCII only
  * @param {number} seed Positive integer only
  * @return {number} 32-bit positive integer hash
- * @namespace Util/Request/hash
- */
+ * @namespace Util/Request/Hash/hash */
 export const hash = (key, seed) => {
     // eslint-disable-next-line one-var, fp/no-let
     let h1,

--- a/packages/scandipwa/src/util/Request/Mutation.js
+++ b/packages/scandipwa/src/util/Request/Mutation.js
@@ -12,7 +12,7 @@
 import { Field, prepareMutation } from 'Util/Query';
 import { executePost } from 'Util/Request/Request';
 
-/** @namespace Util/Request/fetchMutation */
+/** @namespace Util/Request/Mutation/fetchMutation */
 // eslint-disable-next-line import/prefer-default-export
 export const fetchMutation = (rawMutations) => {
     const queries = rawMutations instanceof Field ? [rawMutations] : rawMutations;

--- a/packages/scandipwa/src/util/Request/Query.js
+++ b/packages/scandipwa/src/util/Request/Query.js
@@ -12,7 +12,7 @@
 import { Field, prepareQuery } from 'Util/Query';
 import { executePost } from 'Util/Request/Request';
 
-/** @namespace Util/Request/fetchQuery */
+/** @namespace Util/Request/Query/fetchQuery */
 // eslint-disable-next-line import/prefer-default-export
 export const fetchQuery = (rawQueries) => {
     const queries = rawQueries instanceof Field ? [rawQueries] : rawQueries;

--- a/packages/scandipwa/src/util/Request/QueryDispatcher.js
+++ b/packages/scandipwa/src/util/Request/QueryDispatcher.js
@@ -62,23 +62,23 @@ export class QueryDispatcher {
             new Promise((resolve, reject) => {
                 executeGet(prepareQuery(queries), name, cacheTTL)
                     .then(
-                        /** @namespace Util/Request/QueryDispatcher/handleData/executeGetThen */
+                        /** @namespace Util/Request/QueryDispatcher/QueryDispatcher/handleData/makeCancelable/executeGet/then/resolve */
                         (data) => resolve(data),
-                        /** @namespace Util/Request/QueryDispatcher/handleData/executeGetError */
+                        /** @namespace Util/Request/QueryDispatcher/QueryDispatcher/handleData/makeCancelable/executeGet/then/reject/catch */
                         (error) => reject(error)
                     );
             })
         );
 
         this.promise.promise.then(
-            /** @namespace Util/Request/QueryDispatcher/handleData/thisPromisePromiseThen */
+            /** @namespace Util/Request/QueryDispatcher/QueryDispatcher/handleData/then */
             (data) => this.onSuccess(data, dispatch, options),
-            /** @namespace Util/Request/QueryDispatcher/handleData/thisPromisePromiseError */
+            /** @namespace Util/Request/QueryDispatcher/QueryDispatcher/handleData/then/catch */
             (error) => this.onError(error, dispatch, options),
         );
 
         listenForBroadCast(name).then(
-            /** @namespace Util/Request/QueryDispatcher/handleData/listenForBroadCastThen */
+            /** @namespace Util/Request/QueryDispatcher/QueryDispatcher/handleData/listenForBroadCast/then */
             (data) => this.onUpdate(data, dispatch, options),
         );
     }

--- a/packages/scandipwa/src/util/Request/Request.js
+++ b/packages/scandipwa/src/util/Request/Request.js
@@ -164,14 +164,14 @@ export const handleConnectionError = (err) => console.error(err); // TODO: Add t
  */
 export const parseResponse = (promise) => new Promise((resolve, reject) => {
     promise.then(
-        /** @namespace Util/Request/promiseThen */
+        /** @namespace Util/Request/parseResponse/Promise/promise/then */
         (res) => res.json().then(
-            /** @namespace Util/Request/resJsonThen */
+            /** @namespace Util/Request/parseResponse/Promise/promise/then/json/then/resolve */
             (res) => resolve(checkForErrors(res)),
-            /** @namespace Util/Request/resJsonError */
+            /** @namespace Util/Request/parseResponse/Promise/promise/then/json/then/catch */
             () => handleConnectionError('Can not transform JSON!') && reject()
         ),
-        /** @namespace Util/Request/promiseError */
+        /** @namespace Util/Request/parseResponse/Promise/promise/then/catch */
         (err) => handleConnectionError('Can not establish connection!') && reject(err)
     );
 });
@@ -193,15 +193,15 @@ export const executeGet = (queryObject, name, cacheTTL) => {
 
     return parseResponse(new Promise((resolve) => {
         getFetch(uri, name).then(
-            /** @namespace Util/Request/getFetchThen */
+            /** @namespace Util/Request/executeGet/parseResponse/getFetch/then */
             (res) => {
                 if (res.status === HTTP_410_GONE) {
                     putPersistedQuery(getGraphqlEndpoint(), query, cacheTTL).then(
-                        /** @namespace Util/Request/putPersistedQueryThen */
+                        /** @namespace Util/Request/executeGet/parseResponse/getFetch/then/putPersistedQuery/then */
                         (putResponse) => {
                             if (putResponse.status === HTTP_201_CREATED) {
                                 getFetch(uri, name).then(
-                                    /** @namespace Util/Request/putResponseGetFetchThen */
+                                    /** @namespace Util/Request/executeGet/parseResponse/getFetch/then/putPersistedQuery/then/getFetch/then/resolve */
                                     (res) => resolve(res)
                                 );
                             }

--- a/packages/scandipwa/src/util/Store/index.js
+++ b/packages/scandipwa/src/util/Store/index.js
@@ -13,8 +13,8 @@ import { combineReducers, createStore } from 'redux';
 
 /**
  * Configure the store
- * @namespace Store/Index/configureStore
- * */
+ * @namespace Util/Store/Index/configureStore
+ */
 export function configureStore(store) {
     // Add a dictionary to keep track of the registered async reducers
     store.asyncReducers = {};
@@ -30,6 +30,7 @@ export function configureStore(store) {
     return store;
 }
 
+/** @namespace Util/Store/Index/noopReducer */
 export const noopReducer = (state) => state;
 
 export const getStore = (() => {

--- a/packages/scandipwa/src/util/Url/Url.js
+++ b/packages/scandipwa/src/util/Url/Url.js
@@ -55,7 +55,7 @@ export const getUrlParam = (match, location) => {
     return currentUrl.replace(baseUrl, '').replace(/^\/*/, '');
 };
 
-/**  Util/Url/trimEndSlash */
+/** @namespace Util/Url/trimEndSlash */
 export const trimEndSlash = (str) => (str.endsWith('/') ? str.slice(0, -1) : str);
 
 /**
@@ -240,6 +240,7 @@ export const objectToUri = (keyValueObject = {}) => {
     return paramString.length > 0 ? `?${paramString}` : '';
 };
 
+/** @namespace Util/Url/isHomePageUrl */
 export const isHomePageUrl = (pathname) => {
     const isHomePage = pathname === appendWithStoreCode('/')
         || pathname === '/'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2627,36 +2627,6 @@
     semver "^7.3.2"
     validate-npm-package-name "^3.0.0"
 
-"@scandipwa/scandipwa@5.0.4":
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/@scandipwa/scandipwa/-/scandipwa-5.0.4.tgz#455e5783a517160f51c384e533a9c3fc7519589c"
-  integrity sha512-JmwJx15zpgZQ1jMKLm4nZXmYjIyblrkE7k7tgXaghMHXxYeDC+gGAXKmhYMirlXNGjNr7Th+Es7sDSZXKpOmUA==
-  dependencies:
-    "@scandipwa/chunk-optimizer" "0.0.3"
-    "@scandipwa/m2-theme" "0.2.2"
-    "@scandipwa/postcss-config" "0.0.2"
-    "@scandipwa/scandipwa-scripts" "2.4.16"
-    "@scandipwa/service-worker" "0.0.16"
-    "@scandipwa/webpack-i18n-runtime" "0.0.28"
-    history "^4.9.0"
-    html-react-parser "^0.13.0"
-    intersection-observer "^0.12.0"
-    prop-types "^15.6.2"
-    react "^16.13.1"
-    react-dom "^16.13.1"
-    react-input-range "^1.3.0"
-    react-intersection-observer "^8.31.0"
-    react-redux "^7.2.0"
-    react-router "^5.2.0"
-    react-router-dom "^5.2.0"
-    react-stripe-elements "^6.1.2"
-    react-vimeo "^2.0.0"
-    react-youtube "^7.11.2"
-    react-zoom-pan-pinch "^1.6.1"
-    rebem-classname "^0.4.0"
-    redux "^4.0.5"
-    unstated "^2.1.1"
-
 "@scandipwa/webpack-fallback-plugin@^1.2.5":
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@scandipwa/webpack-fallback-plugin/-/webpack-fallback-plugin-1.2.5.tgz#325e5edeecf8a2c800cb6b64b6f02821382dbea5"


### PR DESCRIPTION
In this PR:
1. Fixed use-namespace rule for scandipwa.
2. Added exported functions to the rule scope.
3. Added `finally` to the rule scope.
4. Fixed issue when promise handlers had duplicate namespaces.
5. Fixed namespaces in the code.

Mosaic use-namespace has same fixes here: https://github.com/tilework/mosaic/pull/57
With an exception that SPWA use-namespace rule doesn't append component class name to the namespace in order to maintain old namespace schema and don't break existing extensions.