### PR TITLE
[3627] Solve 503 error response being ignored by parseResponse().

### DIFF
--- a/packages/scandipwa/src/util/Request/Request.js
+++ b/packages/scandipwa/src/util/Request/Request.js
@@ -169,13 +169,20 @@ export const parseResponse = (promise) => new Promise((resolve, reject) => {
             /** @namespace Util/Request/parseResponse/Promise/promise/then/json/then/resolve */
             (res) => resolve(checkForErrors(res)),
             /** @namespace Util/Request/parseResponse/Promise/promise/then/json/then/catch */
-            () => handleConnectionError('Can not transform JSON!') && reject()
+            () => {
+                handleConnectionError('Can not transform JSON!');
+                return reject();
+            }
         ),
         /** @namespace Util/Request/parseResponse/Promise/promise/then/catch */
-        (err) => handleConnectionError('Can not establish connection!') && reject(err)
+        (err) => {
+            handleConnectionError('Can not establish connection!');
+            return reject(err);
+        }
     );
 });
 
+export const HTTP_503_SERVICE_UNAVAILABLE = 503;
 export const HTTP_410_GONE = 410;
 export const HTTP_201_CREATED = 201;
 
@@ -191,7 +198,7 @@ export const executeGet = (queryObject, name, cacheTTL) => {
     const { query, variables } = queryObject;
     const uri = formatURI(query, variables, getGraphqlEndpoint());
 
-    return parseResponse(new Promise((resolve) => {
+    return parseResponse(new Promise((resolve, reject) => {
         getFetch(uri, name).then(
             /** @namespace Util/Request/executeGet/parseResponse/getFetch/then */
             (res) => {
@@ -207,6 +214,8 @@ export const executeGet = (queryObject, name, cacheTTL) => {
                             }
                         }
                     );
+                } else if (res.status === HTTP_503_SERVICE_UNAVAILABLE) {
+                    reject(res);
                 } else {
                     resolve(res);
                 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3627

**Problem:**
* HTTP 503 response error was totally ignored
* Request handler did not return reject to JSON parse error
* Request handler did not return reject to connection fail error
* Error notification was implemented but never called

**In this PR:**
* Return reject to 503 response error on request promise
* Ignore `console.error()` returning `false` on `parseResponse()`, returning `reject(err)` to promise.
