### PR TITLE
[3444] Sorting for countries

### DIFF
--- a/packages/scandipwa/src/util/Store/Transform.js
+++ b/packages/scandipwa/src/util/Store/Transform.js
@@ -14,15 +14,24 @@
  * @param countries
  * @namespace Util/Store/Transform/transformCountriesToOptions
  */
-export const transformCountriesToOptions = (countries) => (
-    countries.map((country) => {
+export const transformCountriesToOptions = (countries) => {
+    const options = countries.map((country) => {
         const { id } = country;
+
         return {
             value: id,
             name: id,
             ...country
         };
-    }).sort(({ label }, { label: labelCompare }) => label > labelCompare)
-);
+    });
+
+    const filtered = options.filter(({ label }) => label);
+
+    const sorted = filtered.sort(
+        ({ label }, { label: labelCompare }) => label.localeCompare(labelCompare)
+    );
+
+    return sorted;
+};
 
 export default transformCountriesToOptions;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3444

**Problem:**
* Compare function for sorting ignores locale (special characters) 

**In this PR:**
* Instead of using direct compare `>` changed to function `localeCompare`
* Due to one country not having label, had to add filtration to check if country contains label.
