### PR TITLE
#3660 - region string data lost

### DIFF
--- a/packages/scandipwa/src/util/Address/index.js
+++ b/packages/scandipwa/src/util/Address/index.js
@@ -102,8 +102,8 @@ export const trimCheckoutAddress = (customerAddress) => {
         postcode = '',
         street = [''],
         telephone = '',
-        region = '',
-        region_id = 1,
+        region_string = '',
+        region_id = 0,
         region_code = null,
         vat_id = null
     } = customerAddress;
@@ -117,7 +117,7 @@ export const trimCheckoutAddress = (customerAddress) => {
         postcode,
         street,
         telephone,
-        region,
+        region: region_string,
         region_id: region_id === '' ? 0 : region_id,
         region_code,
         vat_id


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3660

**Problem:**
* `region_string` field data is lost after several data tranformations

**In this PR:**
* fix transformation logic
