### PR TITLE
See #4084 Fixed issue when wrong template file was applied.

### DIFF
--- a/packages/stylelint-config/build-config/stylelint.js
+++ b/packages/stylelint-config/build-config/stylelint.js
@@ -2,7 +2,7 @@ const StylelintPlugin = require('stylelint-webpack-plugin');
 
 module.exports = {
     plugin: {
-        overrideCracoConfig: async ({
+        overrideCracoConfig: ({
             cracoConfig
         }) => {
             cracoConfig.webpack.plugins.push(new StylelintPlugin({


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4084

**Problem:**
* If `overrideCracoConfig` is async, it breaks the build process for `m2-theme` plugin. In this case HTML template is build instead of PHTML.

**In this PR:**
* Fixed stylelint plugin and build process.
