### PR TITLE
#3882 - Set check before history push if it is overlay

### DIFF
--- a/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.js
+++ b/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.js
@@ -153,6 +153,7 @@ export class MyAccountOverlayContainer extends PureComponent {
         const { isSignedIn: prevIsSignedIn } = prevProps;
         const { state: oldMyAccountState } = prevState;
         const { state: newMyAccountState } = this.state;
+        const { isOverlayVisible } = this.props;
         const { location: { pathname } } = history;
 
         const {
@@ -175,7 +176,10 @@ export class MyAccountOverlayContainer extends PureComponent {
             }
         }
 
-        if (newMyAccountState !== STATE_LOGGED_IN && pathname.includes(ACCOUNT_URL)) {
+        if (newMyAccountState !== STATE_LOGGED_IN
+            && pathname.includes(ACCOUNT_URL)
+            && !isOverlayVisible
+        ) {
             history.push({ pathname: appendWithStoreCode(ACCOUNT_LOGIN_URL) });
         }
 

--- a/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.js
+++ b/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.js
@@ -176,7 +176,8 @@ export class MyAccountOverlayContainer extends PureComponent {
             }
         }
 
-        if (newMyAccountState !== STATE_LOGGED_IN
+        if (
+            newMyAccountState !== STATE_LOGGED_IN
             && pathname.includes(ACCOUNT_URL)
             && !isOverlayVisible
         ) {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3882 

**Problem:**
* MyAccountOverlay doesn't check if it is overlay before clicking on forgot passoword so it tries to redirect to other page and closes overlay

**In this PR:**
* Set check if it is overlay
