### PR TITLE
#3791 Increased padding for order total

### DIFF
--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.style.scss
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.style.scss
@@ -140,7 +140,7 @@
         justify-content: space-between;
         padding-block-start: 12px;
         padding-block-end: 6px;
-        padding-inline: 12px;
+        padding-inline: 16px;
 
         background: var(--cart-overlay-totals-background);
 

--- a/packages/scandipwa/src/route/CartPage/CartPage.style.scss
+++ b/packages/scandipwa/src/route/CartPage/CartPage.style.scss
@@ -202,8 +202,7 @@
     }
 
     &-Heading {
-        margin-block-start: 24px;
-        margin-block-end: 18px;
+        margin-block: 24px;
 
         @include mobile {
             display: none;

--- a/packages/scandipwa/src/route/CartPage/CartPage.style.scss
+++ b/packages/scandipwa/src/route/CartPage/CartPage.style.scss
@@ -193,7 +193,7 @@
         @include desktop {
             display: flex;
             flex-direction: column;
-            margin-block-start: 78px;
+            margin-block-start: 86px;
         }
 
         @include tablet {

--- a/packages/scandipwa/src/route/Checkout/Checkout.style.scss
+++ b/packages/scandipwa/src/route/Checkout/Checkout.style.scss
@@ -83,7 +83,8 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding-block: 10px;
+        padding-block-start: 10px;
+        padding-block-end: 24px;
     }
 
     &-StepBarTotal {


### PR DESCRIPTION
Increased padding for order total to match padding around buttons

**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3791
* Fixes https://github.com/scandipwa/scandipwa/issues/3793

**Problem:**
* Order total is not in line with cart buttons at the bottom
* Distance from the bottom of title on cart, shipping, billing page is wrong

**In this PR:**
* Changed order total padding to match padding around cart buttons
* Changed margins and paddings from the bottom of title on cart, shipping and billing page
