### PR TITLE
[3421] Hide price on out of stock for conifurable

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -113,16 +113,23 @@ export class ProductCard extends Product {
             return this.renderTextPlaceholder();
         }
 
-        // If bundle is out of stock, show out of stock msg
-        if (!inStock && typeId === PRODUCT_TYPE.bundle) {
-            return (
-                <div
-                  block={ this.className }
-                  elem="PriceWrapper"
-                >
-                    { __('Out of stock') }
-                </div>
-            );
+        if (!inStock) {
+            // If configurable, do not render price
+            if (typeId === PRODUCT_TYPE.configurable) {
+                return null;
+            }
+
+            // If bundle is out of stock, show out of stock msg
+            if (typeId === PRODUCT_TYPE.bundle) {
+                return (
+                    <div
+                      block={ this.className }
+                      elem="PriceWrapper"
+                    >
+                        { __('Out of stock') }
+                    </div>
+                );
+            }
         }
 
         // If product is not a variant.


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3421

**Problem:**
* Renders empty ProductPrice instead of null when configurable product is out of stock