### PR TITLE
#3568 - Correct positioning of the green line on PDP with RTL

### DIFF
--- a/packages/scandipwa/src/component/FieldGroup/FieldGroup.style.scss
+++ b/packages/scandipwa/src/component/FieldGroup/FieldGroup.style.scss
@@ -20,7 +20,7 @@
     }
 
     &_isValid {
-        border-left: 2px solid var(--primary-success-color);
+        border-inline-start: 2px solid var(--primary-success-color);
         padding-inline-start: 10px;
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3568

**Problem:**
* Green line shown from the left side when user selected options with checkboxes or radio buttons on PDP with RTL

**In this PR:**
* Fix positioning of the green line on PDP with RTL
