### PR TITLE
[3065] Connected PLP view types in search page to redux

### DIFF
--- a/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
@@ -63,7 +63,8 @@ export const mapStateToProps = (state) => ({
     isInfoLoading: state.ProductListInfoReducer.isLoading,
     totalPages: state.ProductListReducer.totalPages,
     totalItems: state.ProductListReducer.totalItems,
-    isMobile: state.ConfigReducer.device.isMobile
+    isMobile: state.ConfigReducer.device.isMobile,
+    plpType: state.ConfigReducer.plp_list_mode
 });
 
 /** @namespace Route/SearchPage/Container/mapDispatchToProps */


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3065

**Problem:**
* Sort page was not receiving PLP view type props from redux

**In this PR:**
* Connected PLP view types in search page to redux
