### PR TITLE
[3822] Tied NewsletterSubscriptionContainer to router (recreated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ runtime-packages/csa
 # build specifc files
 lerna-debug.log
 .eslintcache
+*.json
+*.json
+*.json
+*.json
+packages/scandipwa/i18n/fr_FR.json

--- a/packages/scandipwa/src/component/NewsletterSubscription/NewsletterSubscription.container.js
+++ b/packages/scandipwa/src/component/NewsletterSubscription/NewsletterSubscription.container.js
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
 import { showNotification } from 'Store/Notification/Notification.action';
+import { LocationType } from 'Type/Router.type';
 
 import NewsletterSubscription from './NewsletterSubscription.component';
 
@@ -40,6 +41,7 @@ export const mapDispatchToProps = (dispatch) => ({
 /** @namespace Component/NewsletterSubscription/Container */
 export class NewsletterSubscriptionContainer extends PureComponent {
     static propTypes = {
+        location: LocationType.isRequired,
         subscribeToNewsletter: PropTypes.func.isRequired,
         showErrorNotification: PropTypes.func.isRequired,
         allowGuestSubscribe: PropTypes.bool.isRequired,
@@ -94,11 +96,13 @@ export class NewsletterSubscriptionContainer extends PureComponent {
     }
 
     render() {
+        const { location: { pathname } } = this.props;
+
         return (
             <NewsletterSubscription
               { ...this.containerProps() }
               { ...this.containerFunctions }
-              key={ window.location.pathname }
+              key={ pathname }
             />
         );
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3822

**Problem:**
* Newsletter subscription error won't go away when user changes pages

**In this PR:**
* Tied NewsletterSubscriptionContainer to react router so it refreshes on every page change
