### PR TITLE
 [3770] Made footer social media icon edges rounded

### DIFF
--- a/packages/scandipwa/src/component/Footer/Footer.style.scss
+++ b/packages/scandipwa/src/component/Footer/Footer.style.scss
@@ -125,6 +125,7 @@
     }
 
     &-ColumnItem {
+        border-radius: 7%;
         color: inherit;
         margin-block-end: 12px;
         font-size: 14px;

--- a/packages/scandipwa/src/component/Footer/Footer.style.scss
+++ b/packages/scandipwa/src/component/Footer/Footer.style.scss
@@ -125,7 +125,7 @@
     }
 
     &-ColumnItem {
-        border-radius: 7%;
+        border-radius: 2px;
         color: inherit;
         margin-block-end: 12px;
         font-size: 14px;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3770

**Problem:**
* Social media icons were not rounded

**In this PR:**
* Added border radius property to social media icons
