### PR TITLE
#3912 - Equalize buttons width

### DIFF
--- a/packages/scandipwa/src/component/MyAccountCreateAccount/MyAccountCreateAccount.style.scss
+++ b/packages/scandipwa/src/component/MyAccountCreateAccount/MyAccountCreateAccount.style.scss
@@ -29,7 +29,7 @@
     }
 
     &-PasswordBlock {
-        @include desktop {
+        @include wide-desktop {
             display: grid;
             grid-template-columns: repeat(2, 1fr);
             grid-column-gap: 16px;

--- a/packages/scandipwa/src/route/LoginAccount/LoginAccount.style.scss
+++ b/packages/scandipwa/src/route/LoginAccount/LoginAccount.style.scss
@@ -95,11 +95,4 @@
             margin-inline-start: 5px;
         }
     }
-
-    &-SignInWrapper {
-        @include desktop {
-            max-width: 400px;
-        }
-    }
 }
-


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3912

**Problem:**
* Different size of buttons on the pages(sign in, create an account and forgot password)

**In this PR:**
* On pages larger than the mobile version, the button sizes are the same
