### PR TITLE
CLI & VSCode tool improvements

### DIFF
--- a/build-packages/scandipwa-cli/actions/override/lib/extender.js
+++ b/build-packages/scandipwa-cli/actions/override/lib/extender.js
@@ -8,7 +8,8 @@ const invokeGenerator = require('../../../common/invoke-generator');
 const extender = (resourceType) => async ({
     name,
     targetModule = process.cwd(),
-    sourceModule
+    sourceModule,
+    stylePostfix
 }) => {
     const isExtendedSuccessfully = await invokeGenerator(
         targetModule,
@@ -18,7 +19,8 @@ const extender = (resourceType) => async ({
             resolvedTargetModule,
             logger,
             userInteraction,
-            sourceModule
+            sourceModule,
+            { stylePostfix }
         )
     );
 

--- a/build-packages/scandipwa-cli/actions/override/lib/options/withStyles.js
+++ b/build-packages/scandipwa-cli/actions/override/lib/options/withStyles.js
@@ -6,6 +6,12 @@ const withStyles = (yargs) => yargs
         alias: 'S',
         type: 'string',
         choices: Object.values(StylesOption)
+    })
+    .option('style-postfix', {
+        describe: 'Styles postfix (default: "override")',
+        alias: 'P',
+        type: 'string',
+        default: 'override'
     });
 
 module.exports = withStyles;

--- a/build-packages/scandipwa-development-toolkit-core/src/extend/config.ts
+++ b/build-packages/scandipwa-development-toolkit-core/src/extend/config.ts
@@ -1,0 +1,13 @@
+export type ConfigType = {
+    [key: string]: any;
+}
+
+let config: ConfigType = {};
+
+export const setConfig = (newConfig: ConfigType = {}) => {
+    config = newConfig;
+};
+
+export const getConfigByKey = (key: string, defaultValue?: any) => {
+    return config[key] || defaultValue;
+};

--- a/build-packages/scandipwa-development-toolkit-core/src/extend/index.ts
+++ b/build-packages/scandipwa-development-toolkit-core/src/extend/index.ts
@@ -17,6 +17,7 @@ import { getModuleInformation } from '../util/module';
 import { ExportData, StylesOption } from '../types/extend-component.types';
 import { ILogger, IUserInteraction, ResourceType } from '../types';
 import validateResourceExistance from './validate-resource-existance';
