### PR TITLE
#3928 Wrong space between last subcategory and category in mobile menu

### DIFF
--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -204,7 +204,7 @@
                 padding-inline: 16px;
 
                 @include mobile {
-                    margin-bottom: 22px;
+                    margin-block-end: 22px;
                 }
             }
 

--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -202,6 +202,10 @@
                 background: var(--color-gray);
                 display: block;
                 padding-inline: 16px;
+
+                @include mobile {
+                    margin-bottom: 22px;
+                }
             }
 
             @include desktop {

--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -204,7 +204,7 @@
                 padding-inline: 16px;
 
                 @include mobile {
-                    margin-block-end: 22px;
+                    margin-block-end: 0px;
                 }
             }
 

--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -204,7 +204,7 @@
                 padding-inline: 16px;
 
                 @include mobile {
-                    margin-block-end: 0px;
+                    margin-block-end: 0;
                 }
             }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3928

**Problem:**
* Wrong space between last subcategory and category in the mobile menu it should be 22px

**In this PR:**
* adding margin-bottom: 22px to _isVisible mobile state
