### PR TITLE
3586 - change page on go back

### DIFF
--- a/packages/scandipwa/src/component/CategoryPagination/CategoryPagination.component.js
+++ b/packages/scandipwa/src/component/CategoryPagination/CategoryPagination.component.js
@@ -25,7 +25,6 @@ export class CategoryPagination extends PureComponent {
     static propTypes = {
         isLoading: PropTypes.bool.isRequired,
         pathname: PropTypes.string.isRequired,
-        onPageSelect: PropTypes.func.isRequired,
         totalPages: PropTypes.number.isRequired,
         currentPage: PropTypes.number.isRequired,
         getSearchQuery: PropTypes.func.isRequired,
@@ -123,7 +122,6 @@ export class CategoryPagination extends PureComponent {
     ) {
         const {
             pathname,
-            onPageSelect,
             getSearchQuery
         } = this.props;
 
@@ -136,7 +134,6 @@ export class CategoryPagination extends PureComponent {
                 <CategoryPaginationLink
                   label={ label }
                   url_path={ pathname }
-                  getPage={ onPageSelect }
                   isCurrent={ isCurrent }
                   pageNumber={ pageNumber }
                   getSearchQueryForPage={ getSearchQuery }

--- a/packages/scandipwa/src/component/CategoryPagination/CategoryPagination.container.js
+++ b/packages/scandipwa/src/component/CategoryPagination/CategoryPagination.container.js
@@ -36,7 +36,6 @@ export const mapDispatchToProps = () => ({});
 export class CategoryPaginationContainer extends PureComponent {
     static propTypes = {
         isLoading: PropTypes.bool,
-        onPageSelect: PropTypes.func,
         history: HistoryType.isRequired,
         location: LocationType.isRequired,
         totalPages: PropTypes.number.isRequired,
@@ -49,7 +48,6 @@ export class CategoryPaginationContainer extends PureComponent {
 
     static defaultProps = {
         isLoading: false,
-        onPageSelect: () => {},
         paginationFrame: 5,
         paginationFrameSkip: null,
         anchorTextPrevious: '',
@@ -74,7 +72,6 @@ export class CategoryPaginationContainer extends PureComponent {
             anchorTextPrevious,
             id,
             isLoading,
-            onPageSelect,
             paginationFrame,
             totalPages,
             location: { pathname }
@@ -85,7 +82,6 @@ export class CategoryPaginationContainer extends PureComponent {
             anchorTextPrevious,
             id,
             isLoading,
-            onPageSelect,
             paginationFrame,
             pathname,
             totalPages,

--- a/packages/scandipwa/src/component/CategoryPaginationLink/CategoryPaginationLink.component.js
+++ b/packages/scandipwa/src/component/CategoryPaginationLink/CategoryPaginationLink.component.js
@@ -21,7 +21,6 @@ import './CategoryPaginationLink.style';
 export class CategoryPaginationLink extends PureComponent {
     static propTypes = {
         children: ChildrenType,
-        getPage: PropTypes.func.isRequired,
         label: PropTypes.string.isRequired,
         isCurrent: PropTypes.bool.isRequired,
         url_path: PropTypes.string.isRequired,
@@ -31,11 +30,6 @@ export class CategoryPaginationLink extends PureComponent {
 
     static defaultProps = {
         children: []
-    };
-
-    getPage = () => {
-        const { getPage, pageNumber } = this.props;
-        getPage(pageNumber);
     };
 
     getSearchQueryForPage = () => {
@@ -67,7 +61,6 @@ export class CategoryPaginationLink extends PureComponent {
               block="CategoryPaginationLink"
               mods={ { isCurrent, isArrow: typeof children !== 'string' } }
               aria-current={ isCurrent ? 'page' : 'false' }
-              onClick={ this.getPage }
             >
                 { children }
             </Link>

--- a/packages/scandipwa/src/component/ProductList/ProductList.component.js
+++ b/packages/scandipwa/src/component/ProductList/ProductList.component.js
@@ -38,7 +38,6 @@ export class ProductList extends PureComponent {
         updatePage: PropTypes.func,
         totalPages: PropTypes.number,
         loadPage: PropTypes.func,
-        requestPage: PropTypes.func,
         loadPrevPage: PropTypes.func,
         currentPage: PropTypes.number,
         isShowLoading: PropTypes.bool,
@@ -59,7 +58,6 @@ export class ProductList extends PureComponent {
         updatePage: () => {},
         totalPages: 1,
         loadPage: () => {},
-        requestPage: () => {},
         loadPrevPage: () => {},
         currentPage: 1,
         isShowLoading: false,
@@ -302,7 +300,6 @@ export class ProductList extends PureComponent {
         const {
             isLoading,
             totalPages,
-            requestPage,
             isPaginationEnabled
         } = this.props;
 
@@ -314,7 +311,6 @@ export class ProductList extends PureComponent {
             <CategoryPagination
               isLoading={ isLoading }
               totalPages={ totalPages }
-              onPageSelect={ requestPage }
             />
         );
     }

--- a/packages/scandipwa/src/component/ProductList/ProductList.container.js
+++ b/packages/scandipwa/src/component/ProductList/ProductList.container.js
@@ -116,7 +116,8 @@ export class ProductListContainer extends PureComponent {
         const {
             sort: prevSort,
             search: prevSearch,
-            filter: prevFilter
+            filter: prevFilter,
+            location: prevLocation
         } = prevProps;
 
         const { pagesCount } = this.state;
@@ -127,7 +128,11 @@ export class ProductListContainer extends PureComponent {
             this.setState({ pagesCount: pagesLength });
         }
 
+        const prevPage = this._getPageFromUrl(prevLocation);
+        const currentPage = this._getPageFromUrl();
+
         if (search !== prevSearch
+            || currentPage !== prevPage
             || JSON.stringify(sort) !== JSON.stringify(prevSort)
             || JSON.stringify(filter) !== JSON.stringify(prevFilter)
         ) {
@@ -263,8 +268,9 @@ export class ProductListContainer extends PureComponent {
         return false;
     }
 
-    _getPageFromUrl() {
-        const { location } = this.props;
+    _getPageFromUrl(url) {
+        const { location: currentLocation } = this.props;
+        const location = url || currentLocation;
 
         return +(getQueryParam('page', location) || 1);
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3586

**Problem:**
* No trigger for product list reload on URL change. Product list was updated only on 1. initial load 2. click on pagination link button

**In this PR:**
* Make product list update on URL change (if page number changed)
* Make click on pagination link ONLY update URL and not to rerequest product list. Now change of URL triggers product list update, so there is no need for additional handler. Plus, if additional handler not removed, product list request would be executed twice.
