### PR TITLE
issue-3996 - Set check before rendering coupone code

### DIFF
--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -161,6 +161,10 @@ export class CartOverlay extends PureComponent {
     }
 
     renderCouponCode(code) {
+        if (!code) {
+            return null;
+        }
+
         return <strong block="CartOverlay" elem="DiscountCoupon">{ `${code.toUpperCase()}:` }</strong>;
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3996

**Problem:**
* Shows oops page when rendering coupon code in cart overlay

**In this PR:**
* Set check for coupon code rendering
