### PR TITLE
[3619] Search page loading on page switch

### DIFF
--- a/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
@@ -145,7 +145,7 @@ export class SearchPageContainer extends CategoryPageContainer {
         const search = this.getSearchParam();
 
         // if the search requested is equal to search from URL
-        return search === currentSearch;
+        return super.getIsMatchingListFilter() && search === currentSearch;
     }
 
     getIsMatchingInfoFilter() {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3619

**Problem:**
* Only comparing search query, thus ignoring filters and page numbers

**In this PR:**
* Using category pages check for filters and page changes to check if page requires update.
