### PR TITLE
#3928 Wrong space between last subcategory and category in mobile menu

### DIFF
--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -202,6 +202,10 @@
                 background: var(--color-gray);
                 display: block;
                 padding-inline: 16px;
+                
+                @include mobile {
+                    margin-bottom: 22px;
+                }
             }
 
             @include desktop {


### PR DESCRIPTION
**Related issue(s):**
* [#3928 Wrong space between last subcategory and category in mobile menu](https://github.com/scandipwa/scandipwa/issues/3928)

**Problem:**
* Wrong space between last subcategory and category in mobile menu

**In this PR:**
* add margin-bottom: 22px to isVisible menu for mobile state
