### PR TITLE
SKU bundle to right alligment on mobile

### DIFF
--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -82,6 +82,7 @@
         @include mobile {
             font-weight: normal;
             font-size: 12px;
+            text-align: end;
         }
 
         & + .ProductActions-Sku {


### PR DESCRIPTION
**Related issue(s):**
* Fixes [#3931 SKU for bundle products has left alignment on PDP on mobile ](https://github.com/scandipwa/scandipwa/issues/3931)

**Problem:**
* SKU for bundle products has left alignment on PDP on mobile, its need to be right-aligned

**In this PR:**
* adding text-align:end to ProductActions-Sku class
