### PR TITLE
 Space is absent between option name and + price in all products with checkboxes #3647 

### DIFF
--- a/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.component.js
+++ b/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.component.js
@@ -40,19 +40,7 @@ export class Breadcrumb extends PureComponent {
             url = ''
         } = this.props;
 
-        const { pathname } = location;
-
         if (typeof url === 'string' || !url) {
-            if (pathname.includes('/search/')) {
-                return {
-                    pathname: pathname || '',
-                    search: pathname.split('/').pop(),
-                    state: {
-                        ...this.state
-                    }
-                };
-            }
-
             return {
                 pathname: url || '',
                 search: '',

--- a/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.style.scss
+++ b/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.style.scss
@@ -34,6 +34,9 @@
         .ChevronIcon {
             display: none;
         }
+        :link{
+            pointer-events: none;
+        }
     }
 
     &::before {

--- a/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.component.js
+++ b/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.component.js
@@ -322,7 +322,8 @@ export class ProductBundleOption extends PureComponent {
         return (
             <>
                 { baseLabel }
-                <strong>{ ` ${priceLabel}` }</strong>
+                <span>{ ' ' }</span>
+                <strong>{ priceLabel }</strong>
             </>
         );
     }

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
@@ -65,10 +65,12 @@ export class ProductCustomizableOption extends PureComponent {
         } = customizableOptionToLabel(option, currencyCode);
 
         return (
+            <p>
             <span block="ProductCustomizableItem" elem="Label">
                 { overrideBase || baseLabel }
                 <strong>{ overridePrice || priceLabel }</strong>
             </span>
+            </p>
         );
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3647 

**Problem:**
* No space between name and + price for products with radiobuttons or  checkboxes.

**In this PR:**
* Added "display:flex", "pre" tag with spaces.
