### PR TITLE
#3103 - Remove unused query fields for productlist

### DIFF
--- a/packages/scandipwa/src/component/ProductAttributes/ProductAttributes.component.js
+++ b/packages/scandipwa/src/component/ProductAttributes/ProductAttributes.component.js
@@ -31,8 +31,7 @@ export class ProductAttributes extends PureComponent {
         const groups = Object.values(attributesWithValues).map(
             (attribute) => ({
                 attribute_group_id: attribute.attribute_group_id,
-                attribute_group_name: attribute.attribute_group_name,
-                attribute_group_code: attribute.attribute_group_code
+                attribute_group_name: attribute.attribute_group_name
             })
         );
 

--- a/packages/scandipwa/src/query/ProductList.query.js
+++ b/packages/scandipwa/src/query/ProductList.query.js
@@ -279,24 +279,23 @@ export class ProductListQuery {
         if (isSingleProduct) {
             fields.push(
                 'stock_status',
-                'meta_title',
-                'meta_keyword',
-                'canonical_url',
-                'meta_description',
                 this._getDescriptionField(),
                 this._getMediaGalleryField(),
-                this._getSimpleProductFragment(),
-                this._getProductLinksField(),
-                this._getCustomizableProductFragment()
+                this._getSimpleProductFragment()
             );
 
             // for variants of PDP requested product
             if (!isVariant) {
                 fields.push(
+                    'canonical_url',
+                    'meta_title',
+                    'meta_keyword',
+                    'meta_description',
                     this._getCategoriesField(),
                     this._getReviewsField(),
                     this._getVirtualProductFragment(),
-                    this._getCustomizableProductFragment()
+                    this._getCustomizableProductFragment(),
+                    this._getProductLinksField()
                 );
             }
         }
@@ -559,7 +558,6 @@ export class ProductListQuery {
             'attribute_type',
             'attribute_label',
             'attribute_group_id',
-            'attribute_group_code',
             'attribute_group_name',
             ...(!isVariant
                 ? [
@@ -723,8 +721,17 @@ export class ProductListQuery {
             'price',
             'price_type',
             'can_change_quantity',
-            this._getProductField()
+            this._getProductBundleOptionFields()
         ];
+    }
+
+    _getProductBundleOptionFields() {
+        return new Field('product')
+            .addFieldList(this._getProductNameField());
+    }
+
+    _getProductNameField() {
+        return ['name'];
     }
 
     _getBundleOptionsField() {
@@ -774,7 +781,6 @@ export class ProductListQuery {
 
     _getBundleProductFragmentFields() {
         return [
-            'price_view',
             'dynamic_price',
             'dynamic_sku',
             'ship_bundle_items',


### PR DESCRIPTION
We have problems with query complexity, especially on PDPs. query to get PDP required info has 1044 complexity which is definitely very high. Others request have max 400 complexity.

**Relaited PR:**
* https://github.com/scandipwa/persisted-query/pull/25
* https://github.com/scandipwa/catalog-graphql/pull/121

**In this PR:**
* Reduce product list query complexity from 1044 to 604 by removing unnecessary query calls. 