### PR TITLE
#3940 Line height if price of product is in mini cart adjusted

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.style.scss
+++ b/packages/scandipwa/src/component/CartItem/CartItem.style.scss
@@ -183,6 +183,7 @@
 
         &_isCartOverlay data {
             font-size: 14px;
+            line-height: 20px;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3940

**Problem:**
* Line height set to 28px if the price of the product is in mini cart

**In this PR:**
* Line height set to 20px
