### PR TITLE
[3727] Fix line height for element on menu

### DIFF
--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -21,6 +21,11 @@ $select-arrow-width: 14px !default;
     &-Clickable {
         display: flex;
         align-items: center;
+
+        #storeSwitcher,
+        #CurrencySwitcherList {
+            line-height: 20px;
+        }
     }
 
     .ChevronIcon {

--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -113,6 +113,8 @@
                 }
 
                 &_subcategory {
+                    line-height: 20px;
+
                     @include mobile {
                         margin-inline-end: 0;
                     }

--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -109,6 +109,7 @@
 
                     text-transform: uppercase;
                     font-weight: 700;
+                    line-height: 20px;
                 }
 
                 &_subcategory {

--- a/packages/scandipwa/src/component/StoreSwitcher/StoreSwitcher.style.scss
+++ b/packages/scandipwa/src/component/StoreSwitcher/StoreSwitcher.style.scss
@@ -35,7 +35,7 @@
                 font-weight: 400;
                 opacity: 1;
                 padding-inline-start: 0;
-                line-height: 23px;
+                line-height: 20px;
             }
 
             &::after {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3727

**Problem:**
* Wrong line-height for some element in header on mobile:
       - For store and currency dropdowns: Line-Height 23px
       - For categories items in menu: Line-Height 16px

**In this PR:**
* I have added line-height: 20px; in FieldSelect.style.scss file to storeSwitcher and CurrencySwitcherList IDs.
* I have added line-height: 20px; in Menu.style.scss for Menu-ItemCaption_type_main class.