### PR TITLE
[3402] Align bundle items to top

### DIFF
--- a/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.style.scss
+++ b/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.style.scss
@@ -11,7 +11,7 @@
 
 .GroupedProductsItem {
     display: grid;
-    align-items: center;
+    align-items: start;
     padding-inline-start: 0;
     margin-block-end: 12px;
     grid-template-columns: 72px 3fr 1fr;


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3402

**Problem:**
* Grid items are aligned to center

**In this PR:**
* Aligned items to start