### PR TITLE
[3444] Error when using countrie with non-select region in cart

### DIFF
--- a/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
+++ b/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
@@ -41,7 +41,7 @@ export class CheckoutAddressForm extends MyAccountAddressForm {
 
         onShippingEstimationFieldsChange({
             country_id: countryId || defaultCountry,
-            region_id: regionId,
+            region_id: regionId !== '' ? regionId : null,
             region,
             city,
             postcode
@@ -70,7 +70,7 @@ export class CheckoutAddressForm extends MyAccountAddressForm {
         const { fields = {} } = data;
         const {
             country_id,
-            region_id,
+            region_id: regionId,
             region_string: region,
             city,
             postcode
@@ -80,7 +80,7 @@ export class CheckoutAddressForm extends MyAccountAddressForm {
 
         onShippingEstimationFieldsChange({
             country_id,
-            region_id,
+            region_id: regionId !== '' ? regionId : null,
             region,
             city,
             postcode


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3444

**Problem:**
* To graphql there is sent field `region_string` it should be `region` instead

**In this PR:**
* Sending only correct fields to graphql
