### PR TITLE
#3679 - Correct the shape of checkboxes in the filter on mobile

### DIFF
--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -180,6 +180,7 @@
                     width: 18px;
                     height: 18px;
                     min-width: 18px;
+                    min-height: 18px;
                     vertical-align: top;
                     border-color: var(--color-karaka);
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3679

**Problem:**
* Checkboxes in filters on mobile shown like a rectangle but not square

**In this PR:**
* Fix shape of checkboxes in the filter on mobile
