### PR TITLE
[3479] Double shipment fetch on select change

### DIFF
--- a/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
+++ b/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
@@ -26,6 +26,8 @@ export class CheckoutAddressForm extends MyAccountAddressForm {
         onShippingEstimationFieldsChange: () => {}
     };
 
+    lastRequest = null;
+
     componentDidMount() {
         const {
             address: {
@@ -77,14 +79,23 @@ export class CheckoutAddressForm extends MyAccountAddressForm {
         } = transformToNameValuePair(fields);
 
         const { onShippingEstimationFieldsChange } = this.props;
-
-        onShippingEstimationFieldsChange({
+        const request = {
             country_id,
             region_id: regionId !== '' ? regionId : null,
             region,
             city,
             postcode
-        });
+        };
+
+        // If request hasn't changed, then ignore.
+        if (JSON.stringify(request) === JSON.stringify(this.lastRequest)) {
+            return;
+        }
+
+        onShippingEstimationFieldsChange(request);
+
+        // Caches last request
+        this.lastRequest = request;
     };
 
     renderActions() {

--- a/packages/scandipwa/src/component/PureForm/FieldSelect/FieldSelect.component.js
+++ b/packages/scandipwa/src/component/PureForm/FieldSelect/FieldSelect.component.js
@@ -107,7 +107,9 @@ export class FieldSelect extends PureComponent {
               id={ `o${id}` }
               role="menuitem"
               // eslint-disable-next-line react/jsx-no-bind
-              onClick={ () => handleSelectListOptionClick(option) }
+              onMouseDown={ () => handleSelectListOptionClick(option) }
+              // eslint-disable-next-line react/jsx-no-bind
+              onTouchStart={ () => handleSelectListOptionClick(option) }
               // eslint-disable-next-line react/jsx-no-bind
               onKeyPress={ () => handleSelectListOptionClick(option) }
               tabIndex={ isExpanded ? '0' : '-1' }

--- a/packages/scandipwa/src/component/PureForm/FieldSelect/FieldSelect.container.js
+++ b/packages/scandipwa/src/component/PureForm/FieldSelect/FieldSelect.container.js
@@ -194,6 +194,8 @@ export class FieldSelectContainer extends PureComponent {
             return;
         }
 
+        this.updateValue(valueIndex);
+
         this.setState({ searchString, valueIndex }, () => {
             const { id, value } = options[valueIndex];
 
@@ -208,6 +210,17 @@ export class FieldSelectContainer extends PureComponent {
                 selectedElement.focus();
             }
         });
+    }
+
+    updateValue(valueIndex) {
+        if (this.fieldRef) {
+            const { options } = this.props;
+            const { value } = options[valueIndex];
+
+            if (value) {
+                this.fieldRef.value = value;
+            }
+        }
     }
 
     containerProps() {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3579

**Problem:**
* Due to `onBlur` event bind, there are made two requests: once when deselecting select, and second when deselecting address group.
* Due to how react work, `onClick` event for child will always be fired after `onBlur` event.

**In this PR:**
* Moved `onClick` to `onMouseDown` and `onTouchStart`
* Caching previous request to check if not the same data is sent.
