### PR TITLE
[3853] Removed max width and max height for video player popup.

### DIFF
--- a/packages/scandipwa/src/component/Popup/Popup.style.scss
+++ b/packages/scandipwa/src/component/Popup/Popup.style.scss
@@ -18,6 +18,7 @@
     --popup-content-background: #{$white};
     --popup-min-width: 100%;
     --popup-content-padding: 12px;
+    --popup-max-height: 80%;
 
     @include desktop {
         --popup-min-width: 490px;
@@ -73,7 +74,7 @@
         padding: var(--popup-content-padding);
         min-width: var(--popup-min-width);
         max-width: calc(var(--content-wrapper-width) * .8);
-        max-height: 80%;
+        max-height: var(--popup-max-height);
         overflow-y: auto;
 
         @include mobile {

--- a/packages/scandipwa/src/component/VideoPopup/VideoPopup.style.scss
+++ b/packages/scandipwa/src/component/VideoPopup/VideoPopup.style.scss
@@ -12,12 +12,15 @@
 .VideoPopup {
     --popup-min-width: none;
     --popup-content-padding: 0;
+    --content-wrapper-width: none;
+    --popup-max-height: none;
 
     @include mobile {
         --popup-content-padding: 0;
     }
 
     &-VideoPlayer {
+        overflow: hidden;
         width: 100vw;
         height: calc(100vh - 40px);
         background: black;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3853

**Problem:**
* Video does not fit the popup, creating scrollbars.

**In this PR:**
* Added max height variable for popup, set it to none for video player.
