### PR TITLE
#3367 - pdp compare icon status

### DIFF
--- a/packages/scandipwa/src/component/Router/Router.container.js
+++ b/packages/scandipwa/src/component/Router/Router.container.js
@@ -76,6 +76,9 @@ export const mapDispatchToProps = (dispatch) => ({
         CartDispatcher.then(
             ({ default: dispatcher }) => dispatcher.updateInitialCartData(dispatch)
         );
+        ProductCompareDispatcher.then(
+            ({ default: dispatcher }) => dispatcher.updateInitialProductCompareData(dispatch)
+        );
     }
 });
 


### PR DESCRIPTION
* Fixes https://github.com/scandipwa/scandipwa/issues/3367 

**Problem:** 
No request to the server retrieving info on what products are in compare list on PDP load

**Solution:**
Added such a request