### PR TITLE
3634 - missing crosssell products in cart

### DIFF
--- a/packages/scandipwa/src/query/ProductList.query.js
+++ b/packages/scandipwa/src/query/ProductList.query.js
@@ -226,7 +226,8 @@ export class ProductListQuery {
             this._getStockItemField(),
             this._getProductThumbnailField(),
             this._getCartConfigurableProductFragment(),
-            this._getAttributesField(false, true)
+            this._getAttributesField(false, true),
+            this._getProductLinksField()
         ];
     }
 

--- a/packages/scandipwa/src/route/CartPage/CartPage.container.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.container.js
@@ -139,6 +139,10 @@ export class CartPageContainer extends PureComponent {
                 title
             });
         }
+
+        if (items_qty !== prevItemsQty) {
+            this._updateCrossSellProducts();
+        }
     }
 
     containerProps = () => {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3634

**Problem 1:**
* No product links in cart product data, if product requested from Cart

**Solution 1:**
* Add `product_links` field to GQL response

**Problem 2:**
* Product links are updated only on component mount. If cart items list is empty on component load (i.e. if you load cart page directly via link, don't go there via `Go to Cart` link in Cart overlay), Cross-sell products list will be empty as well (and will not change thereafter).

**Solution 2:**
* Make cross-sell products list update on cart items number change.
