### PR TITLE
#3364 - fix no message after compare list clear

### DIFF
--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
@@ -177,10 +177,13 @@ export class CategoryPage extends PureComponent {
 
     renderFilterButton() {
         const {
-            isContentFiltered, totalPages, category: { is_anchor }
+            isContentFiltered,
+            totalPages,
+            category: { is_anchor },
+            isSearchPage
         } = this.props;
 
-        if ((!isContentFiltered && totalPages === 0) || !is_anchor) {
+        if ((!isContentFiltered && totalPages === 0) || (!is_anchor && !isSearchPage)) {
             return null;
         }
 


### PR DESCRIPTION
**Issue:**
* https://github.com/scandipwa/scandipwa/issues/2934

**Problem:** isCategoryAnchor condition is not enough to make decision whether to show filter or not

**Solution:** show filter button category is anchor or it is search page