### PR TITLE
[3888] Stars for required fields

### DIFF
--- a/packages/scandipwa/src/component/MyAccountSignIn/MyAccountSignIn.component.js
+++ b/packages/scandipwa/src/component/MyAccountSignIn/MyAccountSignIn.component.js
@@ -62,6 +62,7 @@ export class MyAccountSignIn extends PureComponent {
                       isRequired: true,
                       inputType: VALIDATION_INPUT_TYPE.email
                   } }
+                  addRequiredTag
                 />
                 <Field
                   label={ __('Password') }
@@ -77,6 +78,7 @@ export class MyAccountSignIn extends PureComponent {
                       isRequired: true,
                       inputType: VALIDATION_INPUT_TYPE.password
                   } }
+                  addRequiredTag
                 />
                 <button
                   type="button"

--- a/packages/scandipwa/src/route/ConfirmAccountPage/ConfirmAccountPage.component.js
+++ b/packages/scandipwa/src/route/ConfirmAccountPage/ConfirmAccountPage.component.js
@@ -77,6 +77,7 @@ export class ConfirmAccountPage extends PureComponent {
                       name: 'email'
                   } }
                   mix={ { block: 'ConfirmAccountPage', elem: 'EmailInput' } }
+                  addRequiredTag
                 />
                 <Field
                   type={ FIELD_TYPE.password }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3888

**Problem:**
* Sign In and Confirm Account forms' required fields do not have a star for label

**In this PR:**
* Added addRequiredTag for Sign In form's password and email fields, and for password in Account Confirm form
