### PR TITLE
3447/add configurable to cart

### DIFF
--- a/packages/scandipwa/src/component/Product/Product.container.js
+++ b/packages/scandipwa/src/component/Product/Product.container.js
@@ -321,8 +321,6 @@ export class ProductContainer extends PureComponent {
         const { addProductToCart, cartId } = this.props;
         const products = this.getMagentoProduct();
 
-        console.debug(products);
-
         await addProductToCart({ products, cartId });
     }
 

--- a/packages/scandipwa/src/component/Product/Product.container.js
+++ b/packages/scandipwa/src/component/Product/Product.container.js
@@ -29,7 +29,7 @@ import {
     getPrice,
     getProductInStock
 } from 'Util/Product/Extract';
-import { magentoProductTransform } from 'Util/Product/Transform';
+import { magentoProductTransform, transformParameters } from 'Util/Product/Transform';
 import { validateGroup } from 'Util/Validator';
 
 export const CartDispatcher = import(
@@ -321,6 +321,8 @@ export class ProductContainer extends PureComponent {
         const { addProductToCart, cartId } = this.props;
         const products = this.getMagentoProduct();
 
+        console.debug(products);
+
         await addProductToCart({ products, cartId });
     }
 
@@ -381,22 +383,23 @@ export class ProductContainer extends PureComponent {
      * @returns {*[]}
      */
     getMagentoProduct() {
-        const { product } = this.props;
         const {
             quantity,
             enteredOptions,
             selectedOptions,
-            downloadableLinks
+            downloadableLinks,
+            parameters
         } = this.state;
 
-        const activeProduct = this.getActiveProduct();
-        const parentProduct = activeProduct === product ? null : product;
+        const { product, product: { attributes } } = this.props;
+
+        const configurableOptions = transformParameters(parameters, attributes);
+
         return magentoProductTransform(
-            activeProduct,
+            product,
             quantity,
-            parentProduct,
             enteredOptions,
-            [...selectedOptions, ...downloadableLinks],
+            [...selectedOptions, ...downloadableLinks, ...configurableOptions],
         );
     }
 

--- a/packages/scandipwa/src/component/Product/Product.container.js
+++ b/packages/scandipwa/src/component/Product/Product.container.js
@@ -399,7 +399,7 @@ export class ProductContainer extends PureComponent {
             product,
             quantity,
             enteredOptions,
-            [...selectedOptions, ...downloadableLinks, ...configurableOptions],
+            [...selectedOptions, ...downloadableLinks, ...configurableOptions]
         );
     }
 

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
@@ -164,30 +164,17 @@ export class WishlistItemContainer extends PureComponent {
     getProducts() {
         const {
             product: {
-                type_id,
                 wishlist: {
                     quantity,
-                    buy_request,
-                    sku
-                },
-                sku: parentSku
+                    buy_request
+                }
             },
             product: item
         } = this.props;
 
         const selectedOptions = getSelectedOptions(buy_request);
 
-        if (type_id === PRODUCT_TYPE.configurable) {
-            return [{
-                sku,
-                quantity,
-                parent_sku: parentSku,
-                selected_options: selectedOptions,
-                entered_options: []
-            }];
-        }
-
-        return magentoProductTransform(item, quantity, null, [], selectedOptions);
+        return magentoProductTransform(item, quantity, [], selectedOptions);
     }
 
     async addItemToCart() {

--- a/packages/scandipwa/src/util/Product/Transform.js
+++ b/packages/scandipwa/src/util/Product/Transform.js
@@ -247,7 +247,6 @@ export const customizableOptionsToSelectTransform = (options, currencyCode = 'US
  * actions (add to cart, wishlist, exc.)
  * @param product
  * @param quantity
- * @param parentProduct
  * @param enteredOptions
  * @param selectedOptions
  * @returns {*[]}


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3447

**Problem:**
* https://devdocs.magento.com/guides/v2.4/graphql/mutations/add-products-to-cart.html passing parameters as suggested here in option 1 produces wrong result

**In this PR:**
* I changed the way parameters are passed to `addProductsToCart` mutation (option 2 from documentation), as it produces correct result
