### PR TITLE
#3980 - Error message is displayed from the right side for RTL

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -70,7 +70,7 @@
             font-size: 12px;
             margin-block-end: -.1em;
             margin-block-start: 6px;
-            text-align: left;
+            text-align: start;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3980

**Problem:**
* Error message is displayed from the left side for RTL

**In this PR:**
* Error message is displayed from the right side for RTL
