### PR TITLE
#3930 - Add space after account information on mobile

### DIFF
--- a/packages/scandipwa/src/component/MyAccountInformation/MyAccountInformation.style.scss
+++ b/packages/scandipwa/src/component/MyAccountInformation/MyAccountInformation.style.scss
@@ -26,6 +26,12 @@
                 &-Section {
                     width: 48%;
 
+                    &:nth-child(2) {
+                        @include mobile {
+                            margin-block-start: 16px;
+                        }
+                    }
+
                     @include mobile {
                         width: 100%;
                     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3930

**Problem:**
* Space is absent in 'Account Information' after selected checkboxes

**In this PR:**
* Add space in 'Account Information' after selected checkboxes on mobile
