### PR TITLE
See #3475 Fixed footer rerender on props change

### DIFF
--- a/packages/scandipwa/src/component/Footer/Footer.component.js
+++ b/packages/scandipwa/src/component/Footer/Footer.component.js
@@ -52,17 +52,24 @@ export class Footer extends Component {
             device: {
                 isMobile
             },
-            isVisibleOnMobile
+            isVisibleOnMobile,
+            copyright,
+            newsletterActive
         } = this.props;
 
         const {
             device: {
                 isMobile: nextIsMobile
             },
-            isVisibleOnMobile: nextIsVisibleOnMobile
+            isVisibleOnMobile: nextIsVisibleOnMobile,
+            copyright: nextCopyright,
+            newsletterActive: nextNewsletterActive
         } = nextProps;
 
-        return isMobile !== nextIsMobile || isVisibleOnMobile !== nextIsVisibleOnMobile;
+        return isMobile !== nextIsMobile
+            || isVisibleOnMobile !== nextIsVisibleOnMobile
+            || copyright !== nextCopyright
+            || newsletterActive !== nextNewsletterActive;
     }
 
     renderColumnItemContent(src, title) {
@@ -118,9 +125,13 @@ export class Footer extends Component {
 
         const { [columnActiveKey]: isColumnActive } = this.props;
 
+        console.log('COLUMN', title.toString(), columnActiveKey, this.props);
+
         if (columnActiveKey && !isColumnActive === true) {
             return null;
         }
+
+        console.log('RENDERED', title.toString());
 
         return (
             <div block="Footer" elem="Column" mods={ mods } key={ i }>

--- a/packages/scandipwa/src/component/Footer/Footer.component.js
+++ b/packages/scandipwa/src/component/Footer/Footer.component.js
@@ -125,13 +125,9 @@ export class Footer extends Component {
 
         const { [columnActiveKey]: isColumnActive } = this.props;
 
-        console.log('COLUMN', title.toString(), columnActiveKey, this.props);
-
         if (columnActiveKey && !isColumnActive === true) {
             return null;
         }
-
-        console.log('RENDERED', title.toString());
 
         return (
             <div block="Footer" elem="Column" mods={ mods } key={ i }>


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3475 

**Problem:**
* Newsletter block visibility can be configured by `newsletter_general_active` option in the `ConfigReducer`. By default it is undefined until the config is fetched from the backend and placed to the localstorage. Then cached config is reused as fallback on each page reload. This is why Newsletter block doesn't render on first page visit.
* Footer component implemented own `shouldComponentUpdate` method, but didn't check properties that are comming from the Redux. This is why Newsletter block didn't appear once the config was fetched from the backend.

**In this PR:**
* Added checks to `shouldComponentUpdate` in order to rerender footer contents once config options are available.
