### PR TITLE
[3828] Autocomplete in checkout guest form

### DIFF
--- a/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.form.js
+++ b/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.form.js
@@ -31,7 +31,8 @@ export const checkoutGuestForm = (props, events) => {
                 name: 'guest_email',
                 placeholder: __('Your email'),
                 defaultValue: emailValue,
-                'aria-label': __('Your email')
+                'aria-label': __('Your email'),
+                autocomplete: 'email'
             },
             events: {
                 onChange: handleEmailInput


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3828

**Problem:**
* Browser doesn't offer to autofill a form in checkout

**In this PR:**
* Added autocomplete: "email" to CheckoutGuestForm component
