### PR TITLE
issue-2833 - Disable show new version popup on first website visit

### DIFF
--- a/packages/scandipwa/src/component/NewVersionPopup/NewVersionPopup.container.js
+++ b/packages/scandipwa/src/component/NewVersionPopup/NewVersionPopup.container.js
@@ -58,6 +58,12 @@ export class NewVersionPopupContainer extends PureComponent {
             return;
         }
 
+        const { serviceWorker: { controller } = {} } = navigator;
+
+        if (!controller) {
+            return;
+        }
+
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.addEventListener('controllerchange', () => {
                 showPopup({


### PR DESCRIPTION
**Related issue(s):**
* Fixes #2833 

**Problem:**
* Popup new version is shows each time user first time visit website 

**In this PR:**
* Add check if controller exist (if exist means it is not first visit)

**How I tested:**
1.Go to website with incognito
2. See that no new version popup appear
3. Make changes in code so SW will fire life cycle and popup appear to suggest reload. 