### PR TITLE
#2934 - fix no layered navigation in search (BUGFIXING IN PROGRESS, DON'T MERGE)

### DIFF
--- a/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.container.js
+++ b/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.container.js
@@ -52,7 +52,10 @@ export class CategoryConfigurableAttributesContainer extends ProductConfigurable
     getSearchCategories() {
         const { categoryItems } = this.props;
         const allCategoryItems = Object.values(categoryItems).reduce((prev, next) => [...prev, ...next], []);
-        const categoryIds = allCategoryItems.reduce((prev, { categoryId }) => [...prev, categoryId.toString()], []);
+        const categoryIds = allCategoryItems.reduce(
+            (prev, { categories }) => [...prev, ...categories.map(({ id }) => id.toString())], []
+        );
+
         return Array.from(new Set(categoryIds));
     }
 

--- a/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.container.js
+++ b/packages/scandipwa/src/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.container.js
@@ -20,7 +20,8 @@ import CategoryConfigurableAttributes from './CategoryConfigurableAttributes.com
 export const mapStateToProps = (state) => ({
     currency_code: state.ConfigReducer.currencyData.current_currency_code,
     show_product_count: state.ConfigReducer.layered_navigation_product_count_enabled,
-    childrenCategories: state.CategoryReducer.category.children
+    childrenCategories: state.CategoryReducer.category.children,
+    categoryItems: state.ProductListReducer.pages
 });
 
 /** @namespace Component/CategoryConfigurableAttributes/Container/mapDispatchToProps */
@@ -48,12 +49,25 @@ export class CategoryConfigurableAttributesContainer extends ProductConfigurable
         };
     }
 
