### PR TITLE
#3393 Missing class names for ProductAction & Card

### DIFF
--- a/packages/scandipwa/src/component/Product/Product.component.js
+++ b/packages/scandipwa/src/component/Product/Product.component.js
@@ -68,7 +68,7 @@ export class Product extends PureComponent {
         configFormRef: createRef()
     };
 
-    className = this.constructor.name.slice(0, -1);
+    className = this.constructor.name.slice(0, -1) || 'Product';
 
     //#region PLACEHOLDERS
     renderTextPlaceholder() {

--- a/packages/scandipwa/src/component/Product/Product.component.js
+++ b/packages/scandipwa/src/component/Product/Product.component.js
@@ -259,8 +259,7 @@ export class Product extends PureComponent {
 
         return (
             <AddToCart
-              block={ this.className }
-              elem="AddToCart"
+              mix={ { block: this.className, elem: 'AddToCart' } }
               addToCart={ addToCart }
               isDisabled={ !inStock }
               isIconEnabled={ false }

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.component.js
@@ -52,6 +52,8 @@ export class ProductActions extends Product {
         productName: ''
     };
 
+    className = 'ProductActions';
+
     componentDidUpdate(prevProps) {
         const { product: { id: prevId } } = prevProps;
         const { product: { id }, minQuantity, setQuantity } = this.props;

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -77,6 +77,8 @@ export class ProductCard extends Product {
 
     imageRef = createRef();
 
+    className = 'ProductCard';
+
     registerSharedElement = () => {
         const { registerSharedElement } = this.props;
         registerSharedElement(this.imageRef);


### PR DESCRIPTION
**Original issues:**
* https://github.com/scandipwa/scandipwa/issues/3394
* https://github.com/scandipwa/scandipwa/issues/3393

**Problem:**
* Due to production mode code is minified, thus class name no longer can be accessible.

**In this PR:**
* Added class names for ProductActions and ProductCard
* Added fallback name for Product