### PR TITLE
issue-2333 - Replace history instead of push

### DIFF
--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -333,7 +333,7 @@ export class CheckoutContainer extends PureComponent {
         }
 
         showInfoNotification(__('Please sign in or remove downloadable products from cart!'));
-        history.push(appendWithStoreCode(ACCOUNT_LOGIN_URL));
+        history.replace(appendWithStoreCode(ACCOUNT_LOGIN_URL));
     }
 
     handleSelectDeliveryMethod() {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #2333 

**Problem:**
* Cart is not open if user click back on login page and page was open after click on secure checkout

**In this PR:**
* Replace history instead of push, so that user can redirect back to prev page instead of checkout which will redirect him again to login
