### PR TITLE
#3202 - center welcome message firefox

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -132,6 +132,7 @@
                 @include button-visible;
 
                 @include desktop {
+                    height: 24px;
                     margin-inline-start: 35px;
                 }
             }
@@ -184,6 +185,7 @@
 
     &-CompareButtonWrapper {
         margin-inline-start: 35px;
+        height: 24px;
     }
 
     &-LogoWrapper {
@@ -254,6 +256,12 @@
         }
     }
 
+    &-MyAccount {
+        @include desktop {
+            height: 24px;
+        }
+    }
+
     &-News {
         align-items: center;
         display: flex;
@@ -310,7 +318,7 @@
         white-space: nowrap;
         max-width: 200px;
         align-self: center;
-        height: 24px;
+        line-height: 16px;
 
         @include wide-desktop {
             display: block;


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/3202

Center welcome message in FF and Chrome (as it looked different):

FF:
![ScandiPWA 2021-09-15 17-40-28](https://user-images.githubusercontent.com/79456428/133476277-5f9622fd-2f04-4c58-a957-c5566436fb51.png)


Chrome:
![ScandiPWA 2021-09-15 17-39-57](https://user-images.githubusercontent.com/79456428/133476303-10ff6c7e-a00c-4570-b518-f69bd3da4a00.png)
