### PR TITLE
[2846] Price calculation with discount for downloadable

### DIFF
--- a/packages/scandipwa/src/util/Product/Extract.js
+++ b/packages/scandipwa/src/util/Product/Extract.js
@@ -210,7 +210,7 @@ export const getPrice = (
     const priceExcTaxAcc = type === PRODUCT_TYPE.bundle || type === PRODUCT_TYPE.configurable
         ? 'default_final_price_excl_tax'
         : 'regular_price_excl_tax';
-    const accessRange = type === PRODUCT_TYPE.virtual
+    const accessRange = type === PRODUCT_TYPE.virtual || type === PRODUCT_TYPE.downloadable
         ? 'maximum_price'
         : 'minimum_price';
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/2846

**Problem:**
* Incorrect field accessed for downloadable product calculations.

**In this PR:**
* Switched to correct field `maximum_price`
