### PR TITLE
#3922 - Fix position of price for bundle products with discount

### DIFF
--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.style.scss
@@ -72,7 +72,6 @@
         &_hasDiscount {
             .ProductPrice {
                 &-PriceBadge {
-                    display: block;
                     margin-block-start: 5px;
                     margin-block-end: -5px;
                 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3922

**Problem:**
* Wrong position of prices in product card on PLP for bundle products with discount

**In this PR:**
* Right position of price for bundle products with discount
