### PR TITLE
scandipwa#3972 - fix search with ampersand

### DIFF
--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,11 +77,11 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = searchCriteria.trim().replace(/\s/g, '+');
+        const search = searchCriteria.trim();
         const trimmedSearch = searchCriteria.trim();
 
         if (e.key === 'Enter' && trimmedSearch !== '') {
-            history.push(appendWithStoreCode(`/search/${ search }`));
+            history.push(appendWithStoreCode(`/search/${ encodeURIComponent(search) }`));
             hideActiveOverlay();
             onSearchBarChange({ target: { value: '' } });
             this.searchBarRef.current.blur();

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.component.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.component.js
@@ -28,7 +28,7 @@ export class SearchPage extends CategoryPage {
               } }
             >
                 { __('Search results for: ') }
-                <span>{ search.replace(/\+/g, ' ') }</span>
+                <span>{ decodeURIComponent(search) }</span>
             </h1>
         );
     }

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
@@ -114,7 +114,7 @@ export class SearchPageContainer extends CategoryPageContainer {
 
     updateBreadcrumbs() {
         const { updateBreadcrumbs } = this.props;
-        const search = this.getSearchParam();
+        const search = decodeURIComponent(this.getSearchParam());
 
         updateBreadcrumbs([{
             url: '',
@@ -217,7 +217,7 @@ export class SearchPageContainer extends CategoryPageContainer {
             <SearchPage
               { ...this.containerFunctions }
               { ...this.containerProps() }
-              // addded here to not override the container props
+              // added here to not override the container props
               search={ this.getSearchParam() }
               sortFields={ this.getSortFields() }
             />


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3972

**Problem:**
* `&` in url is normally used for separating pairs of query params. It should be encoded if used as part of query param.

**In this PR:**
* Removed replacement of ' ' to '+', used URL encoding instead (which handles `&` in search param among other cases). 


This is reacreated PR from @tappiola https://github.com/scandipwa/scandipwa/pull/4031