### PR TITLE
[3668] User can select checkbox options if click on field between options in dropdown

### DIFF
--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -83,7 +83,7 @@ $select-arrow-width: 14px !default;
 
         &_isExpanded {
             @include desktop {
-                z-index: 5;
+                z-index: 15;
                 max-height: 200px;
                 border-color: #0a0a0a;
                 border-color: var(--input-border-color);


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3668

**Problem:**
* z-index for checkbox & radio is 10, so if select options have z-index to 5, then checkbox will be selected instead of clicked option as they would be technically above.

**In this PR:**
* Fixed order, so that select options are above checkbox, when opened
