### PR TITLE
[3687] Minimum character error message

### DIFF
--- a/packages/scandipwa/src/util/Validator/Validator.js
+++ b/packages/scandipwa/src/util/Validator/Validator.js
@@ -79,7 +79,7 @@ export const validate = (value, rule) => {
                 output.errorMessages.push(onRangeFailMax || __('Maximum value is %s!', max));
             }
         } else {
-            if (min && value.length < min) {
+            if (min && value.length < min && value.length > 0) {
                 output.errorMessages.push(onRangeFailMin || __('Minimum %s characters!', min));
             }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3687

**Problem:**
* Message "Minimum 8 characters!" displays even when the input field is empty

**In this PR:**
* Modified validator which is responsible for input length by adding that length > 0
