### PR TITLE
[3653] Same styled option names of downloadable and other products

### DIFF
--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
@@ -52,7 +52,7 @@ export class ProductDownloadableLinks extends PureComponent {
         return (
             <span block="ProductDownloadableLink" elem="SampleTitle">
                 { title }
-                { `(+${ formatPrice(price) })` }
+                <strong>{ ` + ${ formatPrice(price) }` }</strong>
             </span>
         );
     }

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -72,7 +72,7 @@
     }
 
     &-SampleTitle {
-        font-weight: bold;
+//        font-weight: bold;
         flex: 1;
     }
 

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -72,7 +72,6 @@
     }
 
     &-SampleTitle {
-//        font-weight: bold;
         flex: 1;
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3653 

**Problem:**
* font-weight of SampleTitle was set bold.
* Price written in brackets without spaces.

**In this PR:**
* Unset bold font-weight to SampleTitle.
* Removed brackets around Price and added the needed spaces. 
