### PR TITLE
[3734] Arrow back centralized near title

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -155,6 +155,7 @@
                 .ChevronIcon {
                     width: 20px;
                     height: 20px;
+                    vertical-align: middle;
                 }
             }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3734 

**Problem:**
* svg was not centralized vertically inside the button

**In this PR:**
* added a vertical alignment
