### PR TITLE
#3803 - Add including and excluding tax for shipping method

### DIFF
--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
@@ -28,13 +28,35 @@ export class CheckoutDeliveryOption extends PureComponent {
         currency: PropTypes.string.isRequired,
         isSelected: PropTypes.bool,
         optionPrice: PropTypes.number,
+        optionSubPrice: PropTypes.number,
         onOptionClick: PropTypes.func.isRequired
     };
 
     static defaultProps = {
         isSelected: false,
-        optionPrice: 0
+        optionPrice: 0,
+        optionSubPrice: 0
     };
+
+    renderSubPrice() {
+        const {
+            currency,
+            optionSubPrice
+        } = this.props;
+
+        if (!optionSubPrice) {
+            return null;
+        }
+
+        return (
+            <span
+              block="CheckoutDeliveryOption"
+              elem="SubPrice"
+            >
+                { __('Excl. tax: %s', formatPrice(optionSubPrice, currency)) }
+            </span>
+        );
+    }
 
     getOptionPrice() {
         const {
@@ -59,6 +81,7 @@ export class CheckoutDeliveryOption extends PureComponent {
         return (
             <strong>
                 { ` - ${ this.getOptionPrice() }` }
+                { this.renderSubPrice() }
             </strong>
         );
     }

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
@@ -62,9 +62,8 @@
         font-size: 12px;
         font-weight: 400;
         text-align: end;
-        margin-inline-start: 15px;
         position: absolute;
-        inset-inline-start: 0;
+        inset-inline-end: 0;
         inset-block-start: 1.5em;
         white-space: nowrap;
     }

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
@@ -62,6 +62,7 @@
         font-size: 12px;
         font-weight: 400;
         text-align: end;
+        margin-inline-start: 15px;
         position: absolute;
         inset-inline-start: 0;
         inset-block-start: 1.5em;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3803

**Problem:**
* Shipping price isn`t displayed Including and Excluding Tax at the same time

**In this PR:**
* Shipping price is display tax according to the parameters selected in the admin panel
