### PR TITLE
Add fallback for cacheTTL in case if it is not intereger

### DIFF
--- a/packages/scandipwa/src/util/Request/Request.js
+++ b/packages/scandipwa/src/util/Request/Request.js
@@ -13,7 +13,7 @@
 
 import { getAuthorizationToken } from 'Util/Auth';
 import { getCurrency } from 'Util/Currency';
-
+import { ONE_MONTH_IN_SECONDS } from 'Util/Request/QueryDispatcher';
 import { hash } from './Hash';
 
 export const GRAPHQL_URI = '/graphql';
@@ -114,7 +114,7 @@ export const putPersistedQuery = (graphQlURI, query, cacheTTL) => fetch(`${ grap
         body: JSON.stringify(query),
         headers: {
             'Content-Type': 'application/json',
-            'SW-Cache-Age': cacheTTL
+            'SW-Cache-Age': Number.isInteger(cacheTTL) ? cacheTTL : ONE_MONTH_IN_SECONDS
         }
     });
 

--- a/packages/scandipwa/src/util/Request/Request.js
+++ b/packages/scandipwa/src/util/Request/Request.js
@@ -14,6 +14,7 @@
 import { getAuthorizationToken } from 'Util/Auth';
 import { getCurrency } from 'Util/Currency';
 import { ONE_MONTH_IN_SECONDS } from 'Util/Request/QueryDispatcher';
+
 import { hash } from './Hash';
 
 export const GRAPHQL_URI = '/graphql';


### PR DESCRIPTION
**Problem:**
* Sometimes graphql request can be not cached due to setting empty string for max-age

**In this PR:**
* Check if integer and fallback to default value if it not integer.
