### PR TITLE
[3875] Border under search in mobile menu

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -97,7 +97,10 @@
     }
 
     &_name {
-        &_menu,
+        &_menu {
+            border-block-end: none;
+        }
+
         &_search,
         &_menu_subcategory {
             border-block-end: 1px solid var(--primary-divider-color);


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3875

**Problem:**
* Line under search field in mobile menu should not be there

**In this PR:**
* Changed headers bottom border in mobile menu to none
