### PR TITLE
Field Config Ref Support

### DIFF
--- a/packages/scandipwa/i18n/da_DK.json
+++ b/packages/scandipwa/i18n/da_DK.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/de_DE.json
+++ b/packages/scandipwa/i18n/de_DE.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/es_ES.json
+++ b/packages/scandipwa/i18n/es_ES.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/fa_IR.json
+++ b/packages/scandipwa/i18n/fa_IR.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/fi_FI.json
+++ b/packages/scandipwa/i18n/fi_FI.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/fr_FR.json
+++ b/packages/scandipwa/i18n/fr_FR.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/it_IT.json
+++ b/packages/scandipwa/i18n/it_IT.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/lv_LV.json
+++ b/packages/scandipwa/i18n/lv_LV.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/nb_NO.json
+++ b/packages/scandipwa/i18n/nb_NO.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/nl_NL.json
+++ b/packages/scandipwa/i18n/nl_NL.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/pl_PL.json
+++ b/packages/scandipwa/i18n/pl_PL.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/pt_BR.json
+++ b/packages/scandipwa/i18n/pt_BR.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/ru_RU.json
+++ b/packages/scandipwa/i18n/ru_RU.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/sl_SI.json
+++ b/packages/scandipwa/i18n/sl_SI.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/sv_SE.json
+++ b/packages/scandipwa/i18n/sv_SE.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/tr_TR.json
+++ b/packages/scandipwa/i18n/tr_TR.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/i18n/zh_TW.json
+++ b/packages/scandipwa/i18n/zh_TW.json
@@ -542,5 +542,6 @@
     "Checkbox": null,
     "Radio": null,
     "Breadcrumbs": null,
-    "Please fill in all rating fields": null
+    "Please fill in all rating fields": null,
+    "Save customer": null
 }

--- a/packages/scandipwa/src/component/App/App.component.js
+++ b/packages/scandipwa/src/component/App/App.component.js
@@ -17,6 +17,7 @@ import Router from 'Component/Router';
 import SharedTransition from 'Component/SharedTransition';
 import SomethingWentWrong from 'Route/SomethingWentWrong';
 import injectStaticReducers from 'Store';
+import { noopFn } from 'Util/Common';
 import getStore from 'Util/Store';
 
 /** @namespace Component/App/Component */
@@ -105,7 +106,7 @@ export class App extends PureComponent {
         if (typeof window.__REACT_DEVTOOLS_GLOBAL_HOOK__ === 'object') {
             // eslint-disable-next-line no-restricted-syntax, fp/no-loops, no-unused-vars
             for (const [key, value] of Object.entries(window.__REACT_DEVTOOLS_GLOBAL_HOOK__)) {
-                window.__REACT_DEVTOOLS_GLOBAL_HOOK__[key] = typeof value === 'function' ? () => {} : null;
+                window.__REACT_DEVTOOLS_GLOBAL_HOOK__[key] = typeof value === 'function' ? noopFn : null;
             }
         }
     }

--- a/packages/scandipwa/src/component/CarouselScroll/CarouselScroll.component.js
+++ b/packages/scandipwa/src/component/CarouselScroll/CarouselScroll.component.js
@@ -15,6 +15,7 @@ import { CAROUSEL_ITEM_GAP } from 'Component/CarouselScroll/CarouselScroll.confi
 import CarouselScrollArrow from 'Component/CarouselScrollArrow';
 import CarouselScrollItem from 'Component/CarouselScrollItem';
 import { ChildrenType } from 'Type/Common.type';
+import { noopFn } from 'Util/Common';
 import CSS from 'Util/CSS';
 import { isRtl } from 'Util/CSS/CSS';
 
