### PR TITLE
#4047 Account icon is shifted left on checkout 

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -426,6 +426,6 @@
 
     &-MyAccountContainer {
         display: flex;
-        margin-inline-start: 40px;
+        margin-inline-start: auto;
     }
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes [#4047 Account icon is shifted left on checkout ](https://github.com/scandipwa/scandipwa/issues/4047)

**Problem:**
* Account icon is shifted left on checkout

**In this PR:**
* change MyaccountContainer margin-inline-start from 44px to auto

