### PR TITLE
#scandipwa-3901 - fix error write review render

### DIFF
--- a/packages/scandipwa/src/component/ProductTabs/ProductTabs.component.js
+++ b/packages/scandipwa/src/component/ProductTabs/ProductTabs.component.js
@@ -25,12 +25,7 @@ export class ProductTabs extends PureComponent {
         tabs: PropTypes.arrayOf(PropTypes.shape({
             name: PropTypes.string.isRequired,
             render: PropTypes.func.isRequired
-        })).isRequired,
-        defaultTab: PropTypes.number
-    };
-
-    static defaultProps = {
-        defaultTab: 0
+        })).isRequired
     };
 
     onTabClick = this.onTabClick.bind(this);
@@ -38,18 +33,30 @@ export class ProductTabs extends PureComponent {
     __construct(props) {
         super.__construct(props);
 
-        const { defaultTab } = this.props;
+        const { tabs: [{ id }] } = this.props;
 
         this.state = {
-            activeTab: defaultTab
+            activeTab: id
         };
+    }
+
+    componentDidUpdate(prevProps) {
+        const { tabs: prevTabs } = prevProps;
+        const { tabs } = this.props;
+
+        if (prevTabs.length !== tabs.length) {
+            const [{ id }] = tabs;
+
+            // eslint-disable-next-line react/no-did-update-set-state
+            this.setState({ activeTab: id });
+        }
     }
 
     onTabClick(tab) {
         const { tabs } = this.props;
         const { activeTab } = this.state;
 
-        const currentTab = tabs.findIndex(({ name }) => name === tab);
+        const { id: currentTab } = tabs.find(({ name }) => name === tab);
 
         if (activeTab !== currentTab) {
             this.setState({
@@ -61,12 +68,13 @@ export class ProductTabs extends PureComponent {
     renderActiveTab() {
         const { tabs } = this.props;
         const { activeTab } = this.state;
+        const { render } = tabs.find(({ id }) => id === activeTab) || {};
 
-        if (!activeTab) {
+        if (!render) {
             return null;
         }
 
-        return tabs[activeTab].render();
+        return render();
     }
 
     renderAllTabs() {
@@ -75,15 +83,16 @@ export class ProductTabs extends PureComponent {
         return tabs.map(({ render, name }) => render(name));
     }
 
-    renderTab(item, i) {
+    renderTab(item) {
         const { activeTab } = this.state;
+        const { id, name } = item;
 
         return (
             <ProductTab
-              tabName={ item.name }
-              key={ i }
+              tabName={ name }
+              key={ id }
               onClick={ this.onTabClick }
-              isActive={ i === activeTab }
+              isActive={ id === activeTab }
             />
         );
     }

--- a/packages/scandipwa/src/component/ProductTabs/ProductTabs.component.js
+++ b/packages/scandipwa/src/component/ProductTabs/ProductTabs.component.js
@@ -62,6 +62,10 @@ export class ProductTabs extends PureComponent {
         const { tabs } = this.props;
         const { activeTab } = this.state;
 
+        if (!activeTab) {
+            return null;
+        }
+
         return tabs[activeTab].render();
     }
 

--- a/packages/scandipwa/src/component/ProductTabs/ProductTabs.component.js
+++ b/packages/scandipwa/src/component/ProductTabs/ProductTabs.component.js
@@ -46,9 +46,7 @@ export class ProductTabs extends PureComponent {
 
         if (prevTabs.length !== tabs.length) {
             const [{ id }] = tabs;
-
-            // eslint-disable-next-line react/no-did-update-set-state
-            this.setState({ activeTab: id });
+            this.setActiveTab(id);
         }
     }
 
@@ -59,10 +57,12 @@ export class ProductTabs extends PureComponent {
         const { id: currentTab } = tabs.find(({ name }) => name === tab);
 
         if (activeTab !== currentTab) {
-            this.setState({
-                activeTab: currentTab
-            });
+            this.setActiveTab(currentTab);
         }
+    }
+
+    setActiveTab(activeTab) {
+        this.setState({ activeTab });
     }
 
     renderActiveTab() {

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.component.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.component.js
@@ -176,12 +176,20 @@ export class ProductPage extends PureComponent {
     }
 
     shouldTabsRender() {
-        return Object.values(this.tabMap).filter(({ shouldTabRender }) => shouldTabRender());
+        return Object.entries(this.tabMap)
+            .map(([id, values]) => ({ id, ...values }))
+            .filter(({ shouldTabRender }) => shouldTabRender());
     }
 
     renderProductTabs() {
+        const tabs = this.shouldTabsRender();
+
+        if (!tabs) {
+            return null;
+        }
+
         return (
-            <ProductTabs tabs={ this.shouldTabsRender() } />
+            <ProductTabs tabs={ tabs } />
         );
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes [[link for issue]](https://github.com/scandipwa/scandipwa/issues/3901)


**Problem:**
* We store tab index in state to know what tab is active. Default number of tabs is 3, but one of the tabs doesn't render always (there is `shouldTabRender` check which checks if data received from the server includes data for the tab). Sometimes (when user clicks on Reviews tab when still loading) active tab index will be 2 and it will be saved to state, but after `shouldTabRender` check number of tabs to render will be 2 => error appears when we try to access 3rd element (= element with index 2) of a 2 member array.

**In this PR:**
* the solution here is to get rid of indexes and replace them with tab names, as using indexes proves to be insecure in this case
