### PR TITLE
[3822] Tied NewsletterSubscriptionContainer to router

### DIFF
--- a/packages/scandipwa/src/component/NewsletterSubscription/NewsletterSubscription.container.js
+++ b/packages/scandipwa/src/component/NewsletterSubscription/NewsletterSubscription.container.js
@@ -12,6 +12,7 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
 
 import { showNotification } from 'Store/Notification/Notification.action';
 
@@ -97,12 +98,13 @@ export class NewsletterSubscriptionContainer extends PureComponent {
             <NewsletterSubscription
               { ...this.containerProps() }
               { ...this.containerFunctions }
+              key={ window.location.pathname }
             />
         );
     }
 }
 
-export default connect(
+export default withRouter(connect(
     mapStateToProps,
     mapDispatchToProps
-)(NewsletterSubscriptionContainer);
+)(NewsletterSubscriptionContainer));


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3822

**Problem:**
* Newsletter subscription error won't go away when user changes pages

**In this PR:**
* Tied NewsletterSubscriptionContainer to react router so it refreshes on every page change
