### PR TITLE
3436 Product opens 404 if prev page had error

### DIFF
--- a/packages/scandipwa/src/component/Link/Link.container.js
+++ b/packages/scandipwa/src/component/Link/Link.container.js
@@ -19,23 +19,42 @@ import { appendWithStoreCode } from 'Util/Url';
 
 import Link from './Link.component';
 
+export const NoMatchDispatcher = import(
+    /* webpackMode: "lazy", webpackChunkName: "dispatchers" */
+    'Store/NoMatch/NoMatch.dispatcher'
+);
+
 /** @namespace Component/Link/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     baseLinkUrl: state.ConfigReducer.base_link_url || ''
 });
 
 /** @namespace Component/Link/Container/mapDispatchToProps */
-export const mapDispatchToProps = () => ({});
+export const mapDispatchToProps = (dispatch) => ({
+    updateNoMatch: (options) => NoMatchDispatcher.then(
+        ({ default: dispatcher }) => dispatcher.updateNoMatch(dispatch, options)
+    )
+});
 
 /** @namespace Component/Link/Container */
 export class LinkContainer extends PureComponent {
     static propTypes = {
         baseLinkUrl: PropTypes.string.isRequired,
+        updateNoMatch: PropTypes.func.isRequired,
+        onClick: PropTypes.func,
         to: PropTypes.oneOfType([
             PropTypes.string,
             PropTypes.object
         ]).isRequired
     };
+
+    static defaultProps = {
+        onClick: () => {}
+    };
+
+    containerFunctions = {
+        onClick: this.onClick.bind(this)
+    }
 
     containerProps = () => {
         const {
@@ -82,10 +101,21 @@ export class LinkContainer extends PureComponent {
         };
     }
 
+    // Resets no match state on redirect
+    onClick(e) {
+        const { updateNoMatch, onClick } = this.props;
+        updateNoMatch(false);
+
+        if (onClick) {
+            onClick(e);
+        }
+    }
+
     render() {
         return (
             <Link
               { ...this.containerProps() }
+              { ...this.containerFunctions }
             />
         );
     }

--- a/packages/scandipwa/src/component/Link/Link.container.js
+++ b/packages/scandipwa/src/component/Link/Link.container.js
@@ -54,7 +54,7 @@ export class LinkContainer extends PureComponent {
 
     containerFunctions = {
         onClick: this.onClick.bind(this)
-    }
+    };
 
     containerProps = () => {
         const {

--- a/packages/scandipwa/src/store/UrlRewrites/UrlRewrites.dispatcher.js
+++ b/packages/scandipwa/src/store/UrlRewrites/UrlRewrites.dispatcher.js
@@ -10,8 +10,8 @@
  */
 
 import UrlRewritesQuery from 'Query/UrlRewrites.query';
-import { showNotification } from 'Store/Notification/Notification.action';
 import { updateNoMatch } from 'Store/NoMatch/NoMatch.action';
+import { showNotification } from 'Store/Notification/Notification.action';
 import { setIsUrlRewritesLoading, updateUrlRewrite } from 'Store/UrlRewrites/UrlRewrites.action';
 import { QueryDispatcher } from 'Util/Request';
 

--- a/packages/scandipwa/src/store/UrlRewrites/UrlRewrites.dispatcher.js
+++ b/packages/scandipwa/src/store/UrlRewrites/UrlRewrites.dispatcher.js
@@ -11,6 +11,7 @@
 
 import UrlRewritesQuery from 'Query/UrlRewrites.query';
 import { showNotification } from 'Store/Notification/Notification.action';
+import { updateNoMatch } from 'Store/NoMatch/NoMatch.action';
 import { setIsUrlRewritesLoading, updateUrlRewrite } from 'Store/UrlRewrites/UrlRewrites.action';
 import { QueryDispatcher } from 'Util/Request';
 
@@ -27,11 +28,13 @@ export class UrlRewritesDispatcher extends QueryDispatcher {
 
     onSuccess({ urlResolver }, dispatch, { urlParam }) {
         dispatch(updateUrlRewrite(urlResolver || { notFound: true }, urlParam));
+        dispatch(updateNoMatch(!urlResolver));
     }
 
     onError(error, dispatch, { urlParam }) {
         dispatch(setIsUrlRewritesLoading(false));
         dispatch(updateUrlRewrite({ notFound: true }, urlParam));
+        dispatch(updateNoMatch(true));
         dispatch(showNotification('error', __('Error fetching URL-rewrites!'), error));
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3436

**Problem:**
* NoMatch, that is uesd for outputing 404, isn't restored when redirecting to different page, thus if request returns error and sets no match value to true, then by default next opened page will open 404.

**In this PR:**
* Added reset for no match when redirecting to different page
