### PR TITLE
#3699 - Remove the specified font size for the title

### DIFF
--- a/packages/scandipwa/src/route/ConfirmAccountPage/ConfirmAccountPage.style.scss
+++ b/packages/scandipwa/src/route/ConfirmAccountPage/ConfirmAccountPage.style.scss
@@ -36,13 +36,11 @@
     }
 
     &-Heading {
-        font-size: 36px;
         margin-block-end: 12px;
         padding-block-start: 24px;
         text-align: center;
 
         @include mobile {
-            font-size: 28px;
             margin-block-end: 14px;
             margin-block-start: 28px;
             display: none;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3699

**Problem:**
* Header 'Confirm Your Account' has fixed font size

**In this PR:**
* Header 'Confirm Your Account' font size inherited from H1
