### PR TITLE
3392 BUndle product default qty & order

### DIFF
--- a/packages/scandipwa/src/component/GroupedProductList/GroupedProductList.component.js
+++ b/packages/scandipwa/src/component/GroupedProductList/GroupedProductList.component.js
@@ -34,9 +34,11 @@ export class GroupedProductList extends PureComponent {
             setQuantity
         } = this.props;
 
+        const sortedItems = items.sort(({ position }, { position: cmpPosition }) => position > cmpPosition);
+
         return (
             <ul>
-                { items.map(({ product, product: { id } = {}, qty }) => (
+                { sortedItems.map(({ product, product: { id } = {}, qty }) => (
                     <GroupedProductsItem
                       key={ id }
                       product={ product }

--- a/packages/scandipwa/src/component/Product/Product.container.js
+++ b/packages/scandipwa/src/component/Product/Product.container.js
@@ -142,7 +142,10 @@ export class ProductContainer extends PureComponent {
         const { product, product: { type_id: typeId } } = props;
 
         if (typeId === PRODUCT_TYPE.grouped && typeof quantity !== 'object') {
-            return { quantity: {} };
+            const { items } = product;
+            const quantity = items.reduce((o, { qty = 1, product: { id } }) => ({ ...o, [id]: qty }), {});
+
+            return { quantity };
         }
 
         const maxQty = getMaxQuantity(selectedProduct || product);


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3392

**Problem:**
* Missing default qty for bundle
* Incorrect order from graphql

**In this PR:**
* Added default qty for bundle and sorted items before render