### PR TITLE
#3565 - cart query complexity

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.container.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.container.js
@@ -368,7 +368,10 @@ export class CartItemContainer extends PureComponent {
 
         const { attributes = [] } = this.getCurrentProduct() || {};
 
-        return Object.entries(attributes).map(this.getConfigurationOptionLabel).filter((label) => label);
+        return Object.entries(attributes)
+            .filter(([attrKey]) => Object.keys(configurable_options).includes(attrKey))
+            .map(this.getConfigurationOptionLabel)
+            .filter((label) => label);
     }
 
     notifyAboutLoadingStateChange(isLoading) {

--- a/packages/scandipwa/src/query/Cart.query.js
+++ b/packages/scandipwa/src/query/Cart.query.js
@@ -173,7 +173,6 @@ export class CartQuery {
         return [
             'id',
             'label',
-            'type',
             this._getBundleOptionValuesField()
         ];
     }
@@ -183,25 +182,11 @@ export class CartQuery {
             .addFieldList(this._getBundleOptionsFields());
     }
 
-    _getCustomizableOptionPriceFields() {
-        return [
-            'value',
-            'units',
-            'type'
-        ];
-    }
-
-    _getCustomizableOptionPriceField() {
-        return new Field('price')
-            .addFieldList(this._getCustomizableOptionPriceFields());
-    }
-
     _getCustomizableOptionValueFields() {
         return [
             'id',
             'label',
-            'value',
-            this._getCustomizableOptionPriceField()
+            'value'
         ];
     }
 
@@ -215,9 +200,7 @@ export class CartQuery {
             .addFieldList([
                 'id',
                 'label',
-                'is_required',
-                this._getCustomizableOptionValueField(),
-                'sort_order'
+                this._getCustomizableOptionValueField()
             ]);
     }
 
@@ -253,14 +236,8 @@ export class CartQuery {
     }
 
     _getProductField() {
-        ProductListQuery.options.isForLinkedProducts = true;
-
-        const productQuery = new Field('product')
-            .addFieldList(ProductListQuery._getProductInterfaceFields(false, true));
-
-        ProductListQuery.options.isForLinkedProducts = false;
-
-        return productQuery;
+        return new Field('product')
+            .addFieldList(ProductListQuery._getCartProductInterfaceFields());
     }
 
     _getCartItemsField() {

--- a/packages/scandipwa/src/query/ProductList.query.js
+++ b/packages/scandipwa/src/query/ProductList.query.js
@@ -212,6 +212,54 @@ export class ProductListQuery {
         ];
     }
 
+    _getCartProductInterfaceFields() {
+        return [
+            'uid',
+            'id',
+            'sku',
+            'name',
+            'type_id',
+            'stock_status',
+            'url',
+            this._getStockItemField(),
+            this._getProductThumbnailField(),
+            this._getCartConfigurableProductFragment(),
+            this._getAttributesField(false, true)
+        ];
+    }
+
+    _getCartConfigurableProductFragment() {
+        return new Fragment('ConfigurableProduct')
+            .addFieldList([
+                this._getConfigurableOptionsField(),
+                this._getCartVariantsField()
+            ]);
+    }
+
+    _getCartVariantsField() {
+        return new Field('variants')
+            .setAlias('variants')
+            .addFieldList(this._getCartVariantFields());
+    }
+
+    _getCartVariantFields() {
+        return [
+            this._getCartProductField()
+        ];
+    }
+
+    _getCartProductField() {
+        return new Field('product')
+            .addFieldList([
+                'id',
+                'sku',
+                'stock_status',
+                this._getStockItemField(),
+                this._getProductThumbnailField(),
+                this._getAttributesField(true, true)
+            ]);
+    }
+
     _getProductInterfaceFields(isVariant, isForLinkedProducts = false) {
         const {
             isPlp = false,
@@ -511,7 +559,6 @@ export class ProductListQuery {
         return [
             'path',
             'url'
-            // 'label'
         ];
     }
 
@@ -540,41 +587,56 @@ export class ProductListQuery {
             .addFieldList(this._getProductThumbnailFields());
     }
 
-    _getAttributeOptionField() {
+    _getAttributeOptionField(noSwatches) {
         return [
             'label',
             'value',
-            this._getSwatchDataField()
+            !noSwatches && this._getSwatchDataField()
         ];
     }
 
-    _getAttributeOptionsField() {
+    _getAttributeOptionsField(noSwatches) {
         return new Field('attribute_options')
-            .addFieldList(this._getAttributeOptionField());
+            .addFieldList(this._getAttributeOptionField(noSwatches));
     }
 
-    _getAttributeFields(isVariant) {
+    _getAdditionalAttributeFields(isCart) {
+        if (isCart) {
+            return [];
+        }
+
+        return [
+            'attribute_type',
+            'attribute_group_id',
+            'attribute_group_name'
+        ];
+    }
+
+    _getAttributeOptionsFields(isVariant) {
+        if (isVariant) {
+            return [];
+        }
+
+        return [
+            this._getAttributeOptionsField()
+        ];
+    }
+
+    _getAttributeFields(isVariant = false, isCart = false) {
         return [
             'attribute_id',
             'attribute_value',
             'attribute_code',
-            'attribute_type',
             'attribute_label',
-            'attribute_group_id',
-            'attribute_group_name',
-            ...(!isVariant
-                ? [
-                    this._getAttributeOptionsField()
-                ]
-                : []
-            )
+            ...this._getAdditionalAttributeFields(isCart),
+            ...this._getAttributeOptionsFields(isVariant)
         ];
     }
 
-    _getAttributesField(isVariant) {
+    _getAttributesField(isVariant, isCart) {
         return new Field('s_attributes')
             .setAlias('attributes')
-            .addFieldList(this._getAttributeFields(isVariant));
+            .addFieldList(this._getAttributeFields(isVariant, isCart));
     }
 
     _getMediaGalleryFields() {
@@ -926,16 +988,6 @@ export class ProductListQuery {
         return new Fragment('CustomizableDateOption')
             .addFieldList(this._getCustomizableDateFields());
     }
-    //
-    // _getCustomizableDateOption() {
-    //     return new Fragment('CustomizableAreaOption')
-    //         .addFieldList(this._getCustomizableTextFields('areaValues'));
-    // }
-    //
-    // _getCustomizableAreaOption() {
-    //     return new Fragment('CustomizableAreaOption')
-    //         .addFieldList(this._getCustomizableTextFields('areaValues'));
-    // }
 
     _getCustomizableSelectionValueFields() {
         return [


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3542
* Fixes https://github.com/scandipwa/scandipwa/issues/3565

**Problem 1:**
* `isPlp` class variable is set too globally and mistakenly applied when staying on PLP and fetching cart data. `isPlp` setting changes query to get less fields from the server. Among the fields missing is a thumbnail field, which is why picture is not loaded. 

**Solution 1:**
* Change logic for fetching cart data.

**Problem 2:**
* Many unneeded fields requested when loading cart

**Solution 2:**
* Remove fields. Complexity reduced to 103.
