### PR TITLE
[3874] "Field is required!" error positioning on mobile

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -70,6 +70,7 @@
             font-size: 12px;
             margin-block-end: -.1em;
             margin-block-start: 6px;
+            text-align: left;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3874

**Problem:**
* "Field is required" error message is centered in mobile after submitting empty subscribe form

**In this PR:**
* Added text-align: left to error messages
