### PR TITLE
#3473 - wrong price navigate back

### DIFF
--- a/packages/scandipwa/src/component/Product/Product.container.js
+++ b/packages/scandipwa/src/component/Product/Product.container.js
@@ -178,6 +178,11 @@ export class ProductContainer extends PureComponent {
         return null;
     }
 
+    componentDidMount() {
+        this.updateSelectedValues();
+        this.updateAdjustedPrice();
+    }
+
     componentDidUpdate(prevProps, prevState) {
         const { enteredOptions, selectedOptions, downloadableLinks } = this.state;
         const {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3473

**Problem:**
* Method updating initial selected and entered options is not called

**In this PR:**
* Add componentDidMount() where options and price updated are triggered
