### PR TITLE
[3769] Fix-Footer-Copyright-Links-Line-Height

### DIFF
--- a/packages/scandipwa/src/component/Footer/Footer.style.scss
+++ b/packages/scandipwa/src/component/Footer/Footer.style.scss
@@ -45,6 +45,7 @@
         text-align: center;
         color: var(--secondary-dark-color);
         padding-inline: 16px;
+        line-height: 16px;
 
         a {
             color: inherit;

--- a/packages/scandipwa/src/component/Footer/Footer.style.scss
+++ b/packages/scandipwa/src/component/Footer/Footer.style.scss
@@ -129,6 +129,7 @@
         margin-block-end: 12px;
         font-size: 14px;
         font-weight: 400;
+        line-height: 20px;
 
         &:last-of-type {
             margin: 0;

--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -105,7 +105,6 @@
                 &_main {
                     @include desktop {
                         margin: 0 0 16px;
-                        line-height: 20px;
                     }
 
                     text-transform: uppercase;

--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -105,6 +105,7 @@
                 &_main {
                     @include desktop {
                         margin: 0 0 16px;
+                        line-height: 20px;
                     }
 
                     text-transform: uppercase;


### PR DESCRIPTION
Related issue(s):
* Fixes https://github.com/scandipwa/scandipwa/issues/3769

Problem:
* Line-height differ from Line-height in mockup:
- Copyright in Footer
- links on pages (about, men and other)

In this PR:
* I have changed the line-height in Footer.style.scss to fix the style of links and copy-right section.
