### PR TITLE
#3641 Home page opens if user click on name of search query in breadrums on search page

### DIFF
--- a/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.component.js
+++ b/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.component.js
@@ -40,19 +40,7 @@ export class Breadcrumb extends PureComponent {
             url = ''
         } = this.props;
 
-        const { pathname } = location;
-
         if (typeof url === 'string' || !url) {
-            if (pathname.includes('/search/')) {
-                return {
-                    pathname: pathname || '',
-                    search: pathname.split('/').pop(),
-                    state: {
-                        ...this.state
-                    }
-                };
-            }
-
             return {
                 pathname: url || '',
                 search: '',

--- a/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.style.scss
+++ b/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.style.scss
@@ -34,6 +34,9 @@
         .ChevronIcon {
             display: none;
         }
+        :link{
+            pointer-events: none;
+        }
     }
 
     &::before {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3641

**Problem:**
* search query name redirects to home.

**In this PR:**
* make "pointer-event" to last child of breadcrumb unclickable
