### PR TITLE
[3611] Checkout region_id error: should be int32

### DIFF
--- a/packages/scandipwa/src/util/Address/index.js
+++ b/packages/scandipwa/src/util/Address/index.js
@@ -118,7 +118,7 @@ export const trimCheckoutAddress = (customerAddress) => {
         street,
         telephone,
         region,
-        region_id: region_id === '' ? 1 : region_id,
+        region_id: region_id === '' ? 0 : region_id,
         region_code,
         vat_id
     };


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3611

**Problem:**
* `region_id` needs to be int32 type value, but string is passed instead

**In this PR:**
* Fixed empty string issue, by passing default id 1 to region_id.
