### PR TITLE
[3765] Force centering file input label (recreated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ runtime-packages/csa
 # build specifc files
 lerna-debug.log
 .eslintcache
+*.json
+*.json
+*.json
+*.json
+packages/scandipwa/i18n/fr_FR.json


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3765

**Problem:**
* Label in file input was aligning left if the label is too long

**In this PR:**
* Forced label to stay centered and added word breaking so that the label doesn't stretch container if the label is too long.
