### PR TITLE
3430 - chrome gap below bottom bar

### DIFF
--- a/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.style.scss
+++ b/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.style.scss
@@ -32,11 +32,13 @@
         transition: transform 200ms ease-in-out;
         transform: translateY(100%);
         will-change: transform;
+        overflow-y: hidden;
 
         &-Wrapper {
             display: grid;
             grid-template-rows: min-content auto min-content;
             height: 100%;
+            overflow-y: auto;
         }
     }
 


### PR DESCRIPTION
**Issue:**
- https://github.com/scandipwa/scandipwa/issues/3430

**Problem:**
- the whole overlay is scrollable. Applying padding equal to `--safe-inset-area-bottom` doesn't have effect, as bottom of overlay is hidden below bottom of the screen.

**Solution:** 
- fix position of main overlay container on screen by forbidding scroll, apply padding equal to `--safe-inset-area-bottom`, make only inner div scrollable => as a result the very bottom area is never covered with content.

