### PR TITLE
[3584] display Product name instead of SKU

### DIFF
--- a/packages/scandipwa/src/component/ProductAttributes/ProductAttributes.container.js
+++ b/packages/scandipwa/src/component/ProductAttributes/ProductAttributes.container.js
@@ -33,10 +33,14 @@ export class ProductAttributesContainer extends PureComponent {
     }
 
     _getAttributesWithValues() {
-        const { product: { attributes = {}, parameters = {} } } = this.props;
+        const { product: { attributes = {}, parameters = {}, name } } = this.props;
 
         const allAttribsWithValues = Object.entries(attributes).reduce((acc, [key, val]) => {
             const { attribute_label, attribute_value } = val;
+
+            if (key === 'name') {
+                return { ...acc, [attribute_label]: { ...val, attribute_value: name } };
+            }
 
             if (attribute_value) {
                 return { ...acc, [attribute_label]: val };


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3584 

**Problem:**
* SKU was displayed instead product name in detail tab on PDP when selecting all attributes for config product

**In this PR:**
* as intended, product name will be displayed instead of SKU
