### PR TITLE
#3319 - close button wishlist no action

### DIFF
--- a/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.style.scss
+++ b/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.style.scss
@@ -19,6 +19,7 @@
 
     transform: translateX(var(--translateX));
     transition: transform var(--animation-speed) ease-out;
+    z-index: 5;
 
     [dir="rtl"] & {
         transform: translateX(calc(-1 * var(--translateX)));


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3319

**Problem:**
* swipe to delete padding was on top of main card content

**In this PR:**
* moved card content to top
