### PR TITLE
[3714] Sign In and Create An Account button width

### DIFF
--- a/packages/scandipwa/src/component/MyAccountForgotPassword/MyAccountForgotPassword.component.js
+++ b/packages/scandipwa/src/component/MyAccountForgotPassword/MyAccountForgotPassword.component.js
@@ -43,6 +43,7 @@ export class MyAccountForgotPassword extends PureComponent {
                   attr={ {
                       id: 'email',
                       name: 'email',
+                      class: 'ForgotPassword-Input_type_email',
                       placeholder: __('Your email address'),
                       autocomplete: 'email'
                   } }

--- a/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.component.js
+++ b/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.component.js
@@ -28,7 +28,13 @@ export class ForgotPasswordComponent extends MyAccountOverlay {
             <div block="ForgotPassword" elem="SignInWrapper">
                 <h3>{ __('Registered Customers') }</h3>
                 <p>{ __('If you have an account, sign in with your email address.') }</p>
-                <button block="Button" onClick={ onLoginClick }>{ __('Sign In') }</button>
+                <button
+                  block="Button"
+                  mix={ { block: 'ForgotPassword', elem: 'SignInButton' } }
+                  onClick={ onLoginClick }
+                >
+                { __('Sign In') }
+                </button>
             </div>
         );
     }
@@ -43,7 +49,13 @@ export class ForgotPasswordComponent extends MyAccountOverlay {
                     { __('Creating an account has many benefits:') }
                     { __(' check out faster, keep more than one address, track orders and more.') }
                 </p>
-                <button block="Button" onClick={ onCreateAccountClick }>{ __('Create an Account') }</button>
+                <button
+                  block="Button"
+                  mix={ { block: 'ForgotPassword', elem: 'CreateAccountButton' } }
+                  onClick={ onCreateAccountClick }
+                >
+                { __('Create an Account') }
+                </button>
             </div>
         );
     }

--- a/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.style.scss
+++ b/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.style.scss
@@ -21,6 +21,14 @@
         }
     }
 
+    &-CreateAccountButton {
+        width: 100%;
+    }
+
+    &-SignInButton {
+        width: 100%;
+    }
+
     &-InnerWrapper {
         @include desktop() {
             display: grid;

--- a/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.style.scss
+++ b/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.style.scss
@@ -21,11 +21,9 @@
         }
     }
 
-    &-CreateAccountButton {
-        width: 100%;
-    }
-
-    &-SignInButton {
+    &-CreateAccountButton,
+    &-SignInButton
+    {
         width: 100%;
     }
 

--- a/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.style.scss
+++ b/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.style.scss
@@ -27,6 +27,12 @@
         width: 100%;
     }
 
+    &-Input {
+        &_type_email {
+            width: 100%;
+        }
+    }
+
     &-InnerWrapper {
         @include desktop() {
             display: grid;

--- a/packages/scandipwa/src/route/LoginAccount/LoginAccount.component.js
+++ b/packages/scandipwa/src/route/LoginAccount/LoginAccount.component.js
@@ -62,7 +62,13 @@ export class LoginAccountComponent extends MyAccountOverlay {
                     { __('Creating an account has many benefits:') }
                     { __(' check out faster, keep more than one address, track orders and more.') }
                 </p>
-                <button block="Button" onClick={ onCreateAccountClick }>{ __('Create an Account') }</button>
+                <button
+                  block="Button"
+                  mix={ { block: 'LoginAccount', elem: 'CreateAccountButton' } }
+                  onClick={ onCreateAccountClick }
+                >
+                { __('Create an Account') }
+                </button>
             </div>
         );
     }

--- a/packages/scandipwa/src/route/LoginAccount/LoginAccount.style.scss
+++ b/packages/scandipwa/src/route/LoginAccount/LoginAccount.style.scss
@@ -21,6 +21,10 @@
         }
     }
 
+    &-CreateAccountButton {
+        width: 100%;
+    }
+
     &-InnerWrapper {
         @include desktop() {
             display: grid;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3714

**Problem:**
* Create an account button on login page has the wrong width
* Create an account button on forgot password page has the wrong width
* Sign in button on forgot password page has the wrong width

**In this PR:**
* Added classes to all the buttons to make them easily identifiable
* Added width: 100% to all of the new classes
