### PR TITLE
Fix for html script hash generation

### DIFF
--- a/packages/scandipwa/src/component/Html/Html.component.js
+++ b/packages/scandipwa/src/component/Html/Html.component.js
@@ -222,7 +222,7 @@ export class Html extends PureComponent {
 
     replaceScript(elem) {
         const { attribs, children } = elem;
-        const elemHash = hash(elem);
+        const elemHash = hash(children[0].data);
 
         if (this.createdOutsideElements[elemHash]) {
             return <></>;


### PR DESCRIPTION
**Problem:**
All scripts have the same hash, only one script per page can be parsed.

**In this PR:**
Adjusting code to use the content of the script tag that is a `string` when generating a hash for the script