-    getSubCategories(option) {
-        const optionWithSubcategories = { ...option };
+    getSearchCategories() {
+        const { categoryItems } = this.props;
+        const allCategoryItems = Object.values(categoryItems).reduce((prev, next) => [...prev, ...next], []);
+        const categoryIds = allCategoryItems.reduce((prev, { categoryId }) => [...prev, categoryId.toString()], []);
+        return Array.from(new Set(categoryIds));
+    }
+
+    getCategorySubCategories() {
         const { childrenCategories } = this.props;
+        return childrenCategories.map(({ id }) => id.toString());
+    }
+
+    getSubCategories(option) {
+        const { isSearchPage } = this.props;
+        const optionWithSubcategories = { ...option };
         const { attribute_values } = option;
-        const childrenCategoryIds = childrenCategories.map((category) => category.id.toString());
-        const subCategoriesIds = attribute_values.filter((item) => childrenCategoryIds.includes(item));
+
+        const categoryItemsIds = isSearchPage ? this.getSearchCategories() : this.getCategorySubCategories();
+        const subCategoriesIds = attribute_values.filter((item) => categoryItemsIds.includes(item));
         optionWithSubcategories.attribute_values = subCategoriesIds;
 
         return optionWithSubcategories;

--- a/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
+++ b/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
@@ -38,7 +38,8 @@ export class CategoryFilterOverlay extends PureComponent {
         toggleCustomFilter: PropTypes.func.isRequired,
         getFilterUrl: PropTypes.func.isRequired,
         totalPages: PropTypes.number.isRequired,
-        isCategoryAnchor: PropTypes.bool.isRequired
+        isCategoryAnchor: PropTypes.bool.isRequired,
+        isSearchPage: PropTypes.bool.isRequired
     };
 
     renderFilters() {
@@ -47,7 +48,8 @@ export class CategoryFilterOverlay extends PureComponent {
             customFiltersValues,
             toggleCustomFilter,
             isMatchingInfoFilter,
-            getFilterUrl
+            getFilterUrl,
+            isSearchPage
         } = this.props;
 
         return (
@@ -58,6 +60,7 @@ export class CategoryFilterOverlay extends PureComponent {
               getLink={ getFilterUrl }
               parameters={ customFiltersValues }
               updateConfigurableVariant={ toggleCustomFilter }
+              isSearchPage={ isSearchPage }
             />
         );
     }
@@ -198,10 +201,12 @@ export class CategoryFilterOverlay extends PureComponent {
             totalPages,
             isProductsLoading,
             isContentFiltered,
-            isCategoryAnchor
+            isCategoryAnchor,
+            isSearchPage
         } = this.props;
 
-        if ((!isProductsLoading && totalPages === 0 && !isContentFiltered) || !isCategoryAnchor) {
+        // show CategoryFilterOverlay for 1. categories marked as `anchor` in Magento admin 2. Search page
+        if ((!isProductsLoading && totalPages === 0 && !isContentFiltered) || (!isCategoryAnchor && !isSearchPage)) {
             return (
                 <div block="CategoryFilterOverlay" />
             );

--- a/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.container.js
+++ b/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.container.js
@@ -56,6 +56,7 @@ export class CategoryFilterOverlayContainer extends PureComponent {
         isCategoryAnchor: PropTypes.bool,
         isMatchingInfoFilter: PropTypes.bool,
         isProductsLoading: PropTypes.bool.isRequired,
+        isSearchPage: PropTypes.bool.isRequired,
         totalPages: PropTypes.number.isRequired
     };
 
@@ -230,6 +231,7 @@ export class CategoryFilterOverlayContainer extends PureComponent {
             isInfoLoading,
             isMatchingInfoFilter,
             isProductsLoading,
+            isSearchPage,
             totalPages
         } = this.props;
 
@@ -239,6 +241,7 @@ export class CategoryFilterOverlayContainer extends PureComponent {
             isInfoLoading,
             isProductsLoading,
             isMatchingInfoFilter,
+            isSearchPage,
             totalPages,
             customFiltersValues,
             areFiltersEmpty: this.getAreFiltersEmpty(),

--- a/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.component.js
+++ b/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.component.js
@@ -81,10 +81,18 @@ export class InstallPrompt extends PureComponent {
     }
 
     render() {
+        const { device, isBannerClosed, hasInstallPromptEvent } = this.props;
+        const {
+            android,
+            standaloneMode
+        } = device;
+
         const displayComponent = this.hasSupport();
 
         if (!displayComponent) {
-            return null;
+            return JSON.stringify({
+                hasSupport: displayComponent, standaloneMode, android, isBannerClosed, hasInstallPromptEvent
+            });
         }
 
         return (

--- a/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.component.js
+++ b/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.component.js
@@ -89,29 +89,23 @@ export class InstallPrompt extends PureComponent {
         } = device;
 
         const displayComponent = this.hasSupport();
+        const debugMsg = SON.stringify({
+            hasSupport: displayComponent,
+            standaloneMode,
+            android,
+            isBannerClosed,
+            hasInstallPromptEvent,
+            hasHomeScreenSupport: hasHomeScreenSupport()
+        });
 
         if (!displayComponent) {
-            return JSON.stringify({
-                hasSupport: displayComponent,
-                standaloneMode,
-                android,
-                isBannerClosed,
-                hasInstallPromptEvent,
-                hasHomeScreenSupport: hasHomeScreenSupport()
-            });
+            return debugMsg;
         }
 
         return (
             <div block="InstallPrompt">
                 { this.renderPrompt() }
-                { JSON.stringify({
-                    hasSupport: displayComponent,
-                    standaloneMode,
-                    android,
-                    isBannerClosed,
-                    hasInstallPromptEvent,
-                    hasHomeScreenSupport: hasHomeScreenSupport()
-                }) }
+                { debugMsg }
             </div>
         );
     }

--- a/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.component.js
+++ b/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.component.js
@@ -15,7 +15,7 @@ import { PureComponent } from 'react';
 import InstallPromptAndroid from 'Component/InstallPromptAndroid';
 import InstallPromptIOS from 'Component/InstallPromptIOS';
 import { DeviceType } from 'Type/Device';
-import { hasHomeScreenSupport, hasManifest } from 'Util/Mobile/hasHomeScreenSupport';
+import { hasHomeScreenSupport, hasManifest, hasServiceWorker } from 'Util/Mobile/hasHomeScreenSupport';
 
 import './InstallPrompt.style';
 
@@ -96,7 +96,8 @@ export class InstallPrompt extends PureComponent {
             isBannerClosed,
             hasInstallPromptEvent,
             hasHomeScreenSupport: hasHomeScreenSupport(),
-            hasManifest: hasManifest()
+            hasManifest: hasManifest(),
+            hasServiceWorker: hasServiceWorker()
         });
 
         if (!displayComponent) {

--- a/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.component.js
+++ b/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.component.js
@@ -98,6 +98,9 @@ export class InstallPrompt extends PureComponent {
         return (
             <div block="InstallPrompt">
                 { this.renderPrompt() }
+                { JSON.stringify({
+                    hasSupport: displayComponent, standaloneMode, android, isBannerClosed, hasInstallPromptEvent
+                }) }
             </div>
         );
     }

--- a/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.component.js
+++ b/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.component.js
@@ -15,6 +15,7 @@ import { PureComponent } from 'react';
 import InstallPromptAndroid from 'Component/InstallPromptAndroid';
 import InstallPromptIOS from 'Component/InstallPromptIOS';
 import { DeviceType } from 'Type/Device';
+import { hasHomeScreenSupport } from 'Util/Mobile/hasHomeScreenSupport';
 
 import './InstallPrompt.style';
 
@@ -91,7 +92,12 @@ export class InstallPrompt extends PureComponent {
 
         if (!displayComponent) {
             return JSON.stringify({
-                hasSupport: displayComponent, standaloneMode, android, isBannerClosed, hasInstallPromptEvent
+                hasSupport: displayComponent,
+                standaloneMode,
+                android,
+                isBannerClosed,
+                hasInstallPromptEvent,
+                hasHomeScreenSupport: hasHomeScreenSupport()
             });
         }
 
@@ -99,7 +105,12 @@ export class InstallPrompt extends PureComponent {
             <div block="InstallPrompt">
                 { this.renderPrompt() }
                 { JSON.stringify({
-                    hasSupport: displayComponent, standaloneMode, android, isBannerClosed, hasInstallPromptEvent
+                    hasSupport: displayComponent,
+                    standaloneMode,
+                    android,
+                    isBannerClosed,
+                    hasInstallPromptEvent,
+                    hasHomeScreenSupport: hasHomeScreenSupport()
                 }) }
             </div>
         );

--- a/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.component.js
+++ b/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.component.js
@@ -15,7 +15,7 @@ import { PureComponent } from 'react';
 import InstallPromptAndroid from 'Component/InstallPromptAndroid';
 import InstallPromptIOS from 'Component/InstallPromptIOS';
 import { DeviceType } from 'Type/Device';
-import { hasHomeScreenSupport } from 'Util/Mobile/hasHomeScreenSupport';
+import { hasHomeScreenSupport, hasManifest } from 'Util/Mobile/hasHomeScreenSupport';
 
 import './InstallPrompt.style';
 
@@ -89,13 +89,14 @@ export class InstallPrompt extends PureComponent {
         } = device;
 
         const displayComponent = this.hasSupport();
-        const debugMsg = SON.stringify({
+        const debugMsg = JSON.stringify({
             hasSupport: displayComponent,
             standaloneMode,
             android,
             isBannerClosed,
             hasInstallPromptEvent,
-            hasHomeScreenSupport: hasHomeScreenSupport()
+            hasHomeScreenSupport: hasHomeScreenSupport(),
+            hasManifest: hasManifest()
         });
 
         if (!displayComponent) {

--- a/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.container.js
+++ b/packages/scandipwa/src/component/InstallPrompt/InstallPrompt.container.js
@@ -88,6 +88,7 @@ export class InstallPromptContainer extends PureComponent {
     listenForInstallPrompt() {
         window.addEventListener('beforeinstallprompt', (event) => {
             event.preventDefault();
+            alert('beforeinstallprompt event occurred');
             window.promt_event = Object.assign(event);
             this.setState({ hasInstallPromptEvent: true });
         });

--- a/packages/scandipwa/src/query/ProductList.query.js
+++ b/packages/scandipwa/src/query/ProductList.query.js
@@ -312,7 +312,11 @@ export class ProductListQuery {
      * @private
      */
     _getCategoryIds() {
-        return new Field('categories').addField('id');
+        return new Field('categories').addFieldList(['id', this._getBreadcrumbs()]);
+    }
+
+    _getBreadcrumbs() {
+        return new Field('breadcrumbs').addField('category_level');
     }
 
     /**

--- a/packages/scandipwa/src/query/ProductList.query.js
+++ b/packages/scandipwa/src/query/ProductList.query.js
@@ -299,9 +299,20 @@ export class ProductListQuery {
                     this._getCustomizableProductFragment()
                 );
             }
+        } else {
+            fields.push(this._getCategoryIds());
         }
 
         return fields;
+    }
+
+    /**
+     * Returns categories ids on PLP (required for layered navigation)
+     * @returns {Field}
+     * @private
+     */
+    _getCategoryIds() {
+        return new Field('categories').addField('id');
     }
 
     /**

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
@@ -68,6 +68,7 @@ export class CategoryPage extends PureComponent {
         isCurrentCategoryLoaded: PropTypes.bool,
         isMatchingListFilter: PropTypes.bool,
         isMatchingInfoFilter: PropTypes.bool,
+        isSearchPage: PropTypes.bool.isRequired,
         totalPages: PropTypes.number,
         totalItems: PropTypes.number.isRequired,
         isMobile: PropTypes.bool.isRequired,
@@ -208,7 +209,8 @@ export class CategoryPage extends PureComponent {
         const {
             filters,
             selectedFilters,
-            isMatchingInfoFilter
+            isMatchingInfoFilter,
+            isSearchPage
         } = this.props;
 
         const { category: { is_anchor } } = this.props;
@@ -224,6 +226,7 @@ export class CategoryPage extends PureComponent {
                   customFiltersValues={ selectedFilters }
                   isMatchingInfoFilter={ isMatchingInfoFilter }
                   isCategoryAnchor={ !!is_anchor }
+                  isSearchPage={ isSearchPage }
                 />
             </Suspense>
         );

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.js
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.js
@@ -426,7 +426,8 @@ export class CategoryPageContainer extends PureComponent {
             sortFields,
             toggleOverlayByKey,
             totalPages,
-            totalItems
+            totalItems,
+            isSearchPage
         } = this.props;
 
         return {
@@ -440,6 +441,7 @@ export class CategoryPageContainer extends PureComponent {
             isMatchingInfoFilter: this.getIsMatchingInfoFilter(),
             isMatchingListFilter: this.getIsMatchingListFilter(),
             isMobile,
+            isSearchPage,
             plpTypes: this.getPlpTypes(),
             selectedFilters: this.getSelectedFiltersFromUrl(),
             selectedSort: this.getSelectedSortFromUrl(),

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
@@ -14,7 +14,6 @@ import { connect } from 'react-redux';
 import { CATEGORY } from 'Component/Header/Header.config';
 import { LOADING_TIME } from 'Route/CategoryPage/CategoryPage.config';
 import { CategoryPageContainer } from 'Route/CategoryPage/CategoryPage.container';
-import { updateCurrentCategory } from 'Store/Category/Category.action';
 import CategoryReducer from 'Store/Category/Category.reducer';
 import { updateMeta } from 'Store/Meta/Meta.action';
 import { changeNavigationState } from 'Store/Navigation/Navigation.action';
@@ -84,10 +83,6 @@ export const mapDispatchToProps = (dispatch) => ({
         ({ default: dispatcher }) => dispatcher.updateNoMatch(dispatch, options)
     ),
     setBigOfflineNotice: (isBig) => dispatch(setBigOfflineNotice(isBig)),
-    updateMetaFromCategory: (category) => MetaDispatcher.then(
-        ({ default: dispatcher }) => dispatcher.updateWithCategory(category, dispatch)
-    ),
-    updateCurrentCategory: (category) => dispatch(updateCurrentCategory(category)),
     updateMeta: (meta) => dispatch(updateMeta(meta))
 });
 

--- a/packages/scandipwa/src/util/Mobile/hasHomeScreenSupport.js
+++ b/packages/scandipwa/src/util/Mobile/hasHomeScreenSupport.js
@@ -52,4 +52,4 @@ export const hasHomeScreenSupport = () => {
     return platform.isCompatible;
 };
 
-export const hasManifest = () => document.querySelector("[rel='manifest']");
+export const hasManifest = () => !!document.querySelector("[rel='manifest']");

--- a/packages/scandipwa/src/util/Mobile/hasHomeScreenSupport.js
+++ b/packages/scandipwa/src/util/Mobile/hasHomeScreenSupport.js
@@ -53,3 +53,5 @@ export const hasHomeScreenSupport = () => {
 };
 
 export const hasManifest = () => !!document.querySelector("[rel='manifest']");
+
+export const hasServiceWorker = () => 'serviceWorker' in navigator;

--- a/packages/scandipwa/src/util/Mobile/hasHomeScreenSupport.js
+++ b/packages/scandipwa/src/util/Mobile/hasHomeScreenSupport.js
@@ -48,7 +48,6 @@ export const hasHomeScreenSupport = () => {
         || platform.isOpera
         || platform.isIDevice;
 
-    console.debug(platform.isCompatible);
     return platform.isCompatible;
 };
 

--- a/packages/scandipwa/src/util/Mobile/hasHomeScreenSupport.js
+++ b/packages/scandipwa/src/util/Mobile/hasHomeScreenSupport.js
@@ -1,0 +1,53 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export const platform = {};
+
+export const hasHomeScreenSupport = () => {
+    // browser info and capability
+    const _ua = window.navigator.userAgent;
+
+    platform.isIDevice = /iphone|ipod|ipad/i.test(navigator.platform);
+    platform.isSamsung = /Samsung/i.test(_ua);
+    platform.isFireFox = /Firefox/i.test(_ua);
+    platform.isOpera = /opr/i.test(_ua);
+    platform.isEdge = /edg/i.test(_ua);
+
+    // Opera & FireFox only Trigger on Android
+    if (platform.isFireFox) {
+        platform.isFireFox = /android/i.test(_ua);
+    }
+
+    if (platform.isOpera) {
+        platform.isOpera = /android/i.test(_ua);
+    }
+
+    platform.isChromium = 'onbeforeinstallprompt' in window;
+    platform.isInWebAppiOS = window.navigator.standalone === true;
+    platform.isInWebAppChrome = window.matchMedia('(display-mode: fullscreen)').matches
+        || window.matchMedia('(display-mode: standalone)').matches
+        || window.matchMedia('(display-mode: minimal-ui)').matches;
+    platform.isMobileSafari = platform.isIDevice
+        && _ua.indexOf('Safari') > -1
+        && _ua.indexOf('CriOS') < 0;
+    platform.isStandalone = platform.isInWebAppiOS || platform.isInWebAppChrome;
+    platform.isiPad = platform.isMobileSafari && _ua.indexOf('iPad') > -1;
+    platform.isiPhone = platform.isMobileSafari && _ua.indexOf('iPad') === -1;
+    platform.isCompatible = platform.isChromium
+        || platform.isMobileSafari
+        || platform.isSamsung
+        || platform.isFireFox
+        || platform.isOpera
+        || platform.isIDevice;
+
+    console.debug(platform.isCompatible);
+    return platform.isCompatible;
+};

--- a/packages/scandipwa/src/util/Mobile/hasHomeScreenSupport.js
+++ b/packages/scandipwa/src/util/Mobile/hasHomeScreenSupport.js
@@ -51,3 +51,5 @@ export const hasHomeScreenSupport = () => {
     console.debug(platform.isCompatible);
     return platform.isCompatible;
 };
+
+export const hasManifest = () => document.querySelector("[rel='manifest']");

--- a/packages/scandipwa/src/util/Product/Product.js
+++ b/packages/scandipwa/src/util/Product/Product.js
@@ -287,11 +287,13 @@ export const getIndexedProduct = (product, itemSku) => {
         bundle_options = []
     } = product;
 
+    const { categories, ...otherProductFields } = product;
+
     const attributes = getIndexedAttributes(initialAttributes || []);
     const reviews = getIndexedReviews(initialReviews);
 
     const updatedProduct = {
-        ...product,
+        ...otherProductFields,
         configurable_options: getIndexedConfigurableOptions(initialConfigurableOptions, attributes),
         variants: itemSku ? getIndexedSingleVariant(initialVariants, itemSku) : getIndexedVariants(initialVariants),
         options: getIndexedCustomOptions(initialOptions || []),
@@ -306,6 +308,11 @@ export const getIndexedProduct = (product, itemSku) => {
 
     if (bundle_options.length) {
         updatedProduct.items = getBundleOptions(bundle_options, items);
+    }
+
+    if (categories.length) {
+        const [{ id }] = categories;
+        updatedProduct.categoryId = id;
     }
 
     return updatedProduct;

--- a/packages/scandipwa/src/util/Product/Product.js
+++ b/packages/scandipwa/src/util/Product/Product.js
@@ -287,13 +287,11 @@ export const getIndexedProduct = (product, itemSku) => {
         bundle_options = []
     } = product;
 
-    const { categories, ...otherProductFields } = product;
-
     const attributes = getIndexedAttributes(initialAttributes || []);
     const reviews = getIndexedReviews(initialReviews);
 
     const updatedProduct = {
-        ...otherProductFields,
+        ...product,
         configurable_options: getIndexedConfigurableOptions(initialConfigurableOptions, attributes),
         variants: itemSku ? getIndexedSingleVariant(initialVariants, itemSku) : getIndexedVariants(initialVariants),
         options: getIndexedCustomOptions(initialOptions || []),
@@ -308,11 +306,6 @@ export const getIndexedProduct = (product, itemSku) => {
 
     if (bundle_options.length) {
         updatedProduct.items = getBundleOptions(bundle_options, items);
-    }
-
-    if (categories.length) {
-        const [{ id }] = categories;
-        updatedProduct.categoryId = id;
     }
 
     return updatedProduct;


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/2934

Reason for missing layered navigation: 
After this PR search was treated as no anchor category https://github.com/scandipwa/scandipwa/issues/1474 => no search navigation was shown

Also fixes problem of category filter missing on search page.
By default parent and child categories are returned from the server and displayed (e.g. `Bags`, `Leather bags` and `Small bags` categories are displayed in `Bags` category). This case has been fixed before and logic to show only subcategories where products belong are shown on category page (`Leather bags` and `Small bags` for bags category). Category info stored in Category reducer was used as source for this data. This logic doesn't  work correctly with search page, as this is not normal category and there is no relevant data in Category reducer. This is why `categories` field was added on PDP => to get info on which categories found products belong to.

And one more thing: same logic cannot be used for 2 cases: for category page you are already inside category and need info on SUBcategories (I didn't change this); for search page you need info on TOP categories, not subcategories (this is how it works in Luma).