+import { ConfigType, setConfig } from './config';
 
 /**
  * @param resourceType Type of resource to extend
@@ -31,8 +32,11 @@ const extend = async (
     targetModulePath: string,
     logger: ILogger,
     userInteraction: IUserInteraction,
-    optionalSourceModulePath?: string
+    optionalSourceModulePath?: string,
+    config?: ConfigType
 ): Promise<string[]> => {
+    setConfig(config);
+
     const relativeResourceDirectory = getRelativeResourceDirectory(resourceName, resourceType);
 
     // Resolve the source resource using the target module as CWD

--- a/build-packages/scandipwa-development-toolkit-core/src/extend/scss-generation.ts
+++ b/build-packages/scandipwa-development-toolkit-core/src/extend/scss-generation.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs-extra';
 
 import { ILogger, IUserInteraction, StylesOption } from "../types";
 import { createNewFileFromTemplate } from '../util/file';
+import { getConfigByKey } from './config';
 
 // Initial paths' calculation
 const templateDirectory = path.join(__dirname, '..', 'templates');
@@ -12,8 +13,10 @@ export const getStyleFileName = (
     resourceName: string, 
     stylesOption: StylesOption
 ) => {
+    const postfix = getConfigByKey('stylePostfix', 'override');
+
     if (stylesOption === StylesOption.extend) {
-        return `${resourceName}.override.style.scss`;
+        return `${resourceName}.${postfix}.style.scss`;
     }
 
     return `${resourceName}.style.scss`;

--- a/build-packages/scandipwa-development-toolkit-core/src/templates/stylesheet.scss
+++ b/build-packages/scandipwa-development-toolkit-core/src/templates/stylesheet.scss
@@ -1,3 +1,3 @@
 .Placeholder {
-    
+    // TODO style the element
 }

--- a/build-packages/scandipwa-development-toolkit-vscode/package.json
+++ b/build-packages/scandipwa-development-toolkit-vscode/package.json
@@ -88,9 +88,20 @@
 			"editor/title": [
 				{
 					"command": "extension.goToChildTheme",
-					"group": "navigation"
+					"group": "navigation",
+					"when": "editorLangId in extension.scandipwaSupportedLangs"
 				}
 			]
+		},
+		"configuration": {
+			"title": "ScandiPWA",
+			"properties": {
+				"scandipwa.stylePostfix": {
+					"type": ["string", "null"],
+					"default": null,
+					"description": "Styles postfix to use when creating style overrides"
+				}
+			}
 		}
 	},
 	"dependencies": {

--- a/build-packages/scandipwa-development-toolkit-vscode/package.json
+++ b/build-packages/scandipwa-development-toolkit-vscode/package.json
@@ -35,7 +35,9 @@
 		"onCommand:extension.extendRoute",
 		"onCommand:extension.extendQuery",
 		"onCommand:extension.extendStore",
-		"onCommand:extension.extensionCreate"
+		"onCommand:extension.extensionCreate",
+		"onCommand:extension.goToChildTheme",
+		"onStartupFinished"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -75,8 +77,21 @@
 			{
 				"command": "extension.extensionCreate",
 				"title": "ScandiPWA: Create an extension"
+			},
+			{
+				"command": "extension.goToChildTheme",
+				"title": "ScandiPWA: Go to child theme",
+				"icon": "$(symbol-null)"
 			}
-		]
+		],
+		"menus": {
+			"editor/title": [
+				{
+					"command": "extension.goToChildTheme",
+					"group": "navigation"
+				}
+			]
+		}
 	},
 	"dependencies": {
 		"@babel/generator": "^7.9.6",

--- a/build-packages/scandipwa-development-toolkit-vscode/src/commands/go-to-child-theme/index.ts
+++ b/build-packages/scandipwa-development-toolkit-vscode/src/commands/go-to-child-theme/index.ts
@@ -1,0 +1,148 @@
+import fs from 'fs';
+import * as vscode from 'vscode';
+import logger from '../../util/logger';
+
+const { getMosaicConfig } = require('@tilework/mosaic-dev-utils/mosaic-config');
+
+import { getWorkspaceModules, getWorkspaceThemes } from '../../util/cwd/workspace';
+import { openFile } from '../../util/file';
+import { ExtendConfig, suggestExtension } from './suggest-extend';
+import { resolveTargetResourceDirectory } from '@scandipwa/scandipwa-development-toolkit-core/out/extend/resolve';
+import { getModuleInformation } from '@scandipwa/scandipwa-development-toolkit-core/out/util/module';
+const { walkDirectoryUp } = require('@scandipwa/scandipwa-dev-utils/get-context');
+
+const fileContextCache: { [key: string]: {
+	isPWA: boolean;
+	childThemePath?: string;
+	extendConfig?: ExtendConfig;
+} } = {};
+
+const updateFileContextCache = (uri: vscode.Uri, force = false) => {
+	if (!force && fileContextCache[uri.fsPath]) {
+		return;
+		// ^^^ skip update if present (and update is not forced)
+	}
+
+	try {
+		const workspaceModules = getWorkspaceModules();
+		const workspaceThemes = getWorkspaceThemes(workspaceModules);
+
+		// console.log(workspaceThemes);
+
+		if (!workspaceThemes.length) {
+			throw new Error('No workspace is a theme');
+		}
+
+		const cwd = workspaceThemes[0];
+		const { sourceDirectories }: { sourceDirectories: string[] } = getMosaicConfig(cwd);
+		const firstMatchedRelativePath = sourceDirectories.map(sourceDirectory => {
+			const match = uri.fsPath.match(new RegExp(`[\\\\/](${sourceDirectory}[\\\\/].*)`));
+
+			if (!match) {
+				return '';
+			}
+
+			return match[1];
+		}).filter(Boolean)[0];
+
+		if (!firstMatchedRelativePath) {
+			throw new Error('Unable to detect relative path');
+		}
+
+		try {
+			// I have not idea why this fails for extension... ;/
+			const { pathname: sourceModulePath } = walkDirectoryUp(uri.fsPath);
+
+			if (!sourceModulePath) {
+				throw new Error('Unable to detect NPM module of the file');
+			}
+
+			const {
+				name: sourceModuleName,
+				type: sourceModuleType
+			} = getModuleInformation(sourceModulePath);
+
+			const childThemePath = resolveTargetResourceDirectory(
+				firstMatchedRelativePath,
+				cwd,
+				sourceModuleType,
+				sourceModuleName
+			);
+
+			if (childThemePath === uri.fsPath) {
+				// triggered when overriding file from current theme
+				// throw new Error('File has no override yet');
+				fileContextCache[uri.fsPath] = {
+					isPWA: true
+				};
+
+				return;
+			}
+
+			if (!fs.existsSync(childThemePath)) {
+				throw new Error('Override file does not exist');
+			}
+
+			fileContextCache[uri.fsPath] = {
+				isPWA: true,
+				childThemePath
+			};
+		} catch (e) {
+			fileContextCache[uri.fsPath] = {
+				isPWA: true,
+				extendConfig: {
+					cwd,
+					relativePath: firstMatchedRelativePath,
+					originalPath: uri.fsPath
+				}
+			};
+		}
+	} catch (e) {
+		fileContextCache[uri.fsPath] = {
+			isPWA: false
+		}
+	}
+};
+
+export const goToChildTheme = async () => {
+	const activeEditor = vscode.window.activeTextEditor;
+
+	if (!activeEditor) {
+		logger.error('No active editor');
+		return;
+	}
+
+	updateFileContextCache(activeEditor.document.uri);
+
+	const { fsPath } = activeEditor.document.uri;
+	const extendConfig = fileContextCache[fsPath]?.extendConfig;
+
+	if (extendConfig) {
+		try {
+			await suggestExtension(extendConfig);
+			updateFileContextCache(activeEditor.document.uri, true);
+		} catch (e) {
+			if (e instanceof Error) {
+				logger.error(e.message);
+			}
+		}
+	}
+
+	try {
+		const childPath = fileContextCache[fsPath]?.childThemePath;
+		const isPWA = fileContextCache[fsPath]?.isPWA;
+
+		if (!childPath) {
+			if (isPWA) {
+				logger.warn('Override can not be created for this file');
+			} else {
+				logger.warn('File you attempt to override is not coming from ScandiPWA');
+			}
+			return;
+		}
+
+		openFile(childPath);
+	} catch (e) {
+		logger.error('Can not open override file');
+	}
+};

--- a/build-packages/scandipwa-development-toolkit-vscode/src/commands/go-to-child-theme/suggest-extend.ts
+++ b/build-packages/scandipwa-development-toolkit-vscode/src/commands/go-to-child-theme/suggest-extend.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { extend, ResourceType } from "@scandipwa/scandipwa-development-toolkit-core";
+import * as vscode from 'vscode';
 
 import logger from '../../util/logger';
 import ui from '../../util/ui';
@@ -11,7 +12,6 @@ export type ExtendConfig = {
 	relativePath: string;
 	originalPath: string;
 };
-
 
 const getFileType = (pathname: string): ResourceType | null => {
 	const possiblePaths = ['route', 'component', 'store', 'query'];
@@ -27,6 +27,21 @@ const getResourceName = (pathname: string) => {
     }
 
     return name;
+};
+
+const getConfig = () => {
+    if (vscode.workspace.workspaceFolders) {
+        const config = vscode.workspace.getConfiguration('scandipwa');
+        const stylePostfix = config.get('stylePostfix');
+
+        if (!stylePostfix) {
+            return {};
+        }
+
+        return { stylePostfix };
+    }
+
+    return {};
 };
 
 export const suggestExtension = async (extendConfig: ExtendConfig | undefined) => {
@@ -52,5 +67,6 @@ export const suggestExtension = async (extendConfig: ExtendConfig | undefined) =
         logger,
         ui,
         sourceModulePathname,
+        getConfig()
     );
 }

--- a/build-packages/scandipwa-development-toolkit-vscode/src/commands/go-to-child-theme/suggest-extend.ts
+++ b/build-packages/scandipwa-development-toolkit-vscode/src/commands/go-to-child-theme/suggest-extend.ts
@@ -1,0 +1,56 @@
+import path from 'path';
+import { extend, ResourceType } from "@scandipwa/scandipwa-development-toolkit-core";
+
+import logger from '../../util/logger';
+import ui from '../../util/ui';
+
+const { walkDirectoryUp } = require('@scandipwa/scandipwa-dev-utils/get-context');
+
+export type ExtendConfig = {
+	cwd: string;
+	relativePath: string;
+	originalPath: string;
+};
+
+
+const getFileType = (pathname: string): ResourceType | null => {
+	const possiblePaths = ['route', 'component', 'store', 'query'];
+	return possiblePaths.find((pathPiece) => pathname.includes(pathPiece)) as ResourceType;
+};
+
+const getResourceName = (pathname: string) => {
+    const { name: filename } = path.parse(pathname);
+    const [name, postfix = ''] = filename.split('.');
+
+    if (postfix.length < 3) {
+        throw new Error('A filename does not follow postfix convention');
+    }
+
+    return name;
+};
+
+export const suggestExtension = async (extendConfig: ExtendConfig | undefined) => {
+	if (!extendConfig) {
+		return;
+	}
+
+	const { cwd: targetModulePathname, relativePath, originalPath } = extendConfig;
+	const resourceType = getFileType(relativePath);
+
+	if (!resourceType) {
+		logger.error('Can not override this type of resource.');
+		return;
+	}
+
+	const { pathname: sourceModulePathname } = walkDirectoryUp(originalPath);
+    const resourceName = getResourceName(relativePath);
+
+    await extend(
+        resourceType,
+        resourceName,
+        targetModulePathname,
+        logger,
+        ui,
+        sourceModulePathname,
+    );
+}

--- a/build-packages/scandipwa-development-toolkit-vscode/src/commands/warn-in-source/index.ts
+++ b/build-packages/scandipwa-development-toolkit-vscode/src/commands/warn-in-source/index.ts
@@ -1,0 +1,7 @@
+import * as vscode from 'vscode';
+
+export const onDidSave = () => {
+    vscode.window.showWarningMessage(
+        'You are saving a file from a node_modules folder. This is not recommended.',
+    );
+}

--- a/build-packages/scandipwa-development-toolkit-vscode/src/extension.ts
+++ b/build-packages/scandipwa-development-toolkit-vscode/src/extension.ts
@@ -39,6 +39,15 @@ export function activate(context: vscode.ExtensionContext) {
 			)
 		);
 	});
+
+	vscode.commands.executeCommand('setContext', 'extension.scandipwaSupportedLangs', [
+		'javascript',
+		'javascriptreact',
+		'typescript',
+		'typescriptreact',
+		'scss',
+		'css'
+	]);
 }
 
 export function deactivate() {}

--- a/build-packages/scandipwa-development-toolkit-vscode/src/extension.ts
+++ b/build-packages/scandipwa-development-toolkit-vscode/src/extension.ts
@@ -8,6 +8,7 @@ import { creator } from './commands/create';
 import { extender } from './commands/extend';
 
 import extensionCreator from './commands/extension/create';
+import { goToChildTheme } from './commands/go-to-child-theme';
 
 const commandMap = {
 	'extension.createComponent': creator(ResourceType.Component),
@@ -21,13 +22,15 @@ const commandMap = {
 	'extension.extendStore': extender(ResourceType.Store),
 
 	'extension.extensionCreate': extensionCreator,
+
+	'extension.goToChildTheme': goToChildTheme,
 };
 
 export function activate(context: vscode.ExtensionContext) {
 	Object.entries(commandMap).forEach(([ name, handler ]) => {
 		context.subscriptions.push(
 			vscode.commands.registerCommand(
-				name, 
+				name,
 				() => {
 					ContextManager.createInstance(context);
 

--- a/build-packages/scandipwa-development-toolkit-vscode/src/extension.ts
+++ b/build-packages/scandipwa-development-toolkit-vscode/src/extension.ts
@@ -9,6 +9,7 @@ import { extender } from './commands/extend';
 
 import extensionCreator from './commands/extension/create';
 import { goToChildTheme } from './commands/go-to-child-theme';
+import { onDidSave } from './commands/warn-in-source';
 
 const commandMap = {
 	'extension.createComponent': creator(ResourceType.Component),
@@ -48,6 +49,8 @@ export function activate(context: vscode.ExtensionContext) {
 		'scss',
 		'css'
 	]);
+
+	vscode.workspace.onDidSaveTextDocument(onDidSave);
 }
 
 export function deactivate() {}


### PR DESCRIPTION
**Related issue(s):**
No issue is linked. This is an improvement suggestion diverged from the FE team.

**Problem:**
- The VSCode extension had no easy way of overriding a file. Now, when browsing source files, we can press a button to override it.
- The source code in node_modules was easy to modify, now it shows warnings when done
- Added option to pass style postfix, so it is configurable

**In this PR:**
All above mention features are implemented
