### PR TITLE
[3800] Fixing the fields for date/time/date&time on PDP

### DIFF
--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
@@ -40,6 +40,7 @@
                     input {
                         max-width: 100%;
                         width: 250px;
+                        height: 44.6px;
                     }
                 }
             }


### PR DESCRIPTION
**Related issue(s):**
 Fixes https://github.com/scandipwa/scandipwa/issues/3800

**Problem:**
Fields for date/time/date&time on PDP has wrong high, it is about 51.7 and 51.8px now

**In this PR:**
set fixed height= 44.6
