### PR TITLE
#3312 Text overlaps to bullets on CMS page

### DIFF
--- a/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
@@ -112,4 +112,15 @@
     .widget {
         overflow-x: auto;
     }
+    
+    ul,
+    ol {
+        margin-inline-start: 20px;
+
+        li {
+            &::before {
+                inset-inline-start: -20px;
+            }
+        }
+    }
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes [#3312 Text overlaps to bullets on CMS page](https://github.com/scandipwa/scandipwa/issues/3312)

**Problem:**
* Text overlaps to bullets on CMS page

**In this PR:**
* adding margin-inline-start for ul / ol
* adding inset-inline-startfor li:before
