### PR TITLE
#3890 - Display VAT number in account section

### DIFF
--- a/packages/scandipwa/src/component/MyAccountCustomerForm/MyAccountCustomerForm.component.js
+++ b/packages/scandipwa/src/component/MyAccountCustomerForm/MyAccountCustomerForm.component.js
@@ -30,7 +30,8 @@ export class MyAccountCustomerForm extends FieldForm {
         handleEmailInput: PropTypes.func.isRequired,
         handlePasswordInput: PropTypes.func.isRequired,
         email: PropTypes.string,
-        currentPassword: PropTypes.string
+        currentPassword: PropTypes.string,
+        vatNumberRequired: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -52,6 +53,7 @@ export class MyAccountCustomerForm extends FieldForm {
             handleChangePasswordCheckbox,
             showEmailChangeField,
             showPasswordChangeField,
+            vatNumberRequired,
             customer: {
                 firstname = '',
                 lastname = '',
@@ -69,7 +71,8 @@ export class MyAccountCustomerForm extends FieldForm {
             handleChangePasswordCheckbox,
             handleChangeEmailCheckbox,
             showEmailChangeField,
-            showPasswordChangeField
+            showPasswordChangeField,
+            vatNumberRequired
         });
     }
 

--- a/packages/scandipwa/src/component/MyAccountCustomerForm/MyAccountCustomerForm.container.js
+++ b/packages/scandipwa/src/component/MyAccountCustomerForm/MyAccountCustomerForm.container.js
@@ -13,7 +13,10 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
-import { SHOW_VAT_NUMBER_REQUIRED } from 'Component/MyAccountCreateAccount/MyAccountCreateAccount.config';
+import {
+    SHOW_VAT_NUMBER_OPTIONAL,
+    SHOW_VAT_NUMBER_REQUIRED
+} from 'Component/MyAccountCreateAccount/MyAccountCreateAccount.config';
 import { CustomerType } from 'Type/Account.type';
 
 import MyAccountCustomerForm from './MyAccountCustomerForm.component';
@@ -53,7 +56,6 @@ export class MyAccountCustomerFormContainer extends PureComponent {
             customer: { email: currentCustomerEmail },
             customer,
             onSave,
-            showTaxVatNumber,
             showEmailChangeField,
             showPasswordChangeField,
             handleChangeEmailCheckbox,
@@ -64,7 +66,8 @@ export class MyAccountCustomerFormContainer extends PureComponent {
         return {
             customer,
             onSave,
-            showTaxVatNumber: showTaxVatNumber === SHOW_VAT_NUMBER_REQUIRED,
+            showTaxVatNumber: this.getIsShowVatNumber(),
+            vatNumberRequired: this.getVatNumberRequired(),
             showEmailChangeField,
             showPasswordChangeField,
             handleChangeEmailCheckbox,
@@ -72,6 +75,19 @@ export class MyAccountCustomerFormContainer extends PureComponent {
             currentPassword,
             email: email || currentCustomerEmail
         };
+    }
+
+    getIsShowVatNumber() {
+        const { showTaxVatNumber } = this.props;
+
+        return showTaxVatNumber === SHOW_VAT_NUMBER_REQUIRED
+            || showTaxVatNumber === SHOW_VAT_NUMBER_OPTIONAL;
+    }
+
+    getVatNumberRequired() {
+        const { showTaxVatNumber } = this.props;
+
+        return showTaxVatNumber === SHOW_VAT_NUMBER_REQUIRED;
     }
 
     handleEmailInput(emailInput) {

--- a/packages/scandipwa/src/component/MyAccountCustomerForm/MyAccountCustomerForm.form.js
+++ b/packages/scandipwa/src/component/MyAccountCustomerForm/MyAccountCustomerForm.form.js
@@ -26,7 +26,8 @@ export const customerInformationFields = (props) => {
         handleChangeEmailCheckbox,
         handleChangePasswordCheckbox,
         showEmailChangeField,
-        showPasswordChangeField
+        showPasswordChangeField,
+        vatNumberRequired
     } = props;
 
     return [
@@ -67,10 +68,10 @@ export const customerInformationFields = (props) => {
                     defaultValue: taxvat,
                     placeholder: __('Your tax/VAT number')
                 },
-                addRequiredTag: true,
+                addRequiredTag: vatNumberRequired,
                 validateOn: ['onChange'],
                 validationRule: {
-                    isRequired: true
+                    isRequired: vatNumberRequired
                 }
             }
         ] : []),

--- a/packages/scandipwa/src/component/MyAccountCustomerTable/MyAccountCustomerTable.component.js
+++ b/packages/scandipwa/src/component/MyAccountCustomerTable/MyAccountCustomerTable.component.js
@@ -37,6 +37,11 @@ export class MyAccountCustomerTable extends KeyValueTable {
                 source: customer
             },
             {
+                key: 'taxvat',
+                label: __('Tax/VAT Number'),
+                source: customer
+            },
+            {
                 key: 'email',
                 label: __('Email'),
                 source: customer


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3890

**Problem:**
* VAT number is not displayed in the 'Account Information' section

**In this PR:**
* VAT number is displayed in the Account Information section when viewing and editing
