### PR TITLE
#3930 - Add space after account information on mobile

### DIFF
--- a/packages/scandipwa/src/component/MyAccountCustomerForm/MyAccountCustomerForm.component.js
+++ b/packages/scandipwa/src/component/MyAccountCustomerForm/MyAccountCustomerForm.component.js
@@ -161,7 +161,11 @@ export class MyAccountCustomerForm extends FieldForm {
                     </legend>
                         { this.customerInformationFieldMap.map(this.renderSection) }
                     </div>
-                    <div block="FieldForm" elem="Section">
+                    <div
+                      block="FieldForm"
+                      elem="Section"
+                      mix={ { block: 'FieldForm', elem: 'SectionWithSpace' } }
+                    >
                         { this.renderEmailAndPasswordFields() }
                     </div>
                 </div>

--- a/packages/scandipwa/src/component/MyAccountInformation/MyAccountInformation.style.scss
+++ b/packages/scandipwa/src/component/MyAccountInformation/MyAccountInformation.style.scss
@@ -26,6 +26,12 @@
                 &-Section {
                     width: 48%;
 
+                    &:nth-child(2) {
+                        @include mobile {
+                            margin-block-start: 16px;
+                        }
+                    }
+
                     @include mobile {
                         width: 100%;
                     }

--- a/packages/scandipwa/src/component/MyAccountInformation/MyAccountInformation.style.scss
+++ b/packages/scandipwa/src/component/MyAccountInformation/MyAccountInformation.style.scss
@@ -26,14 +26,14 @@
                 &-Section {
                     width: 48%;
 
-                    &:nth-child(2) {
+                    @include mobile {
+                        width: 100%;
+                    }
+
+                    &WithSpace {
                         @include mobile {
                             margin-block-start: 16px;
                         }
-                    }
-
-                    @include mobile {
-                        width: 100%;
                     }
                 }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3930

**Problem:**
* Space is absent in 'Account Information' after selected checkboxes

**In this PR:**
* Add space in 'Account Information' after selected checkboxes on mobile
