### PR TITLE
#3498 - add to cart PLP

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.container.js
@@ -69,9 +69,7 @@ export class ProductCardContainer extends ProductContainer {
 
         children: ChildrenType,
         mix: MixType,
-        layout: LayoutType,
-
-        cartId: PropTypes.string
+        layout: LayoutType
     };
 
     static defaultProps = {
@@ -83,8 +81,7 @@ export class ProductCardContainer extends ProductContainer {
         isLoading: false,
         children: null,
         mix: {},
-        layout: GRID_LAYOUT,
-        cartId: ''
+        layout: GRID_LAYOUT
     };
 
     containerFunctions = {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3498

**Problem:**
* Promise is rejected due to `cartId` equal to empty string. `CartId` equals empty string, as it is props default value.

**In this PR:**
* Remove default props value. `CartId` is resolved inside dispatcher logic, if not passed when calling add to cart method.
