### PR TITLE
issue-4008 - Set correct order id for downloadable orders on redirect

### DIFF
--- a/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.container.js
+++ b/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.container.js
@@ -34,10 +34,7 @@ export const mapStateToProps = (state) => ({
 /** @namespace Component/MyAccountDownloadable/Container/mapDispatchToProps */
 export const mapDispatchToProps = (dispatch) => ({
     showErrorNotification: (message) => dispatch(showNotification('error', message)),
-    showSuccessNotification: (message) => dispatch(showNotification('success', message)),
-    getOrderList: () => OrderDispatcher.then(
-        ({ default: dispatcher }) => dispatcher.requestOrders(dispatch)
-    )
+    showSuccessNotification: (message) => dispatch(showNotification('success', message))
 });
 
 /** @namespace Component/MyAccountDownloadable/Container */
@@ -55,9 +52,6 @@ export class MyAccountDownloadableContainer extends PureComponent {
     };
 
     componentDidMount() {
-        const { getOrderList } = this.props;
-
-        getOrderList();
         this.requestDownloadable();
     }
 
@@ -82,7 +76,8 @@ export class MyAccountDownloadableContainer extends PureComponent {
         return items.reduce((acc, item, index) => {
             acc.push({
                 id: index,
-                order_id: item.order_increment_id,
+                order_id: item.order_id,
+                order_increment_id: item.order_increment_id,
                 status_label: item.status,
                 created_at: item.date,
                 download_url: item.download_url,

--- a/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.component.js
+++ b/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.component.js
@@ -27,10 +27,10 @@ export class MyAccountDownloadableTableRowComponent extends PureComponent {
         isOpenInNewTab: PropTypes.bool.isRequired
     };
 
-    renderOrderId() {
+    renderOrderIncrementId() {
         const {
             order: {
-                order_id
+                order_increment_id
             },
             onOrderIdClick
         } = this.props;
@@ -38,7 +38,7 @@ export class MyAccountDownloadableTableRowComponent extends PureComponent {
         return (
             <div onClick={ onOrderIdClick } block="MyAccountDownloadTableRow" elem="OrderId">
                 #
-                { order_id }
+                { order_increment_id }
             </div>
         );
     }
@@ -73,7 +73,7 @@ export class MyAccountDownloadableTableRowComponent extends PureComponent {
     render() {
         const {
             order: {
-                order_id,
+                order_increment_id,
                 downloads,
                 created_at,
                 title,
@@ -83,7 +83,7 @@ export class MyAccountDownloadableTableRowComponent extends PureComponent {
 
         return (
             <tr block="MyAccountOrderTableRow">
-                <td>{ order_id ? this.renderOrderId() : '' }</td>
+                <td>{ order_increment_id ? this.renderOrderIncrementId() : '' }</td>
                 <td>{ created_at }</td>
                 <td>
                     { title }

--- a/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.container.js
+++ b/packages/scandipwa/src/component/MyAccountDownloadableTableRow/MyAccountDownloadableTableRow.container.js
@@ -29,13 +29,11 @@ export const mapStateToProps = (state) => ({
 });
 
 /** @namespace Component/MyAccountDownloadableTableRow/Container/mapDispatchToProps */
-export const mapDispatchToProps = () => ({
-});
+export const mapDispatchToProps = () => ({});
 
 /** @namespace Component/MyAccountDownloadableTableRow/Container */
 export class MyAccountDownloadableTableRowContainer extends PureComponent {
     static propTypes = {
-        showPopup: PropTypes.func.isRequired,
         orderList: OrdersType.isRequired,
         order: DownloadableType.isRequired,
         device: DeviceType.isRequired,
@@ -47,9 +45,9 @@ export class MyAccountDownloadableTableRowContainer extends PureComponent {
     };
 
     onOrderIdClick() {
-        const { order: { id } } = this.props;
+        const { order: { order_id } } = this.props;
 
-        history.push({ pathname: appendWithStoreCode(`${ACCOUNT_ORDER_URL}/${id}`) });
+        history.push({ pathname: appendWithStoreCode(`${ACCOUNT_ORDER_URL}/${order_id}`) });
     }
 
     containerProps() {

--- a/packages/scandipwa/src/query/Order.query.js
+++ b/packages/scandipwa/src/query/Order.query.js
@@ -504,6 +504,7 @@ export class OrderQuery {
 
     _getDownloadableFields() {
         return [
+            'order_id',
             'order_increment_id',
             'date',
             'status',

--- a/packages/scandipwa/src/type/Order.type.js
+++ b/packages/scandipwa/src/type/Order.type.js
@@ -133,7 +133,8 @@ export const OrderType = PropTypes.shape({
 
 export const DownloadableType = PropTypes.shape({
     id: PropTypes.number,
-    order_id: PropTypes.string,
+    order_id: PropTypes.number,
+    order_increment_id: PropTypes.string,
     status_label: PropTypes.string,
     downloads: PropTypes.string,
     download_url: PropTypes.string,


### PR DESCRIPTION
**Related PR(s):**
* https://github.com/scandipwa/customer-downloadable-graphql/pull/7

**Related issue(s):**
* Fixes #4008

**Problem:**
* When clicking or order row in downloadable orders, it redirect to not existing orders.

**In this PR:**
* Get and set correct order id for redirect
