### PR TITLE
[3562] Notification on submitting forgot password

### DIFF
--- a/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.js
+++ b/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.js
@@ -69,6 +69,7 @@ export class MyAccountOverlayContainer extends PureComponent {
         isOverlayVisible: PropTypes.bool.isRequired,
         isPasswordForgotSend: PropTypes.bool.isRequired,
         isSignedIn: PropTypes.bool.isRequired,
+        isForgotPasswordPage: PropTypes.bool,
 
         goToPreviousHeaderState: PropTypes.func,
         hideActiveOverlay: PropTypes.func.isRequired,
@@ -83,6 +84,7 @@ export class MyAccountOverlayContainer extends PureComponent {
     static defaultProps = {
         isCheckout: false,
         isLoading: false,
+        isForgotPasswordPage: false,
         onSignIn: noopFn,
         goToPreviousHeaderState: noopFn
     };
@@ -106,8 +108,10 @@ export class MyAccountOverlayContainer extends PureComponent {
     static getDerivedStateFromProps(props, state) {
         const {
             isPasswordForgotSend,
+            showNotification,
             isOverlayVisible,
-            isMobile
+            isMobile,
+            isForgotPasswordPage
         } = props;
 
         const {
@@ -138,9 +142,10 @@ export class MyAccountOverlayContainer extends PureComponent {
             stateToBeUpdated.state = STATE_SIGN_IN;
         }
 
-        if (isPasswordForgotSend !== currentIsPasswordForgotSend) {
+        if (isPasswordForgotSend !== currentIsPasswordForgotSend && isForgotPasswordPage && !isOverlayVisible) {
             stateToBeUpdated.isPasswordForgotSend = isPasswordForgotSend;
             // eslint-disable-next-line max-len
+            showNotification('success', __('If there is an account associated with the provided address you will receive an email with a link to reset your password.'));
             stateToBeUpdated.state = STATE_SIGN_IN;
         }
 

--- a/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.js
+++ b/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.js
@@ -106,7 +106,6 @@ export class MyAccountOverlayContainer extends PureComponent {
     static getDerivedStateFromProps(props, state) {
         const {
             isPasswordForgotSend,
-            showNotification,
             isOverlayVisible,
             isMobile
         } = props;
@@ -142,7 +141,6 @@ export class MyAccountOverlayContainer extends PureComponent {
         if (isPasswordForgotSend !== currentIsPasswordForgotSend) {
             stateToBeUpdated.isPasswordForgotSend = isPasswordForgotSend;
             // eslint-disable-next-line max-len
-            showNotification('success', __('If there is an account associated with the provided address you will receive an email with a link to reset your password.'));
             stateToBeUpdated.state = STATE_SIGN_IN;
         }
 

--- a/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.component.js
+++ b/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.component.js
@@ -61,7 +61,7 @@ export class ForgotPasswordComponent extends MyAccountOverlay {
     }
 
     renderForgotPasswordWrapper() {
-        const { device } = this.props;
+        const { device, isForgotPasswordPage } = this.props;
 
         if (device.isMobile) {
             return this.renderForgotPassword();
@@ -73,7 +73,7 @@ export class ForgotPasswordComponent extends MyAccountOverlay {
                 <p>
                     { __('Please enter your email address below to receive a password reset link.') }
                 </p>
-                { this.renderForgotPassword() }
+                { this.renderForgotPassword(isForgotPasswordPage) }
             </div>
         );
     }

--- a/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.container.js
+++ b/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.container.js
@@ -36,15 +36,21 @@ export const mapDispatchToProps = (dispatch) => ({
 export class ForgotPasswordContainer extends MyAccountOverlayContainer {
     static propTypes = {
         ...MyAccountOverlayContainer.propTypes,
-        updateBreadcrumbs: PropTypes.func.isRequired
+        updateBreadcrumbs: PropTypes.func.isRequired,
+        isForgotPasswordPage: PropTypes.bool
+    };
+
+    static defaultProps = {
+        isForgotPasswordPage: true
     };
 
     containerProps() {
-        const { device } = this.props;
+        const { device, isForgotPasswordPage } = this.props;
 
         return {
             ...super.containerProps(),
-            device
+            device,
+            isForgotPasswordPage
         };
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3562

**Problem:**
* When submitting forgot password form a duplicate notification is shown

**In this PR:**
* Removed showNotification() from MyAccountOverlay container when forgot password request is sent
