### PR TITLE
[3712] Header bottom border style

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -100,7 +100,7 @@
         &_menu,
         &_search,
         &_menu_subcategory {
-            border-block-end: none;
+            border-block-end: 1px solid var(--primary-divider-color);
         }
 
         &_category {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3712

**Problem:**
* When the focus is on search products field bottom border of the header disappears

**In this PR:**
* Changed border-block-end from none to using the same border as when not focused on search field in Header_name_search
