### PR TITLE
[3543] Image style in table + Ooops in CMS

### DIFF
--- a/packages/scandipwa/src/component/Image/Image.container.js
+++ b/packages/scandipwa/src/component/Image/Image.container.js
@@ -155,7 +155,7 @@ export class ImageContainer extends PureComponent {
         const size = this._getCorrectSize();
         const { height, width } = size;
 
-        if ((!height || height.slice(-1) === '%') && (!width || width.slice(-1) === '%')) {
+        if (!height || (height.slice(-1) === '%' && (!width || width.slice(-1) === '%'))) {
             return {};
         }
 

--- a/packages/scandipwa/src/component/Image/Image.style.scss
+++ b/packages/scandipwa/src/component/Image/Image.style.scss
@@ -49,10 +49,19 @@
 
     &-WidthFull {
         width: 100%;
+
+        td & {
+            max-width: 100%;
+        }
     }
 
     &-HeightFull {
         height: 100%;
+
+        td & {
+            height: auto;
+            min-height: 100%;
+        }
     }
 
     &-Content {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3543

**Problem:**
* Wrapper is only used if height is defined, because check is not detecting whether or not height is set -> error is omitted. 

**In this PR:**
* Added check for `height`
* Fixed style issues for images when they are in table
