### PR TITLE
[3444] MyAccount address fixes

### DIFF
--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
@@ -43,7 +43,7 @@ export class MyAccountAddressForm extends FieldForm {
     state = {
         countryId: this.getCountry()?.value || 'US',
         availableRegions: this.getAvailableRegions() || [],
-        isStateRequired: this.getCountry()?.is_state_required || true
+        isStateRequired: !!this.getCountry()?.is_state_required
     };
 
     //#region GETTERS
@@ -89,7 +89,6 @@ export class MyAccountAddressForm extends FieldForm {
     getCountry(countryId = null) {
         const { countries, defaultCountry, address: { country_id: countryIdAddress } = {} } = this.props;
         const countryIdFixed = countryId || countryIdAddress || defaultCountry;
-
         return countries.find(({ value }) => value === countryIdFixed);
     }
 
@@ -138,9 +137,17 @@ export class MyAccountAddressForm extends FieldForm {
         onSave(trimCustomerAddress(newAddress));
     };
 
-    onCountryChange = (field) => {
+    onCountryChange = (field, e) => {
+        // Handles auto fill
+        const fieldValue = typeof field === 'object' ? e.value : field;
+
         const { countries } = this.props;
-        const country = countries.find(({ value }) => value === field);
+        const country = countries.find(({ value }) => value === fieldValue);
+
+        if (!country) {
+            return;
+        }
+
         const {
             available_regions: availableRegions = [],
             is_state_required: isStateRequired = true,

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.form.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.form.js
@@ -93,6 +93,7 @@ export const getRegionFields = (props) => {
                     defaultValue: region,
                     placeholder: __('Your state / province')
                 },
+                addRequiredTag: isStateRequired,
                 validateOn: isStateRequired ? ['onChange'] : [],
                 validationRule: {
                     isRequired: isStateRequired
@@ -111,7 +112,7 @@ export const getRegionFields = (props) => {
                 selectPlaceholder: __('Select region...')
             },
             options: availableRegions.map(({ id, name }) => ({ id, label: name, value: id })),
-            addRequiredTag: true,
+            addRequiredTag: isStateRequired,
             validateOn: isStateRequired ? ['onChange'] : [],
             validationRule: {
                 isRequired: isStateRequired

--- a/packages/scandipwa/src/component/PureForm/FieldSelect/FieldSelect.container.js
+++ b/packages/scandipwa/src/component/PureForm/FieldSelect/FieldSelect.container.js
@@ -108,9 +108,9 @@ export class FieldSelectContainer extends PureComponent {
     }
 
     handleSelectExpandedExpand() {
-        const { isSelectExpanded } = this.state;
+        const { isExpanded } = this.state;
 
-        if (isSelectExpanded) {
+        if (isExpanded) {
             this.handleSelectExpand();
         }
     }

--- a/packages/scandipwa/src/util/Store/Transform.js
+++ b/packages/scandipwa/src/util/Store/Transform.js
@@ -22,7 +22,7 @@ export const transformCountriesToOptions = (countries) => (
             name: id,
             ...country
         };
-    })
+    }).sort(({ label }, { label: labelCompare }) => label > labelCompare)
 );
 
 export default transformCountriesToOptions;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3444

**Problem:**
* State is always required when editing address, due to `|| true` suffix for default state value... meaning that it will always be true on load
* Misssing `isStateRequired` for field configuration
* Countries where sorted by code instead of name
* Incorrect attribute used when hiding select on blur event.
* AutoFill passes different data to event

**In this PR:**
* Removed suffix from state check
* Passed isStateRequired to form config
* Added sort for countries by their label
* Fixed incorrect attribute usage
* Added fallback value for autofill & added extra check for `country`.
