### PR TITLE
3519 - wrong max quantity

### DIFF
--- a/packages/scandipwa/src/util/Product/Extract.js
+++ b/packages/scandipwa/src/util/Product/Extract.js
@@ -68,7 +68,7 @@ export const getMinQuantity = (product, configIndex = -1) => (
  * @namespace Util/Product/Extract/getMaxQuantity
  */
 export const getMaxQuantity = (product, configIndex = -1) => (
-    getQuantity(product, DEFAULT_MAX_PRODUCTS, 'max_sale_qty', configIndex) - 1
+    getQuantity(product, DEFAULT_MAX_PRODUCTS, 'max_sale_qty', configIndex)
 );
 
 /**


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3519

**Problem:**
* Qty set in the admin is adjusted by subtracting 1

**In this PR:**
* Don't adjust number received from the server
