### PR TITLE
[3815] Added coupon code name to cart overlay and cart page

### DIFF
--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.style.scss
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.style.scss
@@ -39,6 +39,7 @@
 
     &-Input {
         display: inline-block;
+        margin-right: 24px;
 
         input {
             width: 296px;

--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.style.scss
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.style.scss
@@ -20,6 +20,8 @@
     }
 
     &-Message {
+        word-break: break-word;
+        margin-right: 24px;
         display: inline-block;
     }
 
@@ -67,8 +69,6 @@
 
     &-Button {
         @include button;
-
-        margin-inline-start: 24px;
 
         @include mobile {
             width: 100%;

--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.style.scss
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.style.scss
@@ -21,7 +21,7 @@
 
     &-Message {
         word-break: break-word;
-        margin-right: 24px;
+        margin-inline-end: 24px;
         display: inline-block;
     }
 
@@ -39,7 +39,7 @@
 
     &-Input {
         display: inline-block;
-        margin-right: 24px;
+        margin-inline-end: 24px;
 
         input {
             width: 296px;

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -161,7 +161,7 @@ export class CartOverlay extends PureComponent {
     }
 
     renderCouponCode = (code) => (
-        <strong block="CartOverlay" elem="DiscountCoupon">{ `${code}:` }</strong>
+        <strong block="CartOverlay" elem="DiscountCoupon">{ `${code.toUpperCase()}:` }</strong>
     );
 
     renderDiscount() {

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -161,7 +161,7 @@ export class CartOverlay extends PureComponent {
     }
 
     renderCouponCode = (code) => (
-        <strong block="CartOverlay" elem="DiscountCoupon">{ code }</strong>
+        <strong block="CartOverlay" elem="DiscountCoupon">{ `${code}:` }</strong>
     );
 
     renderDiscount() {
@@ -177,14 +177,17 @@ export class CartOverlay extends PureComponent {
             return null;
         }
 
-        const label = coupon_code ? __('Coupon code discount: ') : __('Discount: ');
+        const label = coupon_code ? __('Coupon code discount ') : __('Discount: ');
 
         return (
             <dl
               block="CartOverlay"
               elem="Discount"
             >
-                <dt>{ label }</dt>
+                <dt>
+                    { label }
+                    { this.renderCouponCode(coupon_code) }
+                </dt>
                 <dd>{ `-${this.renderPriceLine(Math.abs(discount_amount))}` }</dd>
             </dl>
         );

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.style.scss
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.style.scss
@@ -156,6 +156,7 @@
             display: flex;
             flex-direction: column;
             justify-content: flex-end;
+            white-space: nowrap;
 
             span {
                 display: block;

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.style.scss
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.style.scss
@@ -136,6 +136,7 @@
     &-Total,
     &-Tax,
     &-Discount {
+        word-wrap: break-word;
         display: flex;
         justify-content: space-between;
         padding-block-start: 12px;
@@ -152,6 +153,9 @@
 
         dd {
             text-align: end;
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-end;
 
             span {
                 display: block;
@@ -159,6 +163,10 @@
                 font-weight: 400;
             }
         }
+    }
+
+    &-DiscountCoupon {
+        word-break: break-word;
     }
 
     &-Total {

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -108,8 +108,8 @@ export class CheckoutOrderSummary extends PureComponent {
         }
 
         const label = coupon_code ? __('Coupon code discount') : __('Discount');
-
-        return this.renderPriceLine(-Math.abs(discount_amount), label);
+        const mods = { couponCode: coupon_code };
+        return this.renderPriceLine(-Math.abs(discount_amount), label, mods);
     }
 
     renderItems() {

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -77,11 +77,7 @@ export class CheckoutOrderSummary extends PureComponent {
     }
 
     renderItem = (item) => {
-        const {
-            totals: {
-                quote_currency_code
-            }
-        } = this.props;
+        const { totals: { quote_currency_code } } = this.props;
 
         const { item_id } = item;
 
@@ -108,8 +104,14 @@ export class CheckoutOrderSummary extends PureComponent {
         }
 
         const label = coupon_code ? __('Coupon code discount') : __('Discount');
-        const mods = { couponCode: coupon_code };
-        return this.renderPriceLine(-Math.abs(discount_amount), label, mods);
+        const discount = -Math.abs(discount_amount);
+        return (
+            <CheckoutOrderSummaryPriceLine
+              price={ discount }
+              title={ label }
+              coupon_code={ coupon_code }
+            />
+        );
     }
 
     renderItems() {

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
@@ -228,10 +228,8 @@
         flex-direction: column;
         justify-content: flex-end;
         text-align: end;
+        white-space: nowrap;
 
-        strong {
-            white-space: nowrap;
-        }
     }
 
     &-AppendedContent {

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
@@ -227,8 +227,11 @@
         display: flex;
         flex-direction: column;
         justify-content: flex-end;
-        word-break: normal;
         text-align: end;
+
+        strong {
+            white-space: nowrap;
+        }
     }
 
     &-AppendedContent {

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
@@ -211,7 +211,8 @@
     }
 
     &-Text {
-        text-align: end;
+        flex-direction: column;
+        word-break: break-word;
         margin-block-end: 0;
 
         span {
@@ -219,6 +220,15 @@
             font-size: 12px;
             font-weight: 400;
         }
+    }
+
+    &-Price {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+        word-break: normal;
+        text-align: end;
     }
 
     &-AppendedContent {

--- a/packages/scandipwa/src/component/CheckoutOrderSummaryPriceLine/CheckoutOrderSummaryPriceLine.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummaryPriceLine/CheckoutOrderSummaryPriceLine.component.js
@@ -21,6 +21,7 @@ export class CheckoutOrderSummaryPriceLine extends PureComponent {
         price: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
         currency: PropTypes.string.isRequired,
         title: PropTypes.string.isRequired,
+        coupon_code: PropTypes.string.isRequired,
         mods: ModsType,
         subPrice: PropTypes.node,
         children: ChildrenType
@@ -57,23 +58,27 @@ export class CheckoutOrderSummaryPriceLine extends PureComponent {
     }
 
     renderTitle() {
-        const { title, mods: { couponCode } } = this.props;
+        const { title } = this.props;
 
-        if (couponCode) {
-            return (
-            <p block="CheckoutOrderSummary" elem="Text">
-                { title }
-                <b>
-                    { ` ${ couponCode.toUpperCase() }:` }
-                </b>
-            </p>
-            );
+        return (
+        <p block="CheckoutOrderSummary" elem="Text">
+            { title }
+            { this.renderCoupon() }
+        </p>
+        );
+    }
+
+    renderCoupon() {
+        const { coupon_code } = this.props;
+
+        if (!coupon_code) {
+            return null;
         }
 
         return (
-            <p block="CheckoutOrderSummary" elem="Text">
-                { title }
-            </p>
+        <b>
+            { ` ${ coupon_code.toUpperCase() }:` }
+        </b>
         );
     }
 

--- a/packages/scandipwa/src/component/CheckoutOrderSummaryPriceLine/CheckoutOrderSummaryPriceLine.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummaryPriceLine/CheckoutOrderSummaryPriceLine.component.js
@@ -52,10 +52,30 @@ export class CheckoutOrderSummaryPriceLine extends PureComponent {
         );
     }
 
+    renderTitle() {
+        const { title, mods: { couponCode } } = this.props;
+
+        if (couponCode) {
+            return (
+            <p block="CheckoutOrderSummary" elem="Text">
+                { title }
+                <b>
+                    { ` ${ couponCode }:` }
+                </b>
+            </p>
+            );
+        }
+
+        return (
+            <p block="CheckoutOrderSummary" elem="Text">
+                { title }
+            </p>
+        );
+    }
+
     render() {
         const {
             price,
-            title,
             mods,
             children
         } = this.props;
@@ -66,9 +86,7 @@ export class CheckoutOrderSummaryPriceLine extends PureComponent {
 
         return (
             <li block="CheckoutOrderSummary" elem="SummaryItem" mods={ mods }>
-                <p block="CheckoutOrderSummary" elem="Text">
-                    { title }
-                </p>
+                { this.renderTitle() }
                 <strong block="CheckoutOrderSummary" elem="Text">
                     { this.renderPrice() }
                     { this.renderSubPrice() }

--- a/packages/scandipwa/src/component/CheckoutOrderSummaryPriceLine/CheckoutOrderSummaryPriceLine.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummaryPriceLine/CheckoutOrderSummaryPriceLine.component.js
@@ -35,7 +35,11 @@ export class CheckoutOrderSummaryPriceLine extends PureComponent {
     renderPrice() {
         const { price, currency } = this.props;
 
-        return formatPrice(price, currency);
+        return (
+            <strong>
+                { formatPrice(price, currency) }
+            </strong>
+        );
     }
 
     renderSubPrice() {
@@ -60,7 +64,7 @@ export class CheckoutOrderSummaryPriceLine extends PureComponent {
             <p block="CheckoutOrderSummary" elem="Text">
                 { title }
                 <b>
-                    { ` ${ couponCode }:` }
+                    { ` ${ couponCode.toUpperCase() }:` }
                 </b>
             </p>
             );
@@ -87,10 +91,12 @@ export class CheckoutOrderSummaryPriceLine extends PureComponent {
         return (
             <li block="CheckoutOrderSummary" elem="SummaryItem" mods={ mods }>
                 { this.renderTitle() }
-                <strong block="CheckoutOrderSummary" elem="Text">
-                    { this.renderPrice() }
+                <div block="CheckoutOrderSummary" elem="Price">
+                    <strong>
+                        { this.renderPrice() }
+                    </strong>
                     { this.renderSubPrice() }
-                </strong>
+                </div>
                 { children }
             </li>
         );


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3815

**Problem:**
* Coupon name wasn't showing on discount line

**In this PR:**
* Added coupon name to discount line on cart overlay and cart page
