### PR TITLE
#3508 - Change loader position on address popup

### DIFF
--- a/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.component.js
+++ b/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.component.js
@@ -90,8 +90,10 @@ export class MyAccountAddressPopup extends PureComponent {
               clickOutside={ false }
               mix={ { block: 'MyAccountAddressPopup' } }
             >
-                <Loader isLoading={ isLoading } />
-                { this.renderContent() }
+                <div>
+                    <Loader isLoading={ isLoading } />
+                    { this.renderContent() }
+                </div>
             </Popup>
         );
     }

--- a/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.style.scss
+++ b/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.style.scss
@@ -25,4 +25,10 @@
             width: 100%;
         }
     }
+
+    .Loader {
+        &-Scale {
+            position: fixed;
+        }
+    }
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3508

**Problem:**
* Loader animation is shown only at the beginning popup

**In this PR:**
* Loader animation is displayed in the whole popup address window
