### PR TITLE
Fixed spaces absence between blocks on ship and billing steps

### DIFF
--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
@@ -22,6 +22,7 @@
         padding-block-start: 24px;
         padding-block-end: 0;
         padding-inline: 16px;
+        margin-bottom: 15px;
     }
 
     &-Header {

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
@@ -19,10 +19,9 @@
     @include desktop {
         border: 1px solid var(--secondary-base-color);
         border-radius: 2px;
-        padding-block-start: 24px;
-        padding-block-end: 0;
+        padding-block: 24px 0;
         padding-inline: 16px;
-        margin-bottom: 15px;
+        margin: 0 0 15px 0;
     }
 
     &-Header {

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
@@ -21,7 +21,7 @@
         border-radius: 2px;
         padding-block: 24px 0;
         padding-inline: 16px;
-        margin: 0 0 15px 0;
+        margin-block-end: 15px;
     }
 
     &-Header {

--- a/packages/scandipwa/src/component/CmsBlock/CmsBlock.style.scss
+++ b/packages/scandipwa/src/component/CmsBlock/CmsBlock.style.scss
@@ -10,9 +10,6 @@
  */
 
 .CmsBlock {
-    &-Wrapper {
-        margin: 15px;
-    }
 
     &-Wrapper_type {
         &_header_cms {

--- a/packages/scandipwa/src/component/CmsBlock/CmsBlock.style.scss
+++ b/packages/scandipwa/src/component/CmsBlock/CmsBlock.style.scss
@@ -10,7 +10,6 @@
  */
 
 .CmsBlock {
-
     &-Wrapper_type {
         &_header_cms {
             order: 3;

--- a/packages/scandipwa/src/component/CmsBlock/CmsBlock.style.scss
+++ b/packages/scandipwa/src/component/CmsBlock/CmsBlock.style.scss
@@ -10,6 +10,10 @@
  */
 
 .CmsBlock {
+    &-Wrapper {
+        margin: 15px;
+    }
+
     &-Wrapper_type {
         &_header_cms {
             order: 3;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3551

**Problem:**
Space is absent between promotion block and summary block on shipping and billing steps

**In this PR:**
added a margin to CmsBlock-Wrapper by 15px