@@ -34,7 +35,7 @@ export class CarouselScroll extends PureComponent {
     static defaultProps = {
         showArrow: true,
         showedItemCount: 1,
-        onChange: () => {},
+        onChange: noopFn,
         activeItemId: null,
         isImageZoomPopupActive: false
     };

--- a/packages/scandipwa/src/component/CarouselScrollArrow/CarouselScrollArrow.component.js
+++ b/packages/scandipwa/src/component/CarouselScrollArrow/CarouselScrollArrow.component.js
@@ -13,6 +13,7 @@ import { PureComponent } from 'react';
 
 import ChevronIcon from 'Component/ChevronIcon';
 import { ModsType } from 'Type/Common.type';
+import { noopFn } from 'Util/Common';
 
 import './CarouselScrollArrow.style';
 
@@ -25,7 +26,7 @@ export class CarouselScrollArrow extends PureComponent {
 
     static defaultProps = {
         mods: {},
-        onClick: () => {}
+        onClick: noopFn
     };
 
     render() {

--- a/packages/scandipwa/src/component/CarouselScrollItem/CarouselScrollItem.container.js
+++ b/packages/scandipwa/src/component/CarouselScrollItem/CarouselScrollItem.container.js
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import { ChildrenType, RefType } from 'Type/Common.type';
+import { noopFn } from 'Util/Common';
 
 import CarouselScrollItem from './CarouselScrollItem.component';
 
@@ -27,8 +28,8 @@ export class CarouselScrollItemContainer extends PureComponent {
 
     static defaultProps = {
         isActive: false,
-        itemRef: () => {},
-        onClick: () => {},
+        itemRef: noopFn,
+        onClick: noopFn,
         children: []
     };
 

--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.container.js
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.container.js
@@ -14,6 +14,7 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import { MixType } from 'Type/Common.type';
+import { noopFn } from 'Util/Common';
 
 import CartCoupon from './CartCoupon.component';
 
@@ -48,7 +49,7 @@ export class CartCouponContainer extends PureComponent {
 
     static defaultProps = {
         couponCode: '',
-        onCouponCodeUpdate: () => {},
+        onCouponCodeUpdate: noopFn,
         mix: {},
         title: ''
     };

--- a/packages/scandipwa/src/component/CartItemPrice/CartItemPrice.component.js
+++ b/packages/scandipwa/src/component/CartItemPrice/CartItemPrice.component.js
@@ -19,9 +19,13 @@ import { formatPrice, roundPrice } from 'Util/Price';
 export class CartItemPrice extends PureComponent {
     static propTypes = {
         price: PropTypes.number.isRequired,
-        subPrice: PropTypes.number.isRequired,
+        subPrice: PropTypes.number,
         currency_code: PropTypes.string.isRequired,
         mix: MixType.isRequired
+    };
+
+    static defaultProps = {
+        subPrice: null
     };
 
     renderPrice() {

--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 
 import { CustomerType } from 'Type/Account.type';
 import { isSignedIn } from 'Util/Auth';
+import { noopFn } from 'Util/Common';
 
 import CheckoutAddressBook from './CheckoutAddressBook.component';
 
@@ -49,8 +50,8 @@ export class CheckoutAddressBookContainer extends PureComponent {
 
     static defaultProps = {
         isBilling: false,
-        onAddressSelect: () => {},
-        onShippingEstimationFieldsChange: () => {},
+        onAddressSelect: noopFn,
+        onShippingEstimationFieldsChange: noopFn,
         isSubmitted: false,
         is_virtual: false
     };

--- a/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
+++ b/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
@@ -12,6 +12,7 @@
 import PropTypes from 'prop-types';
 
 import MyAccountAddressForm from 'Component/MyAccountAddressForm/MyAccountAddressForm.component';
+import { noopFn } from 'Util/Common';
 import transformToNameValuePair from 'Util/Form/Transform';
 
 /** @namespace Component/CheckoutAddressForm/Component */
@@ -23,7 +24,7 @@ export class CheckoutAddressForm extends MyAccountAddressForm {
 
     static defaultProps = {
         ...MyAccountAddressForm.defaultProps,
-        onShippingEstimationFieldsChange: () => {}
+        onShippingEstimationFieldsChange: noopFn
     };
 
     lastRequest = null;

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
@@ -48,12 +48,16 @@ export class CheckoutBilling extends PureComponent {
         showPopup: PropTypes.func.isRequired,
         paymentMethods: PaymentMethodsType.isRequired,
         totals: TotalsType.isRequired,
-        cartTotalSubPrice: PropTypes.number.isRequired,
+        cartTotalSubPrice: PropTypes.number,
         shippingAddress: Addresstype.isRequired,
         termsAndConditions: PropTypes.arrayOf(PropTypes.shape({
             checkbox_text: PropTypes.string
         })).isRequired,
         selectedShippingMethod: PropTypes.string.isRequired
+    };
+
+    static defaultProps = {
+        cartTotalSubPrice: null
     };
 
     componentDidMount() {

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
@@ -152,10 +152,6 @@ export class CheckoutDeliveryOption extends PureComponent {
                           name: `option-${ carrier_title }`,
                           checked: !!isSelected
                       } }
-                      events={ {
-                          // prevent console error that radio button should have onChange event handler or be readonly
-                          onChange: () => null
-                      } }
                     />
                     { this.renderRow() }
                 </button>

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
@@ -152,6 +152,10 @@ export class CheckoutDeliveryOption extends PureComponent {
                           name: `option-${ carrier_title }`,
                           checked: !!isSelected
                       } }
+                      events={ {
+                          // prevent console error that radio button should have onChange event handler or be readonly
+                          onChange: () => null
+                      } }
                     />
                     { this.renderRow() }
                 </button>

--- a/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.component.js
+++ b/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.component.js
@@ -23,6 +23,7 @@ import {
     STATE_SIGN_IN
 } from 'Component/MyAccountOverlay/MyAccountOverlay.config';
 import MyAccountSignIn from 'Component/MyAccountSignIn';
+import { noopFn } from 'Util/Common';
 
 import checkoutGuestForm from './CheckoutGuestForm.form';
 
@@ -63,7 +64,7 @@ export class CheckoutGuestForm extends FieldForm {
             render: () => this.renderForgotPasswordSuccess()
         },
         [STATE_LOGGED_IN]: {
-            render: () => {}
+            render: noopFn
         },
         [STATE_CONFIRM_EMAIL]: {
             render: () => this.renderConfirmEmail(),

--- a/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.js
+++ b/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.js
@@ -26,6 +26,7 @@ import { SHIPPING_STEP, UPDATE_EMAIL_CHECK_FREQUENCY } from 'Route/Checkout/Chec
 import { updateEmail, updateEmailAvailable } from 'Store/Checkout/Checkout.action';
 import { showNotification } from 'Store/Notification/Notification.action';
 import { isSignedIn } from 'Util/Auth';
+import { noopFn } from 'Util/Common';
 import { debounce, getErrorMessage } from 'Util/Request';
 
 import CheckoutGuestForm from './CheckoutGuestForm.component';
@@ -82,7 +83,7 @@ export class CheckoutGuestFormContainer extends PureComponent {
     static defaultProps = {
         emailValue: '',
         isGuestEmailSaved: false,
-        onSignIn: () => {}
+        onSignIn: noopFn
     };
 
     state = {

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -21,6 +21,7 @@ import { ChildrenType } from 'Type/Common.type';
 import { CartConfigType } from 'Type/Config.type';
 import { TotalsType } from 'Type/MiniCart.type';
 import { getItemsCountLabel } from 'Util/Cart';
+import { noopFn } from 'Util/Common';
 
 import './CheckoutOrderSummary.style';
 
@@ -46,7 +47,7 @@ export class CheckoutOrderSummary extends PureComponent {
 
     static defaultProps = {
         totals: {},
-        renderCmsBlock: () => {},
+        renderCmsBlock: noopFn,
         isExpandable: false,
         cartShippingPrice: 0,
         cartShippingSubPrice: null,

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.component.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.component.js
@@ -31,7 +31,7 @@ import './CheckoutShipping.style';
 export class CheckoutShipping extends PureComponent {
     static propTypes = {
         totals: TotalsType.isRequired,
-        cartTotalSubPrice: PropTypes.number.isRequired,
+        cartTotalSubPrice: PropTypes.number,
         onShippingSuccess: PropTypes.func.isRequired,
         onShippingError: PropTypes.func.isRequired,
         onShippingEstimationFieldsChange: PropTypes.func.isRequired,
@@ -49,7 +49,8 @@ export class CheckoutShipping extends PureComponent {
     };
 
     static defaultProps = {
-        setSelectedShippingMethodCode: null
+        setSelectedShippingMethodCode: null,
+        cartTotalSubPrice: null
     };
 
     renderOrderTotalExclTax() {

--- a/packages/scandipwa/src/component/ClickOutside/ClickOutside.component.js
+++ b/packages/scandipwa/src/component/ClickOutside/ClickOutside.component.js
@@ -18,6 +18,7 @@ import {
 } from 'react';
 
 import { ChildrenType } from 'Type/Common.type';
+import { noopFn } from 'Util/Common';
 
 /** @namespace Component/ClickOutside/Component */
 export class ClickOutside extends PureComponent {
@@ -27,7 +28,7 @@ export class ClickOutside extends PureComponent {
     };
 
     static defaultProps = {
-        onClick: () => {},
+        onClick: noopFn,
         children: []
     };
 

--- a/packages/scandipwa/src/component/Draggable/Draggable.component.js
+++ b/packages/scandipwa/src/component/Draggable/Draggable.component.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import { ChildrenType, MixType, RefType } from 'Type/Common.type';
+import { noopFn } from 'Util/Common';
 
 import './Draggable.style';
 
@@ -36,7 +37,7 @@ export class Draggable extends PureComponent {
     static defaultProps = {
         shiftX: 0,
         shiftY: 0,
-        onDragStart: () => {},
+        onDragStart: noopFn,
         onDragEnd: (state, callback) => {
             const { translateX, translateY } = state;
 
@@ -47,11 +48,11 @@ export class Draggable extends PureComponent {
                 shiftY: translateY
             });
         },
-        onClick: () => {},
-        onDrag: () => {},
-        handleFocus: () => {},
-        handleKey: () => {},
-        draggableRef: () => {},
+        onClick: noopFn,
+        onDrag: noopFn,
+        handleFocus: noopFn,
+        handleKey: noopFn,
+        draggableRef: noopFn,
         mix: {}
     };
 

--- a/packages/scandipwa/src/component/Field/Field.component.js
+++ b/packages/scandipwa/src/component/Field/Field.component.js
@@ -23,6 +23,7 @@ import {
     LabelType,
     OptionType
 } from 'Type/Field.type';
+import { noopFn } from 'Util/Common';
 
 import { FIELD_TYPE } from './Field.config';
 
@@ -186,12 +187,17 @@ export class Field extends PureComponent {
             setRef,
             attr,
             attr: { id = '' } = {},
+            events: { onChange },
             events,
             isDisabled,
             label
         } = this.props;
 
         const elem = type.charAt(0).toUpperCase() + type.slice(1);
+        const inputEvents = {
+            ...events,
+            onChange: onChange || noopFn
+        };
 
         return (
             <label htmlFor={ id } block="Field" elem={ `${elem}Label` }>
@@ -200,7 +206,7 @@ export class Field extends PureComponent {
                   disabled={ isDisabled }
                   type={ type }
                   { ...attr }
-                  { ...events }
+                  { ...inputEvents }
                 />
                 <div block="input-control" />
                 { label }

--- a/packages/scandipwa/src/component/Field/Field.container.js
+++ b/packages/scandipwa/src/component/Field/Field.container.js
@@ -13,7 +13,7 @@
 import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 
-import { MixType } from 'Type/Common.type';
+import { MixType, RefType } from 'Type/Common.type';
 import {
     EventsType, FieldAttrType, FieldOptionsType, LabelType, ValidationRuleType
 } from 'Type/Field.type';
@@ -36,6 +36,7 @@ export class FieldContainer extends PureComponent {
         isDisabled: PropTypes.bool,
         mix: MixType,
         options: FieldOptionsType,
+        elemRef: RefType,
 
         // Validation
         validationRule: ValidationRuleType,
@@ -60,7 +61,8 @@ export class FieldContainer extends PureComponent {
         isDisabled: false,
         addRequiredTag: false,
         label: '',
-        subLabel: ''
+        subLabel: '',
+        elemRef: null
     };
 
     state = {
@@ -89,10 +91,14 @@ export class FieldContainer extends PureComponent {
 
     // Adds validation event listener to field
     setRef(elem) {
-        const { validationRule } = this.props;
+        const { validationRule, elemRef } = this.props;
 
         if (elem && this.fieldRef !== elem) {
             this.fieldRef = elem;
+
+            if (elemRef) {
+                elemRef.current = elem;
+            }
 
             elem.addEventListener('resetField', this.resetField.bind(this));
 

--- a/packages/scandipwa/src/component/FieldGroup/FieldGroup.container.js
+++ b/packages/scandipwa/src/component/FieldGroup/FieldGroup.container.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 
 import FIELD_TYPE from 'Component/Field/Field.config';
-import { ChildrenType, ModsType } from 'Type/Common.type';
+import { ChildrenType, ModsType, RefType } from 'Type/Common.type';
 import { EventsType, FieldAttrType, ValidationRuleType } from 'Type/Field.type';
 import getFieldsData from 'Util/Form/Extract';
 import { validateGroup } from 'Util/Validator';
@@ -31,6 +31,7 @@ export class FieldGroupContainer extends PureComponent {
         children: ChildrenType,
         attr: FieldAttrType,
         events: EventsType,
+        elemRef: RefType,
 
         // Validation
         validationRule: ValidationRuleType,
@@ -53,7 +54,8 @@ export class FieldGroupContainer extends PureComponent {
         label: '',
         subLabel: '',
         children: [],
-        mods: {}
+        mods: {},
+        elemRef: null
     };
 
     state = {
@@ -78,9 +80,14 @@ export class FieldGroupContainer extends PureComponent {
 
     // Adds validation event listener to field
     setRef(elem) {
+        const { validationRule, elemRef } = this.props;
+
         if (elem && this.groupRef !== elem) {
             this.groupRef = elem;
-            const { validationRule } = this.props;
+
+            if (elemRef) {
+                elemRef.current = elem;
+            }
 
             if (!validationRule || Object.keys(validationRule).length === 0) {
                 return;

--- a/packages/scandipwa/src/component/Form/Form.container.js
+++ b/packages/scandipwa/src/component/Form/Form.container.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 
 import FIELD_TYPE from 'Component/Field/Field.config';
-import { ChildrenType, MixType } from 'Type/Common.type';
+import { ChildrenType, MixType, RefType } from 'Type/Common.type';
 import { EventsType, FieldAttrType, ValidationRuleType } from 'Type/Field.type';
 import getFieldsData from 'Util/Form/Extract';
 import { validateGroup } from 'Util/Validator';
@@ -34,6 +34,7 @@ export class FormContainer extends PureComponent {
         onSubmit: PropTypes.func,
         onError: PropTypes.func,
         returnAsObject: PropTypes.bool,
+        elemRef: RefType,
 
         // Validation
         validationRule: ValidationRuleType,
@@ -59,7 +60,8 @@ export class FormContainer extends PureComponent {
         onError: null,
         children: [],
         returnAsObject: false,
-        mix: {}
+        mix: {},
+        elemRef: null
     };
 
     state = {
@@ -90,10 +92,14 @@ export class FormContainer extends PureComponent {
 
     // Adds validation event listener to field
     setRef(elem) {
-        const { validationRule } = this.props;
+        const { validationRule, elemRef } = this.props;
 
         if (elem && this.formRef !== elem) {
             this.formRef = elem;
+
+            if (elemRef) {
+                elemRef.current = elem;
+            }
 
             elem.addEventListener('reset', this.resetField.bind(this));
 

--- a/packages/scandipwa/src/component/Image/Image.component.js
+++ b/packages/scandipwa/src/component/Image/Image.component.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 
 import { MixType, RefType } from 'Type/Common.type';
+import { noopFn } from 'Util/Common';
 
 import {
     IMAGE_LOADED, IMAGE_LOADING, IMAGE_NOT_FOUND, IMAGE_NOT_SPECIFIED
@@ -72,7 +73,7 @@ export class Image extends PureComponent {
         ratio: 'square',
         mix: {},
         showIsLoading: false,
-        imageRef: () => {}
+        imageRef: noopFn
     };
 
     image = createRef();

--- a/packages/scandipwa/src/component/Image/Image.container.js
+++ b/packages/scandipwa/src/component/Image/Image.container.js
@@ -14,6 +14,7 @@ import { PureComponent } from 'react';
 
 import { IMAGE_HUNDRED_PERCENT } from 'Component/Image/Image.config';
 import { MixType, RefType } from 'Type/Common.type';
+import { noopFn } from 'Util/Common';
 
 import Image from './Image.component';
 
@@ -57,7 +58,7 @@ export class ImageContainer extends PureComponent {
         style: {},
         title: null,
         className: '',
-        imageRef: () => {},
+        imageRef: noopFn,
         isPlain: false,
         showIsLoading: false
     };

--- a/packages/scandipwa/src/component/ImageZoomPopup/ImageZoomPopup.container.js
+++ b/packages/scandipwa/src/component/ImageZoomPopup/ImageZoomPopup.container.js
@@ -17,6 +17,7 @@ import Popup from 'Component/Popup';
 import { hideActiveOverlay } from 'Store/Overlay/Overlay.action';
 import { showPopup } from 'Store/Popup/Popup.action';
 import { ChildrenType, MixType } from 'Type/Common.type';
+import { noopFn } from 'Util/Common';
 
 import ImageZoomPopup from './ImageZoomPopup.component';
 
@@ -46,7 +47,7 @@ export class ImageZoomPopupContainer extends PureComponent {
     };
 
     static defaultProps = {
-        onClose: () => {},
+        onClose: noopFn,
         mix: {}
     };
 

--- a/packages/scandipwa/src/component/Link/Link.component.js
+++ b/packages/scandipwa/src/component/Link/Link.component.js
@@ -17,6 +17,7 @@ import { stringify } from 'rebem-classname';
 
 import { ChildrenType, MixType } from 'Type/Common.type';
 import { LinkType } from 'Type/Router.type';
+import { noopFn } from 'Util/Common';
 
 /** @namespace Component/Link/Component */
 export class Link extends PureComponent {
@@ -32,7 +33,7 @@ export class Link extends PureComponent {
     static defaultProps = {
         bemProps: {},
         className: '',
-        onClick: () => {},
+        onClick: noopFn,
         isOpenInNewTab: false
     };
 

--- a/packages/scandipwa/src/component/Link/Link.container.js
+++ b/packages/scandipwa/src/component/Link/Link.container.js
@@ -16,6 +16,7 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import { LinkType } from 'Type/Router.type';
+import { noopFn } from 'Util/Common';
 import { appendWithStoreCode } from 'Util/Url';
 
 import Link from './Link.component';
@@ -47,7 +48,7 @@ export class LinkContainer extends PureComponent {
     };
 
     static defaultProps = {
-        onClick: () => {}
+        onClick: noopFn
     };
 
     containerFunctions = {

--- a/packages/scandipwa/src/component/MenuItem/MenuItem.component.js
+++ b/packages/scandipwa/src/component/MenuItem/MenuItem.component.js
@@ -18,6 +18,7 @@ import Link from 'Component/Link';
 import MinusIcon from 'Component/MinusIcon';
 import { ModsType } from 'Type/Common.type';
 import { MenuItemType } from 'Type/Menu.type';
+import { noopFn } from 'Util/Common';
 
 /** @namespace Component/MenuItem/Component */
 export class MenuItem extends PureComponent {
@@ -33,7 +34,7 @@ export class MenuItem extends PureComponent {
     };
 
     static defaultProps = {
-        onItemClick: () => {}
+        onItemClick: noopFn
     };
 
     renderPlusMinusIcon() {

--- a/packages/scandipwa/src/component/MenuItem/MenuItem.container.js
+++ b/packages/scandipwa/src/component/MenuItem/MenuItem.container.js
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
 import { ModsType } from 'Type/Common.type';
 import { MenuItemType } from 'Type/Menu.type';
 import { scrollToTop } from 'Util/Browser';
+import { noopFn } from 'Util/Common';
 import history from 'Util/History';
 
 import MenuItem from './MenuItem.component';
@@ -42,8 +43,8 @@ export class MenuItemContainer extends PureComponent {
     };
 
     static defaultProps = {
-        closeMenu: () => {},
-        onCategoryHover: () => {},
+        closeMenu: noopFn,
+        onCategoryHover: noopFn,
         itemMods: {},
         isLink: false,
         isExpandable: false

--- a/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.component.js
+++ b/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.component.js
@@ -21,6 +21,7 @@ import MyAccountForgotPasswordSuccess from 'Component/MyAccountForgotPasswordSuc
 import MyAccountSignIn from 'Component/MyAccountSignIn';
 import Overlay from 'Component/Overlay';
 import { SignInStateType } from 'Type/Account.type';
+import { noopFn } from 'Util/Common';
 
 import {
     CUSTOMER_ACCOUNT_OVERLAY_KEY,
@@ -74,7 +75,7 @@ export class MyAccountOverlay extends PureComponent {
             title: __('Create new account')
         },
         [STATE_LOGGED_IN]: {
-            render: () => {}
+            render: noopFn
         },
         [STATE_CONFIRM_EMAIL]: {
             render: () => this.renderConfirmEmail(),

--- a/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.js
+++ b/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.js
@@ -25,6 +25,7 @@ import { TOP_NAVIGATION_TYPE } from 'Store/Navigation/Navigation.reducer';
 import { showNotification } from 'Store/Notification/Notification.action';
 import { hideActiveOverlay, toggleOverlayByKey } from 'Store/Overlay/Overlay.action';
 import { isSignedIn } from 'Util/Auth';
+import { noopFn } from 'Util/Common';
 import history from 'Util/History';
 import { appendWithStoreCode } from 'Util/Url';
 
@@ -79,8 +80,8 @@ export class MyAccountOverlayContainer extends PureComponent {
     static defaultProps = {
         isCheckout: false,
         isLoading: false,
-        onSignIn: () => {},
-        goToPreviousHeaderState: () => {}
+        onSignIn: noopFn,
+        goToPreviousHeaderState: noopFn
     };
 
     containerFunctions = {

--- a/packages/scandipwa/src/component/MyAccountSignIn/MyAccountSignIn.container.js
+++ b/packages/scandipwa/src/component/MyAccountSignIn/MyAccountSignIn.container.js
@@ -14,6 +14,7 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import { showNotification } from 'Store/Notification/Notification.action';
+import { noopFn } from 'Util/Common';
 import transformToNameValuePair from 'Util/Form/Transform';
 import { getErrorMessage } from 'Util/Request';
 
@@ -58,8 +59,8 @@ export class MyAccountSignInContainer extends PureComponent {
     static defaultProps = {
         emailValue: '',
         isEmailAvailable: true,
-        setSignInState: () => {},
-        handleEmailInput: () => {}
+        setSignInState: noopFn,
+        handleEmailInput: noopFn
     };
 
     containerFunctions = {

--- a/packages/scandipwa/src/component/MyAccountTabList/MyAccountTabList.container.js
+++ b/packages/scandipwa/src/component/MyAccountTabList/MyAccountTabList.container.js
@@ -14,6 +14,7 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import { ActiveTabType, TabMapType } from 'Type/Account.type';
+import { noopFn } from 'Util/Common';
 
 import MyAccountTabList from './MyAccountTabList.component';
 
@@ -43,7 +44,7 @@ export class MyAccountTabListContainer extends PureComponent {
     };
 
     static defaultProps = {
-        onSignOut: () => {}
+        onSignOut: noopFn
     };
 
     containerFunctions = {

--- a/packages/scandipwa/src/component/Overlay/Overlay.component.js
+++ b/packages/scandipwa/src/component/Overlay/Overlay.component.js
@@ -17,6 +17,7 @@ import { createPortal } from 'react-dom';
 
 import { ChildrenType, MixType } from 'Type/Common.type';
 import { toggleScroll } from 'Util/Browser';
+import { noopFn } from 'Util/Common';
 
 import './Overlay.style';
 
@@ -38,9 +39,9 @@ export class Overlay extends PureComponent {
     static defaultProps = {
         mix: {},
         children: [],
-        onVisible: () => {},
+        onVisible: noopFn,
         isStatic: false,
-        onHide: () => {},
+        onHide: noopFn,
         isRenderInPortal: true
     };
 

--- a/packages/scandipwa/src/component/Popup/Popup.container.js
+++ b/packages/scandipwa/src/component/Popup/Popup.container.js
@@ -18,6 +18,7 @@ import { changeNavigationState, goToPreviousNavigationState } from 'Store/Naviga
 import { TOP_NAVIGATION_TYPE } from 'Store/Navigation/Navigation.reducer';
 import { hideActiveOverlay, hideActivePopup } from 'Store/Overlay/Overlay.action';
 import { ChildrenType, MixType } from 'Type/Common.type';
+import { noopFn } from 'Util/Common';
 
 import Popup from './Popup.component';
 
@@ -65,9 +66,9 @@ export class PopupContainer extends PureComponent {
     };
 
     static defaultProps = {
-        onVisible: () => {},
-        onClose: () => {},
-        onHide: () => {},
+        onVisible: noopFn,
+        onClose: noopFn,
+        onHide: noopFn,
         mix: {},
         contentMix: {},
         children: [],

--- a/packages/scandipwa/src/component/PopupSuspense/PopupSuspense.component.js
+++ b/packages/scandipwa/src/component/PopupSuspense/PopupSuspense.component.js
@@ -15,6 +15,7 @@ import { CART_OVERLAY } from 'Component/Header/Header.config';
 import Loader from 'Component/Loader';
 import { CUSTOMER_ACCOUNT_OVERLAY_KEY } from 'Component/MyAccountOverlay/MyAccountOverlay.config';
 import Overlay from 'Component/Overlay';
+import { noopFn } from 'Util/Common';
 
 import { OVERLAY_PLACEHOLDER } from './PopupSuspense.config';
 
@@ -35,7 +36,7 @@ export class PopupSuspense extends PureComponent {
     };
 
     static defaultProps = {
-        onVisible: () => {}
+        onVisible: noopFn
     };
 
     styleMap = {

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -19,6 +19,7 @@ import FIELD_TYPE from 'Component/Field/Field.config';
 import Html from 'Component/Html';
 import { MixType } from 'Type/Common.type';
 import { AttributeType } from 'Type/ProductList.type';
+import { noopFn } from 'Util/Common';
 import { getBooleanLabel } from 'Util/Product';
 
 import { STRING_ONLY_ATTRIBUTE_CODES } from './ProductAttributeValue.config';
@@ -41,8 +42,8 @@ export class ProductAttributeValue extends PureComponent {
 
     static defaultProps = {
         isSelected: false,
-        onClick: () => {},
-        getLink: () => {},
+        onClick: noopFn,
+        getLink: noopFn,
         mix: {},
         isAvailable: true,
         isFormattedAsText: false,
@@ -294,10 +295,6 @@ export class ProductAttributeValue extends PureComponent {
                   name: value,
                   defaultChecked: isSelected,
                   checked: isSelected
-              } }
-              events={ {
-                  // prevent console error that radio button should have onChange event handler or be readonly
-                  onChange: () => null
               } }
               label={ this.getCheckboxLabel(value, subLabel) }
               mix={ {

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -295,6 +295,10 @@ export class ProductAttributeValue extends PureComponent {
                   defaultChecked: isSelected,
                   checked: isSelected
               } }
+              events={ {
+                  // prevent console error that radio button should have onChange event handler or be readonly
+                  onChange: () => null
+              } }
               label={ this.getCheckboxLabel(value, subLabel) }
               mix={ {
                   block: 'ProductAttributeValue',

--- a/packages/scandipwa/src/component/ProductConfigurableAttributes/ProductConfigurableAttributes.container.js
+++ b/packages/scandipwa/src/component/ProductConfigurableAttributes/ProductConfigurableAttributes.container.js
@@ -18,6 +18,7 @@ import {
 } from 'Component/ProductConfigurableAttributes/ProductConfigurableAttributes.config';
 import { MixType } from 'Type/Common.type';
 import { AttributesType, ItemsType } from 'Type/ProductList.type';
+import { noopFn } from 'Util/Common';
 import { getBooleanLabel } from 'Util/Product';
 
 import ProductConfigurableAttributes from './ProductConfigurableAttributes.component';
@@ -39,7 +40,7 @@ export class ProductConfigurableAttributesContainer extends PureComponent {
     };
 
     static defaultProps = {
-        getLink: () => {},
+        getLink: noopFn,
         isExpandable: true,
         showProductAttributeAsLink: true,
         variants: null,

--- a/packages/scandipwa/src/component/ProductList/ProductList.component.js
+++ b/packages/scandipwa/src/component/ProductList/ProductList.component.js
@@ -19,6 +19,7 @@ import { MixType } from 'Type/Common.type';
 import { DeviceType } from 'Type/Device.type';
 import { PagesType } from 'Type/ProductList.type';
 import { scrollToTop } from 'Util/Browser';
+import { noopFn } from 'Util/Common';
 
 import { observerThreshold } from './ProductList.config';
 
@@ -56,10 +57,10 @@ export class ProductList extends PureComponent {
         isPaginationEnabled: false,
         selectedFilters: {},
         isLoading: false,
-        updatePage: () => {},
+        updatePage: noopFn,
         totalPages: 1,
-        loadPage: () => {},
-        loadPrevPage: () => {},
+        loadPage: noopFn,
+        loadPrevPage: noopFn,
         currentPage: 1,
         isShowLoading: false,
         isVisible: true,

--- a/packages/scandipwa/src/component/ProductListPage/ProductListPage.component.js
+++ b/packages/scandipwa/src/component/ProductListPage/ProductListPage.component.js
@@ -18,6 +18,7 @@ import { GRID_LAYOUT } from 'Route/CategoryPage/CategoryPage.config';
 import { FilterType } from 'Type/Category.type';
 import { MixType } from 'Type/Common.type';
 import { ProductType } from 'Type/ProductList.type';
+import { noopFn } from 'Util/Common';
 
 import { DEFAULT_PLACEHOLDER_COUNT } from './ProductListPage.config';
 
@@ -44,7 +45,7 @@ export class ProductListPage extends PureComponent {
 
     static defaultProps = {
         numberOfPlaceholders: DEFAULT_PLACEHOLDER_COUNT,
-        wrapperRef: () => {},
+        wrapperRef: noopFn,
         selectedFilters: {},
         pageNumber: null,
         items: [],

--- a/packages/scandipwa/src/component/ProductTab/ProductTab.component.js
+++ b/packages/scandipwa/src/component/ProductTab/ProductTab.component.js
@@ -12,6 +12,8 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
+import { noopFn } from 'Util/Common';
+
 import './ProductTab.style';
 
 /** @namespace Component/ProductTab/Component */
@@ -23,7 +25,7 @@ export class ProductTab extends PureComponent {
     };
 
     static defaultProps = {
-        onClick: () => {},
+        onClick: noopFn,
         isActive: false
     };
 

--- a/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
+++ b/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
@@ -18,6 +18,7 @@ import { showNotification } from 'Store/Notification/Notification.action';
 import { MixType } from 'Type/Common.type';
 import { MagentoProductType, ProductType } from 'Type/ProductList.type';
 import { isSignedIn } from 'Util/Auth';
+import { noopFn } from 'Util/Common';
 
 import ProductWishlistButton from './ProductWishlistButton.component';
 
@@ -60,7 +61,7 @@ export class ProductWishlistButtonContainer extends PureComponent {
 
     static defaultProps = {
         mix: {},
-        onProductValidationError: () => {}
+        onProductValidationError: noopFn
     };
 
     state = {

--- a/packages/scandipwa/src/component/RenderWhenVisible/RenderWhenVisible.component.js
+++ b/packages/scandipwa/src/component/RenderWhenVisible/RenderWhenVisible.component.js
@@ -16,6 +16,7 @@ import { InView } from 'react-intersection-observer';
 
 import { ChildrenType } from 'Type/Common.type';
 import { isCrawler, isSSR } from 'Util/Browser';
+import { noopFn } from 'Util/Common';
 
 import './RenderWhenVisible.style';
 
@@ -27,7 +28,7 @@ export class RenderWhenVisible extends PureComponent {
     };
 
     static defaultProps = {
-        fallback: () => {}
+        fallback: noopFn
     };
 
     state = {

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -24,6 +24,7 @@ import Loader from 'Component/Loader';
 import SearchIcon from 'Component/SearchIcon';
 import { DeviceType } from 'Type/Device.type';
 import { scrollToTop } from 'Util/Browser';
+import { noopFn } from 'Util/Common';
 import history from 'Util/History';
 import { appendWithStoreCode } from 'Util/Url';
 
@@ -54,7 +55,7 @@ export class SearchField extends PureComponent {
         isVisible: true,
         isActive: true,
         searchCriteria: '',
-        hideActiveOverlay: () => {}
+        hideActiveOverlay: noopFn
     };
 
     searchBarRef = createRef();

--- a/packages/scandipwa/src/component/Slider/Slider.component.js
+++ b/packages/scandipwa/src/component/Slider/Slider.component.js
@@ -17,6 +17,7 @@ import { LEFT, RIGHT } from 'Component/ChevronIcon/ChevronIcon.config';
 import Draggable from 'Component/Draggable';
 import { ChildrenType, MixType, RefType } from 'Type/Common.type';
 import { DeviceType } from 'Type/Device.type';
+import { noopFn } from 'Util/Common';
 import CSS from 'Util/CSS';
 import { isRtl } from 'Util/CSS/CSS';
 
@@ -55,7 +56,7 @@ export class Slider extends PureComponent {
 
     static defaultProps = {
         activeImage: 0,
-        onActiveImageChange: () => {},
+        onActiveImageChange: noopFn,
         showCrumbs: false,
         showArrows: false,
         isInteractionDisabled: false,

--- a/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.container.js
+++ b/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.container.js
@@ -16,6 +16,7 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import { ChildrenType, MixType } from 'Type/Common.type';
+import { noopFn } from 'Util/Common';
 
 import SwipeToDelete from './SwipeToDelete.component';
 import {
@@ -59,9 +60,9 @@ export class SwipeToDeleteContainer extends PureComponent {
         dragItemRemoveThreshold: DRAG_ITEM_REMOVE_THRESHOLD,
         animationDuration: ANIMATION_DURATION,
         animationDurationOnRemove: ANIMATION_DURATION_ON_REMOVE,
-        renderRightSideContent: () => {},
+        renderRightSideContent: noopFn,
         topElemMix: {},
-        onAheadOfDragItemRemoveThreshold: () => {},
+        onAheadOfDragItemRemoveThreshold: noopFn,
         isLoading: false
     };
 

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
@@ -21,6 +21,7 @@ import PRODUCT_TYPE from 'Component/Product/Product.config';
 import ProductCard from 'Component/ProductCard';
 import ProductReviewRating from 'Component/ProductReviewRating';
 import { ProductType } from 'Type/ProductList.type';
+import { noopFn } from 'Util/Common';
 
 import './WishlistItem.style';
 
@@ -41,11 +42,11 @@ export class WishlistItem extends PureComponent {
     };
 
     static defaultProps = {
-        addToCart: () => {},
-        changeQuantity: () => {},
-        changeDescription: () => {},
-        removeItem: () => {},
-        redirectToProductPage: () => {},
+        addToCart: noopFn,
+        changeQuantity: noopFn,
+        changeDescription: noopFn,
+        removeItem: noopFn,
+        redirectToProductPage: noopFn,
         isLoading: false
     };
 

--- a/packages/scandipwa/src/route/CartPage/CartPage.component.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.component.js
@@ -24,6 +24,7 @@ import ProductLinks from 'Component/ProductLinks';
 import { CROSS_SELL } from 'Store/LinkedProducts/LinkedProducts.reducer';
 import { DeviceType } from 'Type/Device.type';
 import { TotalsType } from 'Type/MiniCart.type';
+import { noopFn } from 'Util/Common';
 
 import './CartPage.style';
 
@@ -41,7 +42,7 @@ export class CartPage extends PureComponent {
 
     static defaultProps = {
         hasOutOfStockProductsInCart: false,
-        onCouponCodeUpdate: () => {},
+        onCouponCodeUpdate: noopFn,
         onCartItemLoading: null,
         isCartItemLoading: false
     };

--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -108,7 +108,7 @@ export class Checkout extends PureComponent {
         isPickInStoreMethodSelected: PropTypes.bool.isRequired,
         handleSelectDeliveryMethod: PropTypes.func.isRequired,
         isInStoreActivated: PropTypes.bool.isRequired,
-        cartTotalSubPrice: PropTypes.number.isRequired,
+        cartTotalSubPrice: PropTypes.number,
         onShippingMethodSelect: PropTypes.func.isRequired,
         onStoreSelect: PropTypes.func.isRequired,
         selectedStoreAddress: StoreType
@@ -117,7 +117,8 @@ export class Checkout extends PureComponent {
     static defaultProps = {
         paymentTotals: {},
         selectedStoreAddress: {},
-        isLoading: false
+        isLoading: false,
+        cartTotalSubPrice: null
     };
 
     stepMap = {

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -140,8 +140,12 @@ export class CheckoutContainer extends PureComponent {
         updateShippingPrice: PropTypes.func.isRequired,
         setHeaderState: PropTypes.func.isRequired,
         isMobile: PropTypes.bool.isRequired,
-        cartTotalSubPrice: PropTypes.number.isRequired,
+        cartTotalSubPrice: PropTypes.number,
         isInStoreActivated: PropTypes.bool.isRequired
+    };
+
+    static defaultProps = {
+        cartTotalSubPrice: null
     };
 
     containerFunctions = {

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
@@ -22,6 +22,7 @@ import { BOTTOM_NAVIGATION_TYPE, TOP_NAVIGATION_TYPE } from 'Store/Navigation/Na
 import { setBigOfflineNotice } from 'Store/Offline/Offline.action';
 import { toggleOverlayByKey } from 'Store/Overlay/Overlay.action';
 import { updateInfoLoadStatus } from 'Store/ProductListInfo/ProductListInfo.action';
+import { noopFn } from 'Util/Common';
 import { withReducers } from 'Util/DynamicReducer';
 import { debounce } from 'Util/Request';
 import { appendWithStoreCode } from 'Util/Url';
@@ -97,7 +98,7 @@ export class SearchPageContainer extends CategoryPageContainer {
     static defaultProps = {
         ...this.defaultProps,
         isSearchPage: true,
-        updateMetaFromCategory: () => {}
+        updateMetaFromCategory: noopFn
     };
 
     config = {

--- a/packages/scandipwa/src/util/Common/index.js
+++ b/packages/scandipwa/src/util/Common/index.js
@@ -1,0 +1,20 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+/**
+ * No-operate function.
+ * Can be used as a fallback if real function wasn't passed.
+ * In this case instead of creating empty function every time we can reuse existing.
+ * Examples: default props, argument default values.
+ * @namespace Util/Common/Index/noopFn
+ */
+export const noopFn = () => {};

--- a/packages/scandipwa/src/util/Request/DataContainer.js
+++ b/packages/scandipwa/src/util/Request/DataContainer.js
@@ -11,6 +11,7 @@
 
 import { PureComponent } from 'react';
 
+import { noopFn } from 'Util/Common';
 import { makeCancelable } from 'Util/Promise';
 import { prepareQuery } from 'Util/Query';
 import { executeGet } from 'Util/Request';
@@ -28,7 +29,7 @@ export class DataContainer extends PureComponent {
         }
     }
 
-    fetchData(rawQueries, onSuccess = () => {}, onError = () => {}) {
+    fetchData(rawQueries, onSuccess = noopFn, onError = noopFn) {
         const preparedQuery = prepareQuery(rawQueries);
         const { query, variables } = preparedQuery;
         const queryHash = hash(query + JSON.stringify(variables));


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3745

**Problem:**
* When we configure field with the `fieldMap`, it's not possible to set `ref` to an input element.

**In this PR:**
* Added ref support to field config.
* Fixed some console errors.
* Added translations.
