### PR TITLE
[3737] Fix Font Settings on PDP

### DIFF
--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -47,7 +47,7 @@
 
         span:nth-child(2),
         p {
-            margin-top: -8px;
+            line-height: 16px;
         }
     }
 

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -34,7 +34,7 @@
 
 .ProductActions {
     line-height: 16px;
-    
+
     &-Brand {
         font-weight: bold;
         opacity: .48;

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -44,6 +44,11 @@
 
     &-Price {
         line-height: var(--h2-line-height);
+
+        span:nth-child(2),
+        p {
+            margin-top: -8px;
+        }
     }
 
     &-Title {

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -47,7 +47,7 @@
 
         span:nth-child(2),
         p {
-            line-height: 16px;
+            line-height: 12px;
         }
     }
 

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -42,6 +42,10 @@
         line-height: 16px;
     }
 
+    &-Price {
+        line-height: 28px;
+    }
+
     &-Title {
         margin-block: 8px;
 

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -44,10 +44,6 @@
     &-Title {
         margin-block: 8px;
 
-        @include desktop {
-            line-height: 40px;
-        }
-
         @include mobile {
             font-weight: 400;
             font-size: 14px;

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -39,6 +39,7 @@
         font-weight: bold;
         opacity: .48;
         font-size: 12px;
+        line-height: 16px;
     }
 
     &-Title {

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -43,7 +43,7 @@
     }
 
     &-Price {
-        line-height: 28px;
+        line-height: var(--h2-line-height);
     }
 
     &-Title {

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -42,14 +42,14 @@
         line-height: 16px;
     }
 
-    &-Price {
-        line-height: var(--h2-line-height);
+    // &-Price {
+    //     line-height: var(--h2-line-height);
 
-        span:nth-child(2),
-        p {
-            line-height: 12px;
-        }
-    }
+    //     span:nth-child(2),
+    //     p {
+    //         line-height: 12px;
+    //     }
+    // }
 
     &-Title {
         margin-block: 8px;

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -42,14 +42,7 @@
         line-height: 16px;
     }
 
-    // &-Price {
-    //     line-height: var(--h2-line-height);
-
-    //     span:nth-child(2),
-    //     p {
-    //         line-height: 12px;
-    //     }
-    // }
+    
 
     &-Title {
         margin-block: 8px;

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -34,7 +34,7 @@
 
 .ProductActions {
     line-height: 16px;
-
+    
     &-Brand {
         font-weight: bold;
         opacity: .48;

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -42,8 +42,6 @@
         line-height: 16px;
     }
 
-    
-
     &-Title {
         margin-block: 8px;
 

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
@@ -146,16 +146,11 @@
     }
 
     &-Name {
-        line-height: var(--product-card-name-line-height);
         margin: 5px 0;
         padding-block-end: 2px;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-
-        @include desktop {
-            line-height: 1.3;
-        }
     }
 
     &-Brand {

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
@@ -19,7 +19,6 @@
     --product-card-wishlist-button-color: #d8d5d5;
     --product-card-compare-button-background: var(--product-card-wishlist-button-background);
     --product-card-compare-button-color: var(--product-card-wishlist-button-color);
-    --product-card-name-line-height: 1.2em;
     --product-card-name-max-rows: 2;
     --product-card-brand-line-height: 1.2em;
     --product-card-color-size: 32px;

--- a/packages/scandipwa/src/component/ProductLinks/ProductLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductLinks/ProductLinks.style.scss
@@ -42,6 +42,8 @@
     }
 
     &-Title {
+        font-weight: bold;
+
         @include mobile {
             padding-block-start: 4px;
             padding-block-end: 18px;

--- a/packages/scandipwa/src/component/ProductLinks/ProductLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductLinks/ProductLinks.style.scss
@@ -42,8 +42,6 @@
     }
 
     &-Title {
-        line-height: 1;
-
         @include mobile {
             padding-block-start: 4px;
             padding-block-end: 18px;
@@ -54,7 +52,6 @@
             padding-block-start: 12px;
             padding-block-end: 36px;
             padding-inline: 0;
-            font-weight: bold;
         }
     }
 

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
@@ -13,7 +13,7 @@
     --price-color: #{$black};
     --price-with-discount-color: #b10d0d;
     --price-discount-color: #808080;
-    --price-discout-new-color: #0a0903;
+    --price-discount-new-color: #0a0903;
 }
 
 .ProductPrice {
@@ -42,14 +42,13 @@
     del {
         font-size: 14px;
         font-weight: 500;
-        opacity: .5;
+        opacity: .48;
         display: inline-block;
         margin-inline-end: 12px;
     }
 
     &-HighPrice {
         color: var(--price-discount-new-color);
-        opacity: 0.48;
         line-height: 18px;
     }
 

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
@@ -48,7 +48,7 @@
     }
 
     &-HighPrice {
-        color: var(-price-discount-new-color);
+        color: var(--price-discount-new-color);
         line-height: 18px;
     }
 

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
@@ -13,13 +13,14 @@
     --price-color: #{$black};
     --price-with-discount-color: #b10d0d;
     --price-discount-color: #808080;
+    --price-discout-new-color: #0a0903;
 }
 
 .ProductPrice {
     color: var(--price-color);
     font-weight: 700;
     font-size: 24px;
-    line-height: 1;
+    line-height: var(--h2-line-height);
     vertical-align: middle;
     margin-block-end: 0;
 
@@ -47,7 +48,8 @@
     }
 
     &-HighPrice {
-        color: var(--price-discount-color);
+        color: var(--price-discount-new-color);
+        opacity: 0.48;
         line-height: 18px;
     }
 

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
@@ -48,7 +48,7 @@
     }
 
     &-HighPrice {
-        color: var(--price-discount-new-color);
+        color: var(-price-discount-new-color);
         line-height: 18px;
     }
 

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
@@ -13,7 +13,6 @@
     --price-color: #{$black};
     --price-with-discount-color: #b10d0d;
     --price-discount-color: #808080;
-    --price-discount-new-color: #0a0903;
 }
 
 .ProductPrice {
@@ -48,7 +47,7 @@
     }
 
     &-HighPrice {
-        color: var(--price-discount-new-color);
+        color: var(--price-color);
         line-height: 18px;
     }
 
@@ -65,15 +64,6 @@
                     margin-block-end: -5px;
                 }
             }
