### PR TITLE
#3411 - fix 404 after 404

### DIFF
--- a/packages/scandipwa/src/route/NoMatch/NoMatch.container.js
+++ b/packages/scandipwa/src/route/NoMatch/NoMatch.container.js
@@ -60,6 +60,12 @@ export class NoMatchContainer extends PureComponent {
         this.updateNoMatch();
     }
 
+    componentWillUnmount() {
+        const { updateNoMatch } = this.props;
+
+        updateNoMatch(false);
+    }
+
     containerProps() {
         const { updateBreadcrumbs } = this.props;
 


### PR DESCRIPTION
**Issue:**
- Fixes https://github.com/scandipwa/scandipwa/issues/3411

**Problem:**
- `NoMatchReducer` still contains {noMatch: false} after user leaves 404 page, which may affect consequent page visits.

**Solution:**
-  reset `NoMatchReducer` state when leaving 404 page