### PR TITLE
[3774] Fix Subscription Button Margin

### DIFF
--- a/packages/scandipwa/src/component/NewsletterSubscription/NewsletterSubscription.style.scss
+++ b/packages/scandipwa/src/component/NewsletterSubscription/NewsletterSubscription.style.scss
@@ -56,7 +56,7 @@
     }
 
     .Button {
-        margin-block-start: 32px;
+        margin-block-start: 24px;
         width: 100%;
     }
 }


### PR DESCRIPTION
Related issue(s):
- Fixes https://github.com/scandipwa/scandipwa/issues/3774

Problem:
- The margin from the top of the 'Subscribe' button is 32px in the footer section.

In this PR:
- I have changed the margin-top from 32px to 24px in the NewsletterSubscription.style.scss file.
