### PR TITLE
#scandipwa-3835 - refresh token on every request

### DIFF
--- a/packages/scandipwa/src/util/Auth/Token.js
+++ b/packages/scandipwa/src/util/Auth/Token.js
@@ -23,6 +23,10 @@ export const TOKEN_REFRESH_DELAY = 2000;
 
 /** @namespace Util/Auth/Token/setAuthorizationToken */
 export const setAuthorizationToken = (token) => {
+    if (!token) {
+        return;
+    }
+
     const state = getStore().getState();
     const {
         access_token_lifetime = ONE_HOUR

--- a/packages/scandipwa/src/util/Auth/Token.js
+++ b/packages/scandipwa/src/util/Auth/Token.js
@@ -12,12 +12,14 @@
 import { updateCustomerSignInStatus } from 'Store/MyAccount/MyAccount.action';
 import BrowserDatabase from 'Util/BrowserDatabase';
 import { deleteGuestQuoteId } from 'Util/Cart';
+import { debounce } from 'Util/Request';
 import getStore from 'Util/Store';
 
 export const AUTH_TOKEN = 'auth_token';
 
 export const ONE_HOUR_IN_SECONDS = 3600;
 export const ONE_HOUR = 1;
+export const TOKEN_REFRESH_DELAY = 2000;
 
 /** @namespace Util/Auth/Token/setAuthorizationToken */
 export const setAuthorizationToken = (token) => {
@@ -36,7 +38,10 @@ export const deleteAuthorizationToken = () => BrowserDatabase.deleteItem(AUTH_TO
 export const getAuthorizationToken = () => BrowserDatabase.getItem(AUTH_TOKEN);
 
 /** @namespace Util/Auth/Token/refreshAuthorizationToken */
-export const refreshAuthorizationToken = () => setAuthorizationToken(getAuthorizationToken());
+export const refreshAuthorizationToken = debounce(
+    () => setAuthorizationToken(getAuthorizationToken()),
+    TOKEN_REFRESH_DELAY
+);
 
 /** @namespace Util/Auth/Token/isInitiallySignedIn */
 export const isInitiallySignedIn = () => !!getAuthorizationToken();

--- a/packages/scandipwa/src/util/Auth/Token.js
+++ b/packages/scandipwa/src/util/Auth/Token.js
@@ -67,8 +67,6 @@ export const isSignedIn = () => {
         MyAccountDispatcher.then(
             ({ default: dispatcher }) => dispatcher.logout(true, true, dispatch)
         );
-    } else if (_isSignedIn && isCustomerSignedIn) {
-        refreshAuthorizationToken();
     }
 
     return _isSignedIn;

--- a/packages/scandipwa/src/util/Request/Request.js
+++ b/packages/scandipwa/src/util/Request/Request.js
@@ -11,7 +11,7 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-import { getAuthorizationToken, refreshAuthorizationToken } from 'Util/Auth';
+import { getAuthorizationToken, isSignedIn, refreshAuthorizationToken } from 'Util/Auth';
 import { getCurrency } from 'Util/Currency';
 
 import { hash } from './Hash';
@@ -197,7 +197,10 @@ export const HTTP_201_CREATED = 201;
 export const executeGet = (queryObject, name, cacheTTL) => {
     const { query, variables } = queryObject;
     const uri = formatURI(query, variables, getGraphqlEndpoint());
-    refreshAuthorizationToken();
+
+    if (isSignedIn()) {
+        refreshAuthorizationToken();
+    }
 
     return parseResponse(new Promise((resolve, reject) => {
         getFetch(uri, name).then(
@@ -234,7 +237,10 @@ export const executeGet = (queryObject, name, cacheTTL) => {
 export const executePost = (queryObject) => {
     const { query, variables } = queryObject;
 
-    refreshAuthorizationToken();
+    if (isSignedIn()) {
+        refreshAuthorizationToken();
+    }
+
     return parseResponse(postFetch(getGraphqlEndpoint(), query, variables));
 };
 

--- a/packages/scandipwa/src/util/Request/Request.js
+++ b/packages/scandipwa/src/util/Request/Request.js
@@ -11,7 +11,7 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-import { getAuthorizationToken } from 'Util/Auth';
+import { getAuthorizationToken, refreshAuthorizationToken } from 'Util/Auth';
 import { getCurrency } from 'Util/Currency';
 
 import { hash } from './Hash';
@@ -197,6 +197,7 @@ export const HTTP_201_CREATED = 201;
 export const executeGet = (queryObject, name, cacheTTL) => {
     const { query, variables } = queryObject;
     const uri = formatURI(query, variables, getGraphqlEndpoint());
+    refreshAuthorizationToken();
 
     return parseResponse(new Promise((resolve, reject) => {
         getFetch(uri, name).then(
@@ -233,6 +234,7 @@ export const executeGet = (queryObject, name, cacheTTL) => {
 export const executePost = (queryObject) => {
     const { query, variables } = queryObject;
 
+    refreshAuthorizationToken();
     return parseResponse(postFetch(getGraphqlEndpoint(), query, variables));
 };
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3835

**Problem:**
* Missing logic

**In this PR:**
* Added refreshAuthToken call to every post and get request
* Remove refreshAuthToken call from isSignedIn check => as token is updated on API call, this is a dupe update, I suppose
* add debounce, as method is called too often otherwise
