### PR TITLE
#3190 Add missing callback after successful login.

### DIFF
--- a/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.component.js
+++ b/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.component.js
@@ -38,7 +38,8 @@ export class CheckoutGuestForm extends FieldForm {
         isEmailAvailable: PropTypes.bool.isRequired,
         emailValue: PropTypes.string.isRequired,
         signInState: PropTypes.string.isRequired,
-        setSignInState: PropTypes.func.isRequired
+        setSignInState: PropTypes.func.isRequired,
+        onSignIn: PropTypes.func.isRequired
     };
 
     // eslint-disable-next-line @scandipwa/scandipwa-guidelines/only-render-in-component

--- a/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.js
+++ b/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.js
@@ -137,9 +137,12 @@ export class CheckoutGuestFormContainer extends PureComponent {
             emailValue,
             isEmailAvailable,
             isLoading,
-            signInState
+            signInState,
+            onSignIn: this.handleOnMyAccountSignIn
         });
     }
+
+    handleOnMyAccountSignIn() {}
 
     onFormError() {
         this.setState({ isLoading: false });

--- a/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.js
+++ b/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.js
@@ -129,7 +129,7 @@ export class CheckoutGuestFormContainer extends PureComponent {
     }
 
     containerProps() {
-        const { emailValue, isEmailAvailable } = this.props;
+        const { emailValue, isEmailAvailable, onSignIn } = this.props;
         const { isLoading, signInState } = this.state;
 
         return ({
@@ -138,11 +138,9 @@ export class CheckoutGuestFormContainer extends PureComponent {
             isEmailAvailable,
             isLoading,
             signInState,
-            onSignIn: this.handleOnMyAccountSignIn
+            onSignIn
         });
     }
-
-    handleOnMyAccountSignIn() {}
 
     onFormError() {
         this.setState({ isLoading: false });


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3190

**Problem:**
* The onSignOn callback that was supposed to be called after successful login on the Checkout page is 'undefined' thus a misleading error message appears.

**In this PR:**
* Added an empty 'onMyAccountSignIn' handler to the 'CheckoutGuestForm' container.
