### PR TITLE
Updated Proxy Server URL

### DIFF
--- a/build-packages/csa-generator-theme/index.js
+++ b/build-packages/csa-generator-theme/index.js
@@ -7,7 +7,7 @@ const logger = require('@scandipwa/scandipwa-dev-utils/logger');
 const { getComposerDeps } = require('@scandipwa/scandipwa-dev-utils/composer');
 const writeJson = require('@scandipwa/scandipwa-dev-utils/write-json');
 
-const DEFAULT_PROXY = 'https://demo100-ors-1588667385-csa-qnb.scandipwa.cloud/';
+const DEFAULT_PROXY = 'https://demo100-ors-1588667385-csa-hcx.scandipwa.cloud/';
 
 const ensureLatestComposer = (pathname) => {
     const composerDeps = getComposerDeps(pathname);

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -458,5 +458,5 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://demo100-ors-1588667385-csa-qnb.scandipwa.cloud/"
+    "proxy": "https://demo100-ors-1588667385-csa-hcx.scandipwa.cloud/"
 }


### PR DESCRIPTION
**Problem:**
* Demo server instance that was used as a default remote backend was deleted from the ReadyMage. Thus i created a new instance. But it has different url.

**In this PR:**
* Updated `proxy` url in theme generator and base theme.
