### PR TITLE
#3294 - Loader icon is displayed separately for each product

### DIFF
--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -38,14 +38,12 @@ export class CartOverlay extends PureComponent {
         cartTotalSubPrice: PropTypes.number,
         cartDisplaySettings: CartDisplayType.isRequired,
         isMobile: PropTypes.bool.isRequired,
-        onCartItemLoading: PropTypes.func,
-        isCartItemLoading: PropTypes.bool
+        onCartItemLoading: PropTypes.func
     };
 
     static defaultProps = {
         hasOutOfStockProductsInCart: false,
         onCartItemLoading: null,
-        isCartItemLoading: false,
         currencyCode: null,
         cartTotalSubPrice: null
     };
@@ -70,7 +68,6 @@ export class CartOverlay extends PureComponent {
                 items = [],
                 quote_currency_code
             },
-            isCartItemLoading,
             onCartItemLoading
         } = this.props;
 
@@ -86,7 +83,7 @@ export class CartOverlay extends PureComponent {
                       item={ item }
                       currency_code={ quote_currency_code }
                       onCartItemLoading={ onCartItemLoading }
-                      showLoader={ isCartItemLoading }
+                      showLoader
                       isCartOverlay
                     />
                 )) }

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -16,7 +16,6 @@ import CartItem from 'Component/CartItem';
 import CmsBlock from 'Component/CmsBlock';
 import { CART_OVERLAY } from 'Component/Header/Header.config';
 import Link from 'Component/Link';
-import Loader from 'Component/Loader';
 import LockIcon from 'Component/LockIcon';
 import Overlay from 'Component/Overlay';
 import { OVERLAY_PLACEHOLDER } from 'Component/PopupSuspense/PopupSuspense.config';
@@ -81,14 +80,13 @@ export class CartOverlay extends PureComponent {
 
         return (
             <div block="CartOverlay" elem="Items" aria-label="List of items in cart">
-                <Loader isLoading={ isCartItemLoading } />
                 { items.map((item) => (
                     <CartItem
                       key={ item.item_id }
                       item={ item }
                       currency_code={ quote_currency_code }
                       onCartItemLoading={ onCartItemLoading }
-                      showLoader={ false }
+                      showLoader={ isCartItemLoading }
                       isCartOverlay
                     />
                 )) }

--- a/packages/scandipwa/src/route/CartPage/CartPage.component.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.component.js
@@ -36,15 +36,13 @@ export class CartPage extends PureComponent {
         hasOutOfStockProductsInCart: PropTypes.bool,
         onCouponCodeUpdate: PropTypes.func,
         onCartItemLoading: PropTypes.func,
-        isCartItemLoading: PropTypes.bool,
         device: DeviceType.isRequired
     };
 
     static defaultProps = {
         hasOutOfStockProductsInCart: false,
         onCouponCodeUpdate: noopFn,
-        onCartItemLoading: null,
-        isCartItemLoading: false
+        onCartItemLoading: null
     };
 
     renderCartItems() {
@@ -53,7 +51,6 @@ export class CartPage extends PureComponent {
                 items,
                 quote_currency_code
             },
-            isCartItemLoading,
             onCartItemLoading
         } = this.props;
 
@@ -81,7 +78,7 @@ export class CartPage extends PureComponent {
                           item={ item }
                           currency_code={ quote_currency_code }
                           onCartItemLoading={ onCartItemLoading }
-                          showLoader={ isCartItemLoading }
+                          showLoader
                           isEditing
                           updateCrossSellsOnRemove
                         />

--- a/packages/scandipwa/src/route/CartPage/CartPage.component.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.component.js
@@ -75,14 +75,13 @@ export class CartPage extends PureComponent {
                     <span>{ __('subtotal') }</span>
                 </p>
                 <div block="CartPage" elem="Items" aria-label="List of items in cart">
-                    <Loader isLoading={ isCartItemLoading } />
                     { items.map((item) => (
                         <CartItem
                           key={ item.item_id }
                           item={ item }
                           currency_code={ quote_currency_code }
                           onCartItemLoading={ onCartItemLoading }
-                          showLoader={ false }
+                          showLoader={ isCartItemLoading }
                           isEditing
                           updateCrossSellsOnRemove
                         />


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3294

**Problem:**
* Loader icon is displayed for all product in cart

**In this PR:**
* Loader icon is displayed separately for each product
