### PR TITLE
[3480] Grouped product wishlist & compare list

### DIFF
--- a/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.component.js
+++ b/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.component.js
@@ -97,7 +97,7 @@ export class ProductCompareItem extends PureComponent {
 
         return (
             <ProductWishlistButton
-              magentoProduct={ magentoProductTransform(product) }
+              magentoProduct={ magentoProductTransform(product, null) }
               mix={ { block: 'ProductCard', elem: 'WishListButton' } }
             />
         );

--- a/packages/scandipwa/src/query/ProductCompare.query.js
+++ b/packages/scandipwa/src/query/ProductCompare.query.js
@@ -111,7 +111,7 @@ export class ProductCompareQuery extends ProductListQuery {
 
     _getComparableItemFields() {
         return [
-            this._getProductField(),
+            this._getCompareProductField(),
             this._getComparableItemAttributeField()
         ];
     }
@@ -122,13 +122,14 @@ export class ProductCompareQuery extends ProductListQuery {
         ];
     }
 
-    _getProductField() {
+    _getCompareProductField() {
         return new Field('product')
             .addFieldList(this._getProductInterfaceFields(true, false))
             .addFieldList(['url'])
             .addField(this._getReviewCountField())
             .addField(this._getRatingSummaryField())
-            .addField(this._getDescriptionField());
+            .addField(this._getDescriptionField())
+            .addField(this._getGroupedProductItems());
     }
 
     _getProductIdsField() {

--- a/packages/scandipwa/src/util/Product/Transform.js
+++ b/packages/scandipwa/src/util/Product/Transform.js
@@ -263,36 +263,42 @@ export const magentoProductTransform = (
     const productData = [];
 
     if (typeId === PRODUCT_TYPE.grouped) {
-        if (Object.keys(quantity).length === 0) {
+        const fetchDefaultQuantity = quantity === null;
+
+        if (!fetchDefaultQuantity && Object.keys(quantity).length === 0) {
             return productData;
         }
 
-        const { items } = product;
+        const { items = [] } = product;
 
         items.forEach(({
-            product: { id, sku: groupedSku }
+            product: { id: groupedId },
+            qty
         }) => {
-            const { [id]: groupedQuantity } = quantity;
+            const { [groupedId]: groupedQuantity } = quantity || [];
+            const finalQty = fetchDefaultQuantity ? qty : groupedQuantity;
 
-            if (groupedQuantity) {
-                productData.push({
-                    sku: groupedSku,
-                    quantity: groupedQuantity,
-                    selected_options: selectedOptions,
-                    entered_options: enteredOptions
-                });
+            if (finalQty) {
+                selectedOptions.push(btoa(`grouped/${groupedId}/${finalQty}`));
             }
         });
-    } else {
-        const baseProductToAdd = {
+
+        return [{
             sku,
-            quantity,
+            quantity: 1,
             selected_options: selectedOptions,
             entered_options: enteredOptions
-        };
-
-        productData.push(baseProductToAdd);
+        }];
     }
+
+    const baseProductToAdd = {
+        sku,
+        quantity,
+        selected_options: selectedOptions,
+        entered_options: enteredOptions
+    };
+
+    productData.push(baseProductToAdd);
 
     return productData;
 };


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3484
* Fixes https://github.com/scandipwa/scandipwa/issues/3480

**Required PR:**
* https://github.com/scandipwa/wishlist-graphql/pull/29

**Problem:**
* Using magento product where each grouped product is separate entity is creating separate products in wish-list

**In this PR:**
* Moved grouped product request from multiple product request to single product request that contains selected options following this pattern `grouped/{grouped_item_id}/{grouped_Item_qty}`.
* Added missing `items` in compare query for grouped item.
