### PR TITLE
#3372 - fix 2 loaders on swipe to delete

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.container.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.container.js
@@ -176,6 +176,11 @@ export class CartItemContainer extends PureComponent {
      * @return {void}
      */
     handleRemoveItem(e) {
+        this.handleRemoveItemOnSwipe(e);
+        this.notifyAboutLoadingStateChange(true);
+    }
+
+    handleRemoveItemOnSwipe = (e) => {
         if (e) {
             e.preventDefault();
         }
@@ -183,8 +188,7 @@ export class CartItemContainer extends PureComponent {
         this.setState({ isLoading: true }, () => {
             this.hideLoaderAfterPromise(this.removeProductAndUpdateCrossSell());
         });
-        this.notifyAboutLoadingStateChange(true);
-    }
+    };
 
     getIsMobileLayout() {
         // "isMobileLayout" check is required to render mobile content in some additional cases
@@ -390,7 +394,7 @@ export class CartItemContainer extends PureComponent {
         return (
             <SwipeToDelete
               renderRightSideContent={ this.renderRightSideContent }
-              onAheadOfDragItemRemoveThreshold={ this.containerFunctions.handleRemoveItem }
+              onAheadOfDragItemRemoveThreshold={ this.handleRemoveItemOnSwipe }
               isLoading={ isLoading }
             >
                 <CartItem


### PR DESCRIPTION
**Issue:** https://github.com/scandipwa/scandipwa/issues/3372, issue 7 (a separate PR as not related to iOS 15)

**Problem:** One loader is from SwipetoDelete, another one is from CartPage

**Solution:** Don't set loading state for CartPage if delete on Swipe is active
