### PR TITLE
#3956 Hover effect is absent on billing options

### DIFF
--- a/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.component.js
+++ b/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.component.js
@@ -64,11 +64,9 @@ export class CheckoutPayment extends PureComponent {
                           name: `option-${ title }`,
                           checked: isSelected
                       } }
+                      label={ title }
                       isDisabled
                     />
-                    <label elem="Label" htmlFor={ `option-${ title }` }>
-                        { title }
-                    </label>
                 </button>
             </li>
         );

--- a/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.component.js
+++ b/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.component.js
@@ -66,7 +66,9 @@ export class CheckoutPayment extends PureComponent {
                       } }
                       isDisabled
                     />
-                    { title }
+                    <label elem="Label" htmlFor={ `option-${ title }` }>
+                        { title }
+                    </label>
                 </button>
             </li>
         );

--- a/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.component.js
+++ b/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.component.js
@@ -65,7 +65,7 @@ export class CheckoutPayment extends PureComponent {
                           checked: isSelected
                       } }
                       label={ title }
-                      isDisabled
+                      isDisabled={ false }
                     />
                 </button>
             </li>

--- a/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.style.scss
+++ b/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.style.scss
@@ -48,6 +48,5 @@
 
     .Field_type_checkbox {
         margin-block-start: 0;
-        pointer-events: auto;
     }
 }

--- a/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.style.scss
+++ b/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.style.scss
@@ -48,6 +48,6 @@
 
     .Field_type_checkbox {
         margin-block-start: 0;
-        pointer-events: none;
+        pointer-events: auto;
     }
 }

--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -54,6 +54,9 @@
 
         &:hover {
             cursor: pointer;
+            @include desktop {
+                color: var(--primary-base-color);
+            }
         }
 
         .input-control {

--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -54,6 +54,7 @@
 
         &:hover {
             cursor: pointer;
+            
             @include desktop {
                 color: var(--primary-base-color);
             }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3956

**Problem:**
* Hover effect is absent on billing options

**In this PR:**
* changed .Field_type_checkbox pointer-events from none to auto
* wraped billing options title in label pointed to billing options input checkbox
