### PR TITLE
3771/Fixed long category names go over the button on Homepage

### DIFF
--- a/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
+++ b/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
@@ -73,5 +73,8 @@
 
     a {
         display: block;
+        .Button {
+            flex-wrap: wrap;
+        }
     }
 }


### PR DESCRIPTION
Adding flex-wrap styling to the button container so the text will stay in the box when too long

Related issue(s):

- Fixes #3771 

Problem:

- Long category names do not stay within the button box on the Homepage

In this PR:

- Added flex-wrap styling so the text will stay within the button

