### PR TITLE
[3577] Star on next line for customizable option

### DIFF
--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
@@ -65,10 +65,10 @@ export class ProductCustomizableOption extends PureComponent {
         } = customizableOptionToLabel(option, currencyCode);
 
         return (
-            <div block="ProductCustomizableItem" elem="Label">
+            <span block="ProductCustomizableItem" elem="Label">
                 { overrideBase || baseLabel }
                 <strong>{ overridePrice || priceLabel }</strong>
-            </div>
+            </span>
         );
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3577

**Problem:**
* Using ```<div>``` instead of ```<span>```

**In this PR:**
* Changed ```<div>``` to ```<span>```
