### PR TITLE
See # Fixed styleguide page

### DIFF
--- a/packages/scandipwa/src/route/StyleGuidePage/StyleGuidePage.component.js
+++ b/packages/scandipwa/src/route/StyleGuidePage/StyleGuidePage.component.js
@@ -189,12 +189,22 @@ export class StyleGuidePageComponent extends PureComponent {
         );
     }
 
+    renderIcon(icon) {
+        const [name, Component] = icon;
+
+        if (typeof Component === 'string') {
+            return (
+                <Image src={ Component } alt={ name } key={ name } />
+            );
+        }
+
+        return <Component />;
+    }
+
     renderIcons() {
         return (
             <div block="StyleGuidePage" elem="Icons">
-                { Object.entries(ICONS_LIST).map(
-                    ([iconName, iconPath]) => (<Image src={ iconPath } alt={ iconName } key={ iconName } />)
-                ) }
+                { Object.entries(ICONS_LIST).map(this.renderIcon) }
                 <h4 block="StyleGuidePage" elem="SubHeading">
                     { __('Icons in header [default state + hover]') }
                 </h4>

--- a/packages/scandipwa/src/route/StyleGuidePage/StyleGuidePage.container.js
+++ b/packages/scandipwa/src/route/StyleGuidePage/StyleGuidePage.container.js
@@ -13,8 +13,11 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
+import CategoryReducer from 'Store/Category/Category.reducer';
 import { updateProductDetails } from 'Store/Product/Product.action';
+import ProductReducer from 'Store/Product/Product.reducer';
 import { ProductType } from 'Type/ProductList';
+import { withReducers } from 'Util/DynamicReducer';
 
 import product from './product.json';
 import StyleGuide from './StyleGuidePage.component';
@@ -73,4 +76,12 @@ export class StyleGuidePageContainer extends PureComponent {
     }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(StyleGuidePageContainer);
+export default withReducers({
+    CategoryReducer,
+    ProductReducer
+})(
+    connect(
+        mapStateToProps,
+        mapDispatchToProps
+    )(StyleGuidePageContainer)
+);


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3509 

**Problem:**
* Styleguide page was unmaintained and it's code didn't change during refactoring.

**In this PR:**
* Added missing reducers, wrapped them in the `withReducers` HOC.
* Fixed icons.
