### PR TITLE
Remove cookie lifetime to set auth toke. Use only OAuth setting

### DIFF
--- a/packages/scandipwa/src/util/Auth/Token.js
+++ b/packages/scandipwa/src/util/Auth/Token.js
@@ -16,19 +16,17 @@ import getStore from 'Util/Store';
 
 export const AUTH_TOKEN = 'auth_token';
 
-export const ONE_HOUR = 3600;
+export const ONE_HOUR_IN_SECONDS = 3600;
+export const ONE_HOUR = 1;
 
 /** @namespace Util/Auth/Token/setAuthorizationToken */
 export const setAuthorizationToken = (token) => {
     const state = getStore().getState();
     const {
-        cookie_lifetime = ONE_HOUR,
-        access_token_lifetime
+        access_token_lifetime = ONE_HOUR
     } = state.ConfigReducer;
 
-    const token_lifetime = access_token_lifetime ? access_token_lifetime * ONE_HOUR : cookie_lifetime;
-
-    BrowserDatabase.setItem(token, AUTH_TOKEN, token_lifetime);
+    BrowserDatabase.setItem(token, AUTH_TOKEN, access_token_lifetime * ONE_HOUR_IN_SECONDS);
 };
 
 /** @namespace Util/Auth/Token/deleteAuthorizationToken */


### PR DESCRIPTION
**Related PR(s):**
* Fixes https://github.com/scandipwa/customer-graph-ql/pull/23

**Related issue(s):**
* Fixes #3486 

**Problem:**
* We are using cookie lifetime setting for determining token expire time. 

**In this PR:**
* Change to use only OAuth setting.
