### PR TITLE
#3983 - Disable price for out of stock product in Wishlist

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
@@ -287,6 +287,12 @@ export class WishlistItem extends PureComponent {
     }
 
     renderPrice(productPrice) {
+        const { inStock } = this.props;
+
+        if (!inStock) {
+            return null;
+        }
+
         return (
             <div
               block="WishlistItem"


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3983

**Problem:**
* Price is displayed for out of stock products in Wishlist

**In this PR:**
* Disable price for out of stock product in Wishlist
