### PR TITLE
#3388 - scroll on search

### DIFF
--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -21,6 +21,7 @@ import LockIcon from 'Component/LockIcon';
 import Overlay from 'Component/Overlay';
 import { OVERLAY_PLACEHOLDER } from 'Component/PopupSuspense/PopupSuspense.config';
 import { CartDisplayType, TotalsType } from 'Type/MiniCart';
+import { scrollToTop } from 'Util/Browser';
 import { formatPrice } from 'Util/Price';
 
 import './CartOverlay.style';
@@ -38,7 +39,6 @@ export class CartOverlay extends PureComponent {
         cartTotalSubPrice: PropTypes.number.isRequired,
         cartDisplaySettings: CartDisplayType.isRequired,
         isMobile: PropTypes.bool.isRequired,
-        scrollToTop: PropTypes.func.isRequired,
         onCartItemLoading: PropTypes.func,
         isCartItemLoading: PropTypes.bool
     };
@@ -206,8 +206,6 @@ export class CartOverlay extends PureComponent {
     }
 
     renderActions() {
-        const { scrollToTop } = this.props;
-
         return (
             <div block="CartOverlay" elem="Actions">
                 <Link

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.container.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.container.js
@@ -22,6 +22,7 @@ import { showNotification } from 'Store/Notification/Notification.action';
 import { hideActiveOverlay, toggleOverlayByKey } from 'Store/Overlay/Overlay.action';
 import { CartDisplayType, TotalsType } from 'Type/MiniCart';
 import { isSignedIn } from 'Util/Auth';
+import { scrollToTop } from 'Util/Browser';
 import {
     getCartShippingPrice,
     getCartShippingSubPrice,
@@ -97,7 +98,6 @@ export class CartOverlayContainer extends PureComponent {
     containerFunctions = {
         changeHeaderState: this.changeHeaderState.bind(this),
         handleCheckoutClick: this.handleCheckoutClick.bind(this),
-        scrollToTop: this.scrollToTop.bind(this),
         onCartItemLoading: this.onCartItemLoading.bind(this)
     };
 
@@ -138,10 +138,6 @@ export class CartOverlayContainer extends PureComponent {
         items.some(({ product }) => !getProductInStock(product))
     );
 
-    scrollToTop() {
-        window.scrollTo({ top: 0 });
-    }
-
     hasOutOfStockProductsInCartItems = (items) => (
         items.some(({ product }) => !getProductInStock(product))
     );
@@ -172,7 +168,7 @@ export class CartOverlayContainer extends PureComponent {
         if (guest_checkout || isSignedIn()) {
             hideActiveOverlay();
             history.push({ pathname: appendWithStoreCode(CHECKOUT_URL) });
-            this.scrollToTop();
+            scrollToTop();
 
             return;
         }

--- a/packages/scandipwa/src/component/MenuItem/MenuItem.container.js
+++ b/packages/scandipwa/src/component/MenuItem/MenuItem.container.js
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
+import { scrollToTop } from 'Util/Browser';
 import history from 'Util/History';
 
 import MenuItem from './MenuItem.component';
@@ -74,7 +75,7 @@ export class MenuItemContainer extends PureComponent {
 
     onItemClick() {
         const { closeMenu, activeMenuItemsStack } = this.props;
-        window.scrollTo({ top: 0 });
+        scrollToTop();
         closeMenu();
 
         // keep the stack here, so later we can deconstruct menu out of it

--- a/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.container.js
+++ b/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.container.js
@@ -20,6 +20,7 @@ import { changeNavigationState, goToPreviousNavigationState } from 'Store/Naviga
 import { BOTTOM_NAVIGATION_TYPE, TOP_NAVIGATION_TYPE } from 'Store/Navigation/Navigation.reducer';
 import { hideActiveOverlay, toggleOverlayByKey } from 'Store/Overlay/Overlay.action';
 import { isSignedIn } from 'Util/Auth';
+import { scrollToTop } from 'Util/Browser';
 import browserHistory from 'Util/History';
 import { debounce } from 'Util/Request';
 import { appendWithStoreCode } from 'Util/Url';
@@ -186,7 +187,7 @@ export class NavigationTabsContainer extends NavigationAbstractContainer {
         const { pathname } = location;
 
         if (pathname !== appendWithStoreCode(`/${ CART }`)) {
-            window.scrollTo({ top: 0 });
+            scrollToTop();
             browserHistory.push(appendWithStoreCode(`/${ CART }`));
         }
     }
@@ -254,14 +255,8 @@ export class NavigationTabsContainer extends NavigationAbstractContainer {
         browserHistory.push(appendWithStoreCode('/'));
         hideActiveOverlay();
 
-        if (
-            pathname === appendWithStoreCode('/')
-            || pathname === '/'
-        ) {
-            window.scrollTo({
-                top: 0,
-                behavior: 'smooth'
-            });
+        if (pathname === appendWithStoreCode('/') || pathname === '/') {
+            scrollToTop({ behavior: 'smooth' });
         }
     }
 

--- a/packages/scandipwa/src/component/ProductList/ProductList.component.js
+++ b/packages/scandipwa/src/component/ProductList/ProductList.component.js
@@ -17,6 +17,7 @@ import ProductListPage from 'Component/ProductListPage';
 import { MixType } from 'Type/Common';
 import { DeviceType } from 'Type/Device';
 import { FilterType, PagesType } from 'Type/ProductList';
+import { scrollToTop } from 'Util/Browser';
 
 import { observerThreshold } from './ProductList.config';
 
@@ -78,7 +79,7 @@ export class ProductList extends PureComponent {
 
         // Scroll up on page change, ignore widgets
         if (prevCurrentPage !== currentPage && !isWidget && !device.isMobile) {
-            window.scrollTo({ top: 0, behavior: 'smooth' });
+            scrollToTop({ behavior: 'smooth' });
         }
 
         const { isInfiniteLoaderEnabled } = this.props;

--- a/packages/scandipwa/src/component/ProductList/ProductList.container.js
+++ b/packages/scandipwa/src/component/ProductList/ProductList.container.js
@@ -19,6 +19,7 @@ import { HistoryType, MixType } from 'Type/Common';
 import { DeviceType } from 'Type/Device';
 import { FilterInputType, PagesType } from 'Type/ProductList';
 import { LocationType } from 'Type/Router';
+import { scrollToTop } from 'Util/Browser';
 import { getQueryParam, setQueryParams } from 'Util/Url';
 
 import ProductList from './ProductList.component';
@@ -105,10 +106,20 @@ export class ProductListContainer extends PureComponent {
     }
 
     componentDidUpdate(prevProps) {
-        const { sort, search, filter } = this.props;
-        const { sort: prevSort, search: prevSearch, filter: prevFilter } = prevProps;
+        const {
+            sort,
+            search,
+            filter,
+            pages
+        } = this.props;
 
-        const { pages } = this.props;
+        const {
+            sort: prevSort,
+            search: prevSearch,
+            filter: prevFilter,
+            pages: prevPages
+        } = prevProps;
+
         const { pagesCount } = this.state;
         const pagesLength = Object.keys(pages).length;
 
@@ -122,6 +133,10 @@ export class ProductListContainer extends PureComponent {
             || JSON.stringify(filter) !== JSON.stringify(prevFilter)
         ) {
             this.requestPage(this._getPageFromUrl());
+        }
+
+        if (pages !== prevPages) {
+            scrollToTop({ behavior: 'smooth' });
         }
     }
 

--- a/packages/scandipwa/src/route/CartPage/CartPage.container.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.container.js
@@ -26,6 +26,7 @@ import { HistoryType } from 'Type/Common';
 import { DeviceType } from 'Type/Device';
 import { TotalsType } from 'Type/MiniCart';
 import { isSignedIn } from 'Util/Auth';
+import { scrollToTop } from 'Util/Browser';
 import {
     getCartShippingPrice,
     getCartShippingSubPrice,
@@ -184,7 +185,7 @@ export class CartPageContainer extends PureComponent {
             history.push({
                 pathname: appendWithStoreCode(CHECKOUT_URL)
             });
-            window.scrollTo({ top: 0 });
+            scrollToTop();
 
             return;
         }
@@ -193,7 +194,7 @@ export class CartPageContainer extends PureComponent {
             history.push({
                 pathname: appendWithStoreCode(CHECKOUT_URL)
             });
-            window.scrollTo({ top: 0 });
+            scrollToTop();
 
             return;
         }

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.js
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.js
@@ -27,6 +27,7 @@ import {
 } from 'Store/ProductListInfo/ProductListInfo.action';
 import { CategoryTreeType } from 'Type/Category';
 import { HistoryType, LocationType, MatchType } from 'Type/Common';
+import { scrollToTop } from 'Util/Browser';
 import BrowserDatabase from 'Util/BrowserDatabase';
 import { getFiltersCount } from 'Util/Category';
 import { withReducers } from 'Util/DynamicReducer';
@@ -227,7 +228,7 @@ export class CategoryPageContainer extends PureComponent {
             }
         } = this.props;
 
-        window.scrollTo(0, 0);
+        scrollToTop();
 
         /**
          * Ensure transition PLP => homepage => PLP always having proper meta

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
@@ -20,6 +20,7 @@ import { changeNavigationState } from 'Store/Navigation/Navigation.action';
 import { TOP_NAVIGATION_TYPE } from 'Store/Navigation/Navigation.reducer';
 import { setBigOfflineNotice } from 'Store/Offline/Offline.action';
 import { LocationType, MatchType } from 'Type/Common';
+import { scrollToTop } from 'Util/Browser';
 import history from 'Util/History';
 import { debounce } from 'Util/Request';
 import DataContainer from 'Util/Request/DataContainer';
@@ -115,7 +116,7 @@ export class CmsPageContainer extends DataContainer {
             isOnlyPlaceholder
         } = this.props;
 
-        window.scrollTo(0, 0);
+        scrollToTop();
 
         const { isLoading } = this.state;
 

--- a/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
@@ -27,6 +27,7 @@ import {
 } from 'Type/Account';
 import { HistoryType, LocationType, MatchType } from 'Type/Common';
 import { isSignedIn } from 'Util/Auth';
+import { scrollToTop } from 'Util/Browser';
 import { withReducers } from 'Util/DynamicReducer';
 import history from 'Util/History';
 import { appendWithStoreCode, replace } from 'Util/Url';
@@ -194,8 +195,7 @@ export class MyAccountContainer extends PureComponent {
         this.redirectIfNotSignedIn();
         this.onSignIn();
         this.updateBreadcrumbs();
-
-        window.scrollTo({ top: 0 });
+        scrollToTop();
     }
 
     static getDerivedStateFromProps(props, state) {
@@ -226,7 +226,7 @@ export class MyAccountContainer extends PureComponent {
             this.updateBreadcrumbs();
             this.changeHeaderState();
 
-            window.scrollTo({ top: 0 });
+            scrollToTop();
         }
 
         if (Object.keys(wishlistItems).length !== Object.keys(prevWishlistItems).length) {

--- a/packages/scandipwa/src/route/NoMatch/NoMatch.component.js
+++ b/packages/scandipwa/src/route/NoMatch/NoMatch.component.js
@@ -14,6 +14,7 @@ import { PureComponent } from 'react';
 
 import ContentWrapper from 'Component/ContentWrapper';
 import Link from 'Component/Link';
+import { scrollToTop } from 'Util/Browser';
 
 import './NoMatch.style';
 
@@ -27,7 +28,7 @@ export class NoMatch extends PureComponent {
     componentDidMount() {
         this.updateBreadcrumbs();
         this.cleanUpTransition();
-        window.scrollTo({ top: 0 });
+        scrollToTop();
     }
 
     cleanUpTransition() {

--- a/packages/scandipwa/src/route/NoMatchHandler/NoMatchHandler.component.js
+++ b/packages/scandipwa/src/route/NoMatchHandler/NoMatchHandler.component.js
@@ -15,6 +15,7 @@ import { PureComponent } from 'react';
 import NoMatch from 'Route/NoMatch';
 import { ChildrenType } from 'Type/Common';
 import { LocationType } from 'Type/Router';
+import { scrollToTop } from 'Util/Browser';
 
 /** @namespace Route/NoMatchHandler/Component */
 export class NoMatchHandler extends PureComponent {
@@ -26,7 +27,7 @@ export class NoMatchHandler extends PureComponent {
     };
 
     componentDidMount() {
-        window.scrollTo(0, 0);
+        scrollToTop();
     }
 
     componentDidUpdate(prevProps) {
@@ -34,15 +35,7 @@ export class NoMatchHandler extends PureComponent {
         const { location: { pathname } } = prevProps;
 
         if (newPathname !== pathname) {
-            // 'window.scrollTo' is used to set correct scroll position for newly opened page. Previously we passed (0, 0)
-            // It caused scroll issue in Firefox, when navigating back from ProductPage to CategoryPage
-            // Not calling 'window.scrollTo' did not help, but passing dummy value for 'y' seems to fix it
-            if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-                window.scrollTo(0, 1);
-            } else {
-                window.scrollTo(0, 0);
-            }
-
+            scrollToTop();
             this.onRouteChanged();
         }
     }

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -24,6 +24,7 @@ import ProductReducer from 'Store/Product/Product.reducer';
 import { addRecentlyViewedProduct } from 'Store/RecentlyViewedProducts/RecentlyViewedProducts.action';
 import { HistoryType, LocationType, MatchType } from 'Type/Common';
 import { ProductType } from 'Type/ProductList';
+import { scrollToTop } from 'Util/Browser';
 import { withReducers } from 'Util/DynamicReducer';
 import { getIsConfigurableParameterSelected } from 'Util/Product';
 import { debounce } from 'Util/Request';
@@ -213,7 +214,7 @@ export class ProductPageContainer extends PureComponent {
         /**
          * Scroll page top in order to display it from the start
          */
-        this.scrollTop();
+        scrollToTop();
     }
 
     componentDidUpdate(prevProps) {
@@ -320,10 +321,6 @@ export class ProductPageContainer extends PureComponent {
         } = product;
 
         addRecentlyViewedProduct(productPreview, store);
-    }
-
-    scrollTop() {
-        window.scrollTo(0, 0);
     }
 
     setOfflineNoticeSize = () => {

--- a/packages/scandipwa/src/util/Browser/Browser.js
+++ b/packages/scandipwa/src/util/Browser/Browser.js
@@ -23,3 +23,6 @@ export const toggleScroll = (state) => document.documentElement.classList.toggle
 
 /** @namespace Util/Browser/isScrollDisabled */
 export const isScrollDisabled = () => document.documentElement.classList.contains('scrollDisabled');
+
+/** @namespace Util/Browser/scrollToTop */
+export const scrollToTop = (options = {}) => window.scrollTo({ ...options, top: 0 });


### PR DESCRIPTION
* Fixes https://github.com/scandipwa/scandipwa/issues/3388
* Fixes https://github.com/scandipwa/scandipwa/issues/2641
* Moved `scrolledToTop` to a separate fucntion.

**Problem:**
* No scroll action on search

**Solution:**
* Add scroll to top action when list of products changes. It covers both search case and applying/resetting filters in Layered navigation.