### PR TITLE
Fixed whishlist and compare icones absence on cart page

### DIFF
--- a/packages/scandipwa/src/route/CartPage/CartPage.style.scss
+++ b/packages/scandipwa/src/route/CartPage/CartPage.style.scss
@@ -226,7 +226,7 @@
         z-index: 10;
 
         .ProductCard-ProductActions {
-            display: none;
+            display: flex;
         }
 
         .AddToCart {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3646

**Problem:**
* Icons of Compare and wish list are absent in Cross-sell products on Cart page

**In this PR:**
* changed the display of ProductCard-ProductActions in CartPage.style.scss from none to flex 
