### PR TITLE
3800/Set fixed high for date/time field to 44.6px on PDP

### DIFF
--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
@@ -40,6 +40,7 @@
                     input {
                         max-width: 100%;
                         width: 250px;
+                        height: 44.6px;
                     }
                 }
             }

--- a/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
+++ b/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
@@ -44,7 +44,7 @@
 
     &-Figcaption {
         --button-color: var(--color-white);
-        // --button-padding: 40px;
+        --button-padding: 40px;
         --hollow-button-background: var(--color-white);
         --hollow-button-hover-background: var(--color-white);
 

--- a/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
+++ b/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
@@ -44,7 +44,7 @@
 
     &-Figcaption {
         --button-color: var(--color-white);
-        --button-padding: 40px;
+        // --button-padding: 40px;
         --hollow-button-background: var(--color-white);
         --hollow-button-hover-background: var(--color-white);
 
@@ -75,6 +75,7 @@
         display: block;
         .Button {
             flex-wrap: wrap;
+            height: fit-content;
         }
     }
 }

--- a/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
+++ b/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
@@ -73,5 +73,8 @@
 
     a {
         display: block;
+        .Button {
+            flex-wrap: wrap;
+        }
     }
 }


### PR DESCRIPTION
Set fixed high for date/time field to 44.6px on PDP
Related issue(s):

- Fixes #3800

Problem:

- Wrong date/time field's height on PDP

In this PR:

- Fixed date/time field height to 44.6px on PDP