-        }
-    }
-
-
-    &-RegularPrice {
-        margin-block-start: 5px;
-
-        &, strong {
-            color: var(--price-discount-color);
         }
     }
 

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
@@ -20,7 +20,7 @@
     color: var(--price-color);
     font-weight: 700;
     font-size: 24px;
-    line-height: var(--h2-line-height);
+    line-height: 1;
     vertical-align: middle;
     margin-block-end: 0;
 

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
@@ -87,6 +87,7 @@
         display: block;
         font-weight: 400;
         font-size: 12px;
+        line-height: 16px;
         margin-block-start: 4px;
     }
 

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
@@ -20,8 +20,8 @@
     color: var(--price-color);
     font-weight: 700;
     font-size: 24px;
-    line-height: 1;
     vertical-align: middle;
+    line-height: 28px;
     margin-block-end: 0;
 
     @include desktop {

--- a/packages/scandipwa/src/component/ProductReviewRating/ProductReviewRating.style.scss
+++ b/packages/scandipwa/src/component/ProductReviewRating/ProductReviewRating.style.scss
@@ -21,6 +21,7 @@
 
 .ProductReviewRating {
     display: flex;
+    align-items: flex-end;
     line-height: normal;
 
     &_isLoading {

--- a/packages/scandipwa/src/component/ProductReviewRating/ProductReviewRating.style.scss
+++ b/packages/scandipwa/src/component/ProductReviewRating/ProductReviewRating.style.scss
@@ -21,7 +21,6 @@
 
 .ProductReviewRating {
     display: flex;
-    align-items: flex-end;
     line-height: normal;
 
     &_isLoading {

--- a/packages/scandipwa/src/component/ProductReviews/ProductReviews.style.scss
+++ b/packages/scandipwa/src/component/ProductReviews/ProductReviews.style.scss
@@ -54,6 +54,7 @@
 
         .ProductReviewRating {
             align-items: center;
+            margin-top: -5px;
         }
     }
 

--- a/packages/scandipwa/src/component/ProductReviews/ProductReviews.style.scss
+++ b/packages/scandipwa/src/component/ProductReviews/ProductReviews.style.scss
@@ -51,6 +51,10 @@
         &_isContentExpanded {
             padding-block-start: 0;
         }
+
+        .ProductReviewRating {
+            align-items: center;
+        }
     }
 
     & &-Button {

--- a/packages/scandipwa/src/component/ProductReviews/ProductReviews.style.scss
+++ b/packages/scandipwa/src/component/ProductReviews/ProductReviews.style.scss
@@ -77,7 +77,7 @@
         margin-inline-start: 12px;
         margin-block: auto;
         font-size: 24px;
-        font-weight: bold;
+        font-weight: 700px;
         line-height: 28px;
         font-style: normal;
 

--- a/packages/scandipwa/src/component/ProductReviews/ProductReviews.style.scss
+++ b/packages/scandipwa/src/component/ProductReviews/ProductReviews.style.scss
@@ -77,7 +77,7 @@
         margin-inline-start: 12px;
         margin-block: auto;
         font-size: 24px;
-        font-weight: 700px;
+        font-weight: 700;
         line-height: 28px;
         font-style: normal;
 

--- a/packages/scandipwa/src/component/ProductReviews/ProductReviews.style.scss
+++ b/packages/scandipwa/src/component/ProductReviews/ProductReviews.style.scss
@@ -71,8 +71,11 @@
         display: inline-block;
         margin-inline-start: 12px;
         margin-block: auto;
-        font-size: 24px;
-        font-weight: 700;
+        font-size: var(--h2-font-size);
+        font-weight: var(--h2-font-weight);
+        line-height: var(--h2-line-height);
+        text-transform: var(--h2-text-transform);
+        font-style: var(--h2-font-style);
 
         @include mobile {
             margin-inline-start: 14px;

--- a/packages/scandipwa/src/component/ProductReviews/ProductReviews.style.scss
+++ b/packages/scandipwa/src/component/ProductReviews/ProductReviews.style.scss
@@ -76,11 +76,10 @@
         display: inline-block;
         margin-inline-start: 12px;
         margin-block: auto;
-        font-size: var(--h2-font-size);
-        font-weight: var(--h2-font-weight);
-        line-height: var(--h2-line-height);
-        text-transform: var(--h2-text-transform);
-        font-style: var(--h2-font-style);
+        font-size: 24px;
+        font-weight: bold;
+        line-height: 28px;
+        font-style: normal;
 
         @include mobile {
             margin-inline-start: 14px;


### PR DESCRIPTION
Related issue(s):
* Fixes https://github.com/scandipwa/scandipwa/issues/3737

**Problem:**
* Issue 1 - Line-height from H1 should be inherited for product name
* Issue 2 - Product name of related products don't use Line-height: var(--paragraph-line-height)
* Issue 3 - Wrong line-height for brand = 20px
* Issue 4 - Text '{rate} / {numberOfReviews} reviews' doesn't use h2 styles
* Issue 5 - Title for Related and upsells products doesn't inherit line-height and font-weight for h2
* Issue 6 - Price doesn't use style for h2 Line-height 1
* Issue 7 - Wrong color for product price before discount

In this PR:
* I have removed the Line-height styling of product name from ProductActions.style.scss to allow it to use the styling of H1
* I have changed the the value of the line-height of product name of related products to --paragraph-line-height.
* I have changed the line-height value of .ProductActions-Brand class in ProductActions.style.scss to 16px
* I have changed the font styling values of .ProductReviews-SummaryDetails in ProductReviews.style.scss to match the needed values.
* I have removed line-height styling for .ProductLinks-Title class from ProductLinks.style.scss file.
* I have changed the line-height value for .ProductLinks-Title class in file ProductLinks.style.scss to be var(--h2-line-height) which 28px.
* I have added new variable --price-discout-new-color: #0a0903; with the new color hex code and changed color and opacity styling for ProductPrice-HighPrice class in ProductPrice.style.scss file.
