### PR TITLE
[3373] Fix Height of field of Newsletter

### DIFF
--- a/packages/scandipwa/src/component/NewsletterSubscription/NewsletterSubscription.style.scss
+++ b/packages/scandipwa/src/component/NewsletterSubscription/NewsletterSubscription.style.scss
@@ -36,6 +36,7 @@
                 input {
                     background-color: var(--newsletter-subscription-input-background);
                     padding: 14px 12px;
+                    height: 44.6px;
 
                     &::placeholder {
                         color: var(--newsletter-subscription-placeholder-color);


### PR DESCRIPTION
Related issue(s):
* Fixes https://github.com/scandipwa/scandipwa/issues/3773

Problem:
* Height of field for entering email in the footer in Newsletter is not the same as other input fields = 43.6px

In this PR:
* I have changed the height of the input field in the NewsletterSubscription.style.scss file to 44.6px.
