### PR TITLE
3813/empty description fix

### DIFF
--- a/packages/scandipwa/src/component/ProductAttributes/ProductAttributes.container.js
+++ b/packages/scandipwa/src/component/ProductAttributes/ProductAttributes.container.js
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import { ProductType } from 'Type/ProductList.type';
+import { getAttributesWithValues } from 'Util/Product';
 
 import ProductAttributes from './ProductAttributes.component';
 
@@ -24,34 +25,12 @@ export class ProductAttributesContainer extends PureComponent {
     };
 
     containerProps() {
-        const { areDetailsLoaded } = this.props;
+        const { areDetailsLoaded, product } = this.props;
 
         return {
             areDetailsLoaded,
-            attributesWithValues: this._getAttributesWithValues()
+            attributesWithValues: getAttributesWithValues(product)
         };
-    }
-
-    _getAttributesWithValues() {
-        const { product: { attributes = {}, parameters = {} } } = this.props;
-
-        const allAttribsWithValues = Object.entries(attributes).reduce((acc, [key, val]) => {
-            const { attribute_label, attribute_value } = val;
-
-            if (attribute_value) {
-                return { ...acc, [attribute_label]: val };
-            }
-
-            const valueIndexFromParameter = parameters[key];
-
-            if (valueIndexFromParameter) {
-                return { ...acc, [attribute_label]: { ...val, attribute_value: valueIndexFromParameter } };
-            }
-
-            return acc;
-        }, {});
-
-        return allAttribsWithValues;
     }
 
     render() {

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -26,7 +26,7 @@ import { ProductType } from 'Type/ProductList.type';
 import { HistoryType, LocationType, MatchType } from 'Type/Router.type';
 import { scrollToTop } from 'Util/Browser';
 import { withReducers } from 'Util/DynamicReducer';
-import { getIsConfigurableParameterSelected } from 'Util/Product';
+import { getAttributesWithValues, getIsConfigurableParameterSelected } from 'Util/Product';
 import { debounce } from 'Util/Request';
 import {
     convertQueryStringToKeyValuePairs,
@@ -288,7 +288,7 @@ export class ProductPageContainer extends PureComponent {
     isProductAttributesTabEmpty() {
         const dataSource = this.getDataSource();
 
-        return Object.keys(dataSource?.attributes || {}).length === 0;
+        return Object.keys(getAttributesWithValues(dataSource) || {}).length === 0;
     }
 
     _addToRecentlyViewedProducts() {

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -278,9 +278,11 @@ export class ProductPageContainer extends PureComponent {
     }
 
     isProductInformationTabEmpty() {
-        const dataSource = this.getDataSource();
-
-        return dataSource?.description?.html?.length === 0;
+        const { description: { html = '' } = {} } = this.getDataSource();
+        // handling cases when empty html tag is received
+        const htmlElement = new DOMParser().parseFromString(html, 'text/html');
+        const text = htmlElement?.body?.innerText;
+        return text.length === 0;
     }
 
     isProductAttributesTabEmpty() {

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -281,8 +281,7 @@ export class ProductPageContainer extends PureComponent {
         const { description: { html = '' } = {} } = this.getDataSource();
         // handling cases when empty html tag is received
         const htmlElement = new DOMParser().parseFromString(html, 'text/html');
-        const text = htmlElement?.body?.innerText;
-        return text.length === 0;
+        return !htmlElement?.body?.innerText;
     }
 
     isProductAttributesTabEmpty() {

--- a/packages/scandipwa/src/util/Product/Product.js
+++ b/packages/scandipwa/src/util/Product/Product.js
@@ -457,3 +457,24 @@ export const validateProductQuantity = (quantity, stockItem) => {
 
     return [true];
 };
+
+/** @namespace Util/Product/getAttributesWithValues */
+export const getAttributesWithValues = (product) => {
+    const { attributes = {}, parameters = {} } = product;
+
+    return Object.entries(attributes).reduce((acc, [key, val]) => {
+        const { attribute_label, attribute_value } = val;
+
+        if (attribute_value) {
+            return { ...acc, [attribute_label]: val };
+        }
+
+        const valueIndexFromParameter = parameters[key];
+
+        if (valueIndexFromParameter) {
+            return { ...acc, [attribute_label]: { ...val, attribute_value: valueIndexFromParameter } };
+        }
+
+        return acc;
+    }, {});
+};


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3813, issue 2

**Problem:**
* Description of `<p></p>` was returned from the server, which is an empty text.

**In this PR:**
* Added html tag parsing and check of text length inside the tag.

**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3813, issue 3

**Problem:**
* Tab is rendered if attributes object is not empty, but not all attributes are rendered in Details tab. There may be a case when all the attributes are not rendered.

**In this PR:**
* Get list of attributes that are rendered when making a decision whether to show Details tab or not. 
