### PR TITLE
[3706] Fix Product Compare Attribute Style

### DIFF
--- a/packages/scandipwa/src/component/ProductCompareAttributeRow/ProductCompareAttributeRow.style.scss
+++ b/packages/scandipwa/src/component/ProductCompareAttributeRow/ProductCompareAttributeRow.style.scss
@@ -53,7 +53,6 @@
         padding-inline: var(--product-compare-item-gap) calc(var(--product-compare-item-gap) + var(--prouduct-compare-additional-gap));
         width: var(--product-compare-column-width);
         text-align: justify;
-        overflow: visible;
 
         img {
             height: auto;

--- a/packages/scandipwa/src/component/ProductCompareAttributeRow/ProductCompareAttributeRow.style.scss
+++ b/packages/scandipwa/src/component/ProductCompareAttributeRow/ProductCompareAttributeRow.style.scss
@@ -53,7 +53,7 @@
         padding-inline: var(--product-compare-item-gap) calc(var(--product-compare-item-gap) + var(--prouduct-compare-additional-gap));
         width: var(--product-compare-column-width);
         text-align: justify;
-        overflow: hidden;
+        overflow: visible;
 
         img {
             height: auto;


### PR DESCRIPTION
Related issue(s):
* Fixes https://github.com/scandipwa/scandipwa/issues/3706

Problem:
* The values of attributes are cut in Compare Page, like Capital letters and numbers.

In this PR:
* I have changed the overflow value from hidden to visible in ProductCompareAttributeRow.style.scss file.