### PR TITLE
[3531] Shifted error msg for confirm account page

### DIFF
--- a/packages/scandipwa/src/route/ConfirmAccountPage/ConfirmAccountPage.style.scss
+++ b/packages/scandipwa/src/route/ConfirmAccountPage/ConfirmAccountPage.style.scss
@@ -55,13 +55,15 @@
             align-items: flex-end;
             justify-content: center;
 
-            .Field-Message {
-                position: absolute;
-                width: max-content;
+            .Field {
+                &-ErrorMessages,
+                &-Message {
+                    position: absolute;
+                    width: max-content;
+                }
             }
         }
     }
-
     &-WarningMsg {
         padding-top: 20px;
         text-align: center;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3531

**Problem:**
* Due to display flex, when field contains error msg its container height changes, thus flex elements are not aligned correctly

**In this PR:**
* Moved error message to absolute position, same logic as in Message
