### PR TITLE
 [3824] Changed position of bullet points in product description from absolute to static (Recreated)

### DIFF
--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -58,6 +58,10 @@
         font-size: 14px;
         line-height: 20px;
         margin-block: 16px;
+        
+        div[itemprop="description"] li:before{
+            position: static;
+        }
     }
 
     &-Stock {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3824

**Problem:**
* Bullet points were overlapped by text in product description

**In this PR:**
* Changed position property of bullet points in item description
