### PR TITLE
issue-3156 - Styling adjust, check if instore available for cart

### DIFF
--- a/packages/scandipwa/src/component/StoreInPickUp/StoreInPickUp.container.js
+++ b/packages/scandipwa/src/component/StoreInPickUp/StoreInPickUp.container.js
@@ -23,7 +23,7 @@ import StoreInPickUp from './StoreInPickUp.component';
 
 /** @namespace Component/StoreInPickUp/Container/mapDispatchToProps */
 export const mapDispatchToProps = (dispatch) => ({
-    showPopup: (popupId) => dispatch(showPopup(popupId)),
+    showPopup: (payload) => dispatch(showPopup(STORE_IN_PICK_UP_POPUP_ID, payload)),
     hideActiveOverlay: () => dispatch(hideActiveOverlay())
 });
 
@@ -81,7 +81,7 @@ export class StoreInPickUpContainer extends PureComponent {
     handleOpenPopup() {
         const { showPopup } = this.props;
 
-        showPopup(STORE_IN_PICK_UP_POPUP_ID);
+        showPopup({ title: __('Select Store') });
     }
 
     setSelectedStore(store) {

--- a/packages/scandipwa/src/component/StoreInPickUpPopup/StoreInPickUpPopup.component.js
+++ b/packages/scandipwa/src/component/StoreInPickUpPopup/StoreInPickUpPopup.component.js
@@ -44,17 +44,6 @@ export class StoreInPickUpPopupComponent extends PureComponent {
         isLoading: true
     };
 
-    renderHeading() {
-        return (
-            <h3
-              block="StoreInPickUpPopup"
-              elem="Heading"
-            >
-                { __('Select Store') }
-            </h3>
-        );
-    }
-
     renderNoResult() {
         return (
             <span
@@ -159,7 +148,6 @@ export class StoreInPickUpPopupComponent extends PureComponent {
               clickOutside={ false }
               mix={ { block: 'StoreInPickUpPopup' } }
             >
-                { this.renderHeading() }
                 { this.renderContent() }
             </Popup>
         );

--- a/packages/scandipwa/src/component/StoreInPickUpPopup/StoreInPickUpPopup.container.js
+++ b/packages/scandipwa/src/component/StoreInPickUpPopup/StoreInPickUpPopup.container.js
@@ -171,6 +171,7 @@ export class StoreInPickUpContainer extends PureComponent {
 
     handleChangeCountry(countryId) {
         this.setState({ selectedCountryId: countryId });
+        this.handleStoresSearch();
     }
 
     render() {

--- a/packages/scandipwa/src/component/StoreInPickUpPopup/StoreInPickUpPopup.style.scss
+++ b/packages/scandipwa/src/component/StoreInPickUpPopup/StoreInPickUpPopup.style.scss
@@ -13,8 +13,10 @@
     .Popup {
         &-Content {
             @include desktop {
-                width: 50vh;
-                height: 40vh;
+                max-height: 60vh;
+                min-height: 40vh;
+                overflow-y: hidden;
+                width: 70vh;
             }
         }
     }
@@ -30,7 +32,11 @@
         font-size: 14px;
     }
 
-    &-Heading {
-        margin-block-start: 0;
+
+    &-Results {
+        @include desktop {
+            max-height: 300px;
+            overflow-y: auto;
+        }
     }
 }

--- a/packages/scandipwa/src/component/StoreInPickUpStore/StoreInPickUpStore.component.js
+++ b/packages/scandipwa/src/component/StoreInPickUpStore/StoreInPickUpStore.component.js
@@ -73,7 +73,7 @@ export class StoreInPickUpStoreComponent extends PureComponent {
                 <div block="StoreInPickUpStore" elem="StoreData">
                     <h3>{ name }</h3>
                     <p>{ street }</p>
-                    <p>{ `${city}, ${region} ${postcode}` }</p>
+                    <p>{ `${city}, ${region || ''} ${postcode}` }</p>
                     <p>{ country }</p>
                     <a href={ `tel:${phone}` }>{ phone }</a>
                     <p>

--- a/packages/scandipwa/src/component/StoreInPickUpStore/StoreInPickUpStore.style.scss
+++ b/packages/scandipwa/src/component/StoreInPickUpStore/StoreInPickUpStore.style.scss
@@ -29,5 +29,11 @@
                 margin: 0;
             }
         }
+
+        &Actions {
+            @include desktop {
+                margin-inline-end: 15px;
+            }
+        }
     }
 }

--- a/packages/scandipwa/src/query/Cart.query.js
+++ b/packages/scandipwa/src/query/Cart.query.js
@@ -123,6 +123,7 @@ export class CartQuery {
             'shipping_incl_tax',
             'shipping_tax_amount',
             'shipping_method',
+            'is_in_store_pickup_available',
             this._getCartItemsField(),
             this._getAppliedTaxesField()
         ];

--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -389,10 +389,17 @@ export class Checkout extends PureComponent {
             isPickInStoreMethodSelected,
             handleSelectDeliveryMethod,
             checkoutStep,
-            isInStoreActivated
+            isInStoreActivated,
+            totals: {
+                is_in_store_pickup_available: isInStorePickupAvailable
+            }
         } = this.props;
 
         if (checkoutStep !== SHIPPING_STEP || !isInStoreActivated) {
+            return null;
+        }
+
+        if (!isInStorePickupAvailable) {
             return null;
         }
 

--- a/packages/scandipwa/src/route/Checkout/Checkout.style.scss
+++ b/packages/scandipwa/src/route/Checkout/Checkout.style.scss
@@ -148,6 +148,8 @@
     }
 
     &-DeliverySelect {
+        margin-block-start: 15px;
+
         @include mobile {
             margin-block-start: 10px;
         }


### PR DESCRIPTION
**Relaited PR:**
* https://github.com/scandipwa/quote-graphql/pull/84

**In this PR:**
* Check if for cart instore delivery available
* fetch up to 50 stores when nothing is selected (default magento)
* fetch each time user selects country
* If null comes from BE then render nothing
* Add indent between Progress line and Buttons Shipping and Pick in Store
* Adjust inStore popup styling
* Set title for popup