### PR TITLE
[3680] Fix Text Shifted Up On Mobile

### DIFF
--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -73,7 +73,7 @@
 
     &-SampleTitle {
         flex: 1;
-        margin:auto;
+        margin: auto;
     }
 
     &-SampleLink {

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -73,7 +73,6 @@
 
     &-SampleTitle {
         flex: 1;
-        // removed top
         margin:auto;
     }
 

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -73,7 +73,7 @@
 
     &-SampleTitle {
         flex: 1;
-        top: 3px;
+        margin:auto;
     }
 
     &-SampleLink {

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -73,6 +73,7 @@
 
     &-SampleTitle {
         flex: 1;
+        margin: auto;
     }
 
     &-SampleLink {

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -73,7 +73,7 @@
 
     &-SampleTitle {
         flex: 1;
-        margin: auto;
+        top: 3px;
     }
 
     &-SampleLink {

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -73,6 +73,7 @@
 
     &-SampleTitle {
         flex: 1;
+        // removed top
         margin:auto;
     }
 

--- a/packages/scandipwa/src/component/ProductDownloadableSamples/ProductDownloadableSamples.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableSamples/ProductDownloadableSamples.style.scss
@@ -17,7 +17,6 @@
     &-Title {
         font-weight: bold;
         margin-block-end: 5px;
-
         @include mobile {
             display: none;
         }

--- a/packages/scandipwa/src/component/ProductDownloadableSamples/ProductDownloadableSamples.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableSamples/ProductDownloadableSamples.style.scss
@@ -17,6 +17,7 @@
     &-Title {
         font-weight: bold;
         margin-block-end: 5px;
+        
         @include mobile {
             display: none;
         }

--- a/packages/scandipwa/src/component/ProductDownloadableSamples/ProductDownloadableSamples.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableSamples/ProductDownloadableSamples.style.scss
@@ -17,7 +17,7 @@
     &-Title {
         font-weight: bold;
         margin-block-end: 5px;
-        
+
         @include mobile {
             display: none;
         }


### PR DESCRIPTION
Related issue(s):
* Fixes https://github.com/scandipwa/scandipwa/issues/3680

Problem:
* Mobile: Text is shifted up in checkboxes on PDP.

In this PR:
* I have added margin: auto; to ProductDownloadableLink-SampleTitle class in ProductDownloadableLinks.style.scss file.
