### PR TITLE
[3765] Force centering file input label

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -241,6 +241,8 @@
                 &_isValid {
                     input {
                         & + label {
+                            word-break: break-word;
+                            text-align: center;
                             border-color: var(--primary-success-color);
                         }
                     }
@@ -249,6 +251,8 @@
                 &_hasError {
                     input {
                         & + label {
+                            word-break: break-word;
+                            text-align: center;
                             border-color: var(--primary-error-color);
                         }
                     }


### PR DESCRIPTION
No clue why it was moving to left side

**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3765

**Problem:**
* Label in file input was aligning left if the label is too long

**In this PR:**
* Forced label to stay centered and added word breaking so that the label doesn't stretch container if the label is too long.
