### PR TITLE
#3976 - Set center align for search before authorization

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -426,6 +426,6 @@
 
     &-MyAccountContainer {
         display: flex;
-        margin-inline-start: auto;
+        margin-inline-start: 40px;
     }
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3976

**Problem:**
* Search is not centrally aligned before authorization

**In this PR:**
* Set center align for search before authorization
