### PR TITLE
issue-3896 - Set check if user is signed in when entering customer url in my-account

### DIFF
--- a/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
@@ -157,7 +157,6 @@ export class MyAccountContainer extends PureComponent {
 
     static navigateToSelectedTab(props, state = {}) {
         const {
-            isSignedIn,
             match: {
                 params: {
                     tab: historyActiveTab
@@ -168,7 +167,7 @@ export class MyAccountContainer extends PureComponent {
         } = props;
         const { activeTab } = state;
 
-        if (this.tabMap[selectedTab] && isSignedIn) {
+        if (this.tabMap[selectedTab] && isSignedIn()) {
             return { activeTab: selectedTab };
         }
 
@@ -178,7 +177,7 @@ export class MyAccountContainer extends PureComponent {
             : MY_ACCOUNT;
         const { url: activeTabUrl } = this.tabMap[newActiveTab];
 
-        if (historyActiveTab !== newActiveTab && activeTab !== MY_ACCOUNT && isSignedIn && !isMobile) {
+        if (historyActiveTab !== newActiveTab && activeTab !== MY_ACCOUNT && isSignedIn() && !isMobile) {
             history.push(appendWithStoreCode(`${ ACCOUNT_URL }${ activeTabUrl }`));
         }
 

--- a/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
@@ -168,7 +168,7 @@ export class MyAccountContainer extends PureComponent {
         } = props;
         const { activeTab } = state;
 
-        if (this.tabMap[selectedTab]) {
+        if (this.tabMap[selectedTab] && isSignedIn) {
             return { activeTab: selectedTab };
         }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3896 

**Problem:**
* When token expires user can see try enter any of tabs (won't happen anything, but should redirect to login page)

**In this PR:**
* Set check if user is signed in before setting selected tab as active tab
