### PR TITLE
[3883] Sign-In link height

### DIFF
--- a/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.style.scss
+++ b/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.style.scss
@@ -164,6 +164,7 @@
     &-SignInLink {
         width: auto;
         margin-block-start: 0;
+        line-height: 20px;
     }
 
     &-ResetPassword {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3883

**Problem:**
* In create an account pop-up sign in link is higher than it's supposed to be

**In this PR:**
* Added line-height: 20px to sign in link, so it matches with "Already have an account?" height
