### PR TITLE
Issue 3607

### DIFF
--- a/packages/scandipwa/src/component/AddToCart/AddToCart.container.js
+++ b/packages/scandipwa/src/component/AddToCart/AddToCart.container.js
@@ -19,6 +19,7 @@ import { showNotification } from 'Store/Notification/Notification.action';
 import { MixType } from 'Type/Common';
 import { LayoutType } from 'Type/Layout';
 import { ProductType } from 'Type/ProductList';
+import { ADD_TO_CART } from 'Util/Product';
 import {
     getMaxQuantity, getMinQuantity, getName, getProductInStock
 } from 'Util/Product/Extract';
@@ -118,7 +119,7 @@ export class AddToCartContainer extends PureComponent {
                 cartId,
                 fallbackAddToCart
             } = this.props;
-            const magentoProduct = magentoProductTransform(product, quantity);
+            const magentoProduct = magentoProductTransform(ADD_TO_CART, product, quantity);
 
             try {
                 await fallbackAddToCart({

--- a/packages/scandipwa/src/component/Product/Product.container.js
+++ b/packages/scandipwa/src/component/Product/Product.container.js
@@ -20,7 +20,7 @@ import { DeviceType } from 'Type/Device';
 import { ProductType } from 'Type/ProductList';
 import fromCache from 'Util/Cache/Cache';
 import getFieldsData from 'Util/Form/Extract';
-import { getNewParameters, getVariantIndex } from 'Util/Product';
+import { ADD_TO_CART, getNewParameters, getVariantIndex } from 'Util/Product';
 import {
     getAdjustedPrice,
     getMaxQuantity,
@@ -402,10 +402,11 @@ export class ProductContainer extends PureComponent {
         const configurableOptions = transformParameters(parameters, attributes);
 
         return magentoProductTransform(
+            ADD_TO_CART,
             product,
             quantity,
             enteredOptions,
-            [...selectedOptions, ...downloadableLinks, ...configurableOptions]
+            [...selectedOptions, ...downloadableLinks, ...configurableOptions],
         );
     }
 

--- a/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.component.js
+++ b/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.component.js
@@ -21,6 +21,7 @@ import ProductReviewRating from 'Component/ProductReviewRating';
 import ProductWishlistButton from 'Component/ProductWishlistButton/ProductWishlistButton.container';
 import { ProductType } from 'Type/ProductList';
 import { LinkType } from 'Type/Router';
+import { ADD_TO_WISHLIST } from 'Util/Product';
 import { magentoProductTransform } from 'Util/Product/Transform';
 
 import './ProductCompareItem.style';
@@ -95,7 +96,7 @@ export class ProductCompareItem extends PureComponent {
 
         return (
             <ProductWishlistButton
-              magentoProduct={ magentoProductTransform(product) }
+              magentoProduct={ magentoProductTransform(ADD_TO_WISHLIST, product) }
               mix={ { block: 'ProductCard', elem: 'WishListButton' } }
             />
         );

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
@@ -21,6 +21,7 @@ import { showNotification } from 'Store/Notification/Notification.action';
 import { ProductType } from 'Type/ProductList';
 import { isSignedIn } from 'Util/Auth';
 import history from 'Util/History';
+import { ADD_TO_CART } from 'Util/Product';
 import { getSelectedOptions, magentoProductTransform } from 'Util/Product/Transform';
 import { debounce } from 'Util/Request';
 import { appendWithStoreCode } from 'Util/Url';
@@ -176,7 +177,7 @@ export class WishlistItemContainer extends PureComponent {
 
         const selectedOptions = getSelectedOptions(buy_request);
 
-        return magentoProductTransform(item, quantity, [], selectedOptions);
+        return magentoProductTransform(ADD_TO_CART, item, quantity, [], selectedOptions);
     }
 
     async addItemToCart() {

--- a/packages/scandipwa/src/query/ProductCompare.query.js
+++ b/packages/scandipwa/src/query/ProductCompare.query.js
@@ -111,7 +111,7 @@ export class ProductCompareQuery extends ProductListQuery {
 
     _getComparableItemFields() {
         return [
-            this._getProductField(),
+            this._getCompareProductField(),
             this._getComparableItemAttributeField()
         ];
     }
@@ -122,13 +122,14 @@ export class ProductCompareQuery extends ProductListQuery {
         ];
     }
 
-    _getProductField() {
+    _getCompareProductField() {
         return new Field('product')
             .addFieldList(this._getProductInterfaceFields(true, false))
             .addFieldList(['url'])
             .addField(this._getReviewCountField())
             .addField(this._getRatingSummaryField())
-            .addField(this._getDescriptionField());
+            .addField(this._getDescriptionField())
+            .addField(this._getGroupedProductItems());
     }
 
     _getProductIdsField() {

--- a/packages/scandipwa/src/util/Product/Product.js
+++ b/packages/scandipwa/src/util/Product/Product.js
@@ -16,6 +16,9 @@ import { showPopup } from 'Store/Popup/Popup.action';
 import { isSignedIn } from 'Util/Auth';
 import getStore from 'Util/Store';
 
+export const ADD_TO_CART = 'ADD_TO_CART';
+export const ADD_TO_WISHLIST = 'ADD_TO_WISHLIST';
+
 /**
  * Checks whether every option is in attributes
  * @param {Object} attributes

--- a/packages/scandipwa/src/util/Product/Transform.js
+++ b/packages/scandipwa/src/util/Product/Transform.js
@@ -12,6 +12,8 @@
 import PRODUCT_TYPE from 'Component/Product/Product.config';
 import { formatPrice } from 'Util/Price';
 
+import { ADD_TO_CART } from './Product';
+
 export const PRICE_TYPE_PERCENT = 'PERCENT';
 
 /**
@@ -253,6 +255,7 @@ export const customizableOptionsToSelectTransform = (options, currencyCode = 'US
  * @namespace Util/Product/Transform/magentoProductTransform
  */
 export const magentoProductTransform = (
+    action = ADD_TO_CART,
     product,
     quantity = 1,
     enteredOptions = [],
@@ -262,7 +265,7 @@ export const magentoProductTransform = (
 
     const productData = [];
 
-    if (typeId === PRODUCT_TYPE.grouped) {
+    if (typeId === PRODUCT_TYPE.grouped && action === ADD_TO_CART) {
         if (Object.keys(quantity).length === 0) {
             return productData;
         }


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3608

**Problem:**
* Grouped produces are decoded and sent to BE as selectedOptions which seems to be not correct, since in resolver it is getting only main product (grouped product) and from it adds all others with default qty. 

**In this PR:**
* Change back to adding each product from group product and if it is for wishlist then  add it as 1 product. 
