### PR TITLE
adding scroll to top

### DIFF
--- a/packages/scandipwa/src/route/LoginAccount/LoginAccount.container.js
+++ b/packages/scandipwa/src/route/LoginAccount/LoginAccount.container.js
@@ -58,7 +58,6 @@ export class LoginAccountContainer extends MyAccountOverlayContainer {
     }
 
     componentDidMount() {
-        scrollToTop({ behavior: 'smooth' });
         const {
             setHeaderState,
             toggleBreadcrumbs,
@@ -75,6 +74,7 @@ export class LoginAccountContainer extends MyAccountOverlayContainer {
 
         setHeaderState({ name: CUSTOMER_ACCOUNT, title: __('Sign in') });
         toggleBreadcrumbs(false);
+        scrollToTop({ behavior: 'smooth' });
     }
 
     componentDidUpdate(prevProps, prevState) {

--- a/packages/scandipwa/src/route/LoginAccount/LoginAccount.container.js
+++ b/packages/scandipwa/src/route/LoginAccount/LoginAccount.container.js
@@ -24,6 +24,7 @@ import { ACCOUNT_FORGOT_PASSWORD_URL, ACCOUNT_REGISTRATION_URL, ACCOUNT_URL } fr
 import { toggleBreadcrumbs } from 'Store/Breadcrumbs/Breadcrumbs.action';
 import { LocationType } from 'Type/Router.type';
 import { isSignedIn } from 'Util/Auth';
+import { scrollToTop } from 'Util/Browser';
 import history from 'Util/History';
 import { appendWithStoreCode } from 'Util/Url';
 
@@ -57,6 +58,7 @@ export class LoginAccountContainer extends MyAccountOverlayContainer {
     }
 
     componentDidMount() {
+        scrollToTop({ behavior: 'smooth' });
         const {
             setHeaderState,
             toggleBreadcrumbs,


### PR DESCRIPTION
**Related issue(s):**
* Fixes [#3281 Mobile: Make pages start from the top when you switch to them](https://github.com/scandipwa/scandipwa/issues/3281)

**Problem:**
When you are on mobile, it might be that you change to a different page and it will be scrolled down if you had scrolled down before. Please, make pages start from the top when you switch to them. This include:

1. Sign in
2. Create account
3. Forgot password
4. Compare products


**In this PR:**
* adding scroll to top in LoginAccount container when componentDidMount() function
