### PR TITLE
#3521 - too many requests wishlist

### DIFF
--- a/packages/scandipwa/src/component/PureForm/FieldNumber/FieldNumber.container.js
+++ b/packages/scandipwa/src/component/PureForm/FieldNumber/FieldNumber.container.js
@@ -43,7 +43,7 @@ export class FieldNumberContainer extends PureComponent {
 
     componentDidMount() {
         const { attr: { defaultValue = 0 } } = this.props;
-        this.handleValueChange(defaultValue);
+        this.handleInitialLoad(defaultValue);
     }
 
     setRef(elem) {
@@ -55,21 +55,42 @@ export class FieldNumberContainer extends PureComponent {
         }
     }
 
-    handleValueChange(value) {
+    setValue(value) {
         const {
-            events: { onChange } = {},
             attr: { min = 0, max = DEFAULT_MAX_PRODUCTS } = {}
         } = this.props;
 
         // eslint-disable-next-line no-nested-ternary
         const rangedValue = value < min ? min : value > max ? max : value;
 
-        if (typeof onChange === 'function') {
-            this.fieldRef.value = rangedValue;
-            onChange(rangedValue);
-        }
-
+        this.fieldRef.value = value;
         this.setState({ value: rangedValue });
+
+        return rangedValue;
+    }
+
+    handleInitialLoad(value) {
+        const {
+            events: { onLoad } = {}
+        } = this.props;
+
+        const newValue = this.setValue(value);
+
+        if (typeof onLoad === 'function') {
+            onLoad(newValue);
+        }
+    }
+
+    handleValueChange(value) {
+        const {
+            events: { onChange } = {}
+        } = this.props;
+
+        const newValue = this.setValue(value);
+
+        if (typeof onChange === 'function') {
+            onChange(newValue);
+        }
     }
 
     containerProps() {

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
@@ -91,6 +91,7 @@ export class WishlistItemContainer extends PureComponent {
 
     changeQuantity = debounce((quantity) => {
         const { wishlistId, product: { wishlist: { id: item_id } }, updateWishlistItem } = this.props;
+
         updateWishlistItem({
             wishlistId,
             wishlistItems: [{
@@ -102,6 +103,7 @@ export class WishlistItemContainer extends PureComponent {
 
     changeDescription = debounce((description) => {
         const { wishlistId, product: { wishlist: { id: item_id } }, updateWishlistItem } = this.props;
+
         updateWishlistItem({
             wishlistId,
             wishlistItems: [{


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3521

**Problem:**
* `onChange` handler is attached to Counter input (field of type number). This `onChange` handler makes an API call to update wishlist item quantity in DB  (which is correct, it should happen when user clicks PLUS or MINUS). The problem is that exactly same handler is called on initial component load, when setting default value to input. 

**Solution:**
* Distinguish `onChange` and `onLoad` logic. Most of logic is the same (i.e. setting value to input and to state), but additional `onChange` should not occur on initial load. I added `handleInitialLoad` handler, so that it is possible to perform some additional logic on component load, in case it is needed. 
