### PR TITLE
#4010 Required star on the same line as required field

### DIFF
--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
@@ -283,7 +283,7 @@ export class ProductCustomizableOption extends PureComponent {
         return (
             <div block="ProductCustomizableItem" elem="Heading">
                 { title }
-                { isRequired && <strong block="ProductCustomizableItem" elem="Required"> *</strong> }
+                { isRequired && <strong block="ProductCustomizableItem" elem="Required">*</strong> }
             </div>
         );
     }

--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
@@ -66,7 +66,7 @@
 
     &-Required {
         color: var(--customizable-options-required-text-color);
-        //margin-block-start: 6px;
+        margin-left: 4px;
 
         @include mobile {
             margin-block-start: 7px;

--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
@@ -66,7 +66,7 @@
 
     &-Required {
         color: var(--customizable-options-required-text-color);
-        margin-left: 4px;
+        margin-inline-start: 4px;
 
         @include mobile {
             margin-block-start: 7px;
@@ -108,6 +108,7 @@
             font-weight: bold;
         }
     }
+
     &-Heading {
         font-size: 14px;
         width: auto;

--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
@@ -18,7 +18,7 @@
     &-PriceLabel {
         white-space: nowrap;
     }
-    
+
     &-Wrapper {
         margin-block-start: 26px;
 
@@ -66,7 +66,7 @@
 
     &-Required {
         color: var(--customizable-options-required-text-color);
-        margin-block-start: 6px;
+        //margin-block-start: 6px;
 
         @include mobile {
             margin-block-start: 7px;
@@ -108,9 +108,10 @@
             font-weight: bold;
         }
     }
-
     &-Heading {
         font-size: 14px;
+        width: auto;
+        display: inline-flex;
 
         &Bold {
             font-size: 14px;
@@ -120,6 +121,10 @@
         &Price {
             font-size: 12px;
             font-weight: bold;
+        }
+
+        &>div{
+            width: auto;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4010

**Problem:**
* Star for customizable product option is in the next line of its fields

**In this PR:**
* Now required start is on the same line as required field
