### PR TITLE
[3451] Grouped item image height is 100%

### DIFF
--- a/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.style.scss
+++ b/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.style.scss
@@ -57,6 +57,8 @@
     }
 
     &-Image {
+        height: auto;
+
         &::after {
             content: '';
             position: absolute;


### PR DESCRIPTION
**Original issue:**
* Fixes https://github.com/scandipwa/scandipwa/issues/3451

**Problem:**
* Height was set 100%