### PR TITLE
[3392] Default grouped qty

### DIFF
--- a/packages/scandipwa/src/component/Product/Product.container.js
+++ b/packages/scandipwa/src/component/Product/Product.container.js
@@ -138,8 +138,9 @@ export class ProductContainer extends PureComponent {
     }
 
     static getDerivedStateFromProps(props, state) {
+        const { quantityState } = state;
         const quantity = ProductContainer.getDefaultQuantity(props, state);
-        if (quantity) {
+        if (quantity && typeof quantityState !== 'object') {
             return { quantity };
         }
 
@@ -151,7 +152,7 @@ export class ProductContainer extends PureComponent {
         const { quantity, selectedProduct } = state;
         const { product, product: { type_id: typeId } } = props;
 
-        if (typeId === PRODUCT_TYPE.grouped && typeof quantity !== 'object') {
+        if (typeId === PRODUCT_TYPE.grouped) {
             const { items = [] } = product;
             return items.reduce((o, { qty = 1, product: { id } }) => ({ ...o, [id]: qty }), {});
         }
@@ -191,8 +192,7 @@ export class ProductContainer extends PureComponent {
         if (product !== prevProduct) {
             const quantity = ProductContainer.getDefaultQuantity(this.props, this.state);
             if (quantity) {
-                // eslint-disable-next-line react/no-did-update-set-state
-                this.setState({ quantity });
+                this.setQuantity(quantity);
             }
         }
     }


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3392

**Problem:**
* `typeof quantity !== 'object'` was used inside function that should return default quantity... this is incorrect, as it should return qty based on type, ignoring other values, thus if product wasn't loaded the `setQuantity` will set  `quantity` as `{}` on first time, and then function will return `null`, thus not updating quantity. 