### PR TITLE
#2608 Cross-sells products getting duplicated if user added config products to cart with different attributes options 

### DIFF
--- a/packages/scandipwa/src/route/CartPage/CartPage.container.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.container.js
@@ -249,7 +249,10 @@ export class CartPageContainer extends PureComponent {
             } = {}
         } = this.props;
 
-        updateCrossSellProducts(items);
+        const list = items.filter((product, index) => index
+        === items.findIndex((products) => products.id === product.id));
+
+        updateCrossSellProducts(list);
     }
 
     render() {

--- a/packages/scandipwa/src/route/CartPage/CartPage.container.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.container.js
@@ -34,7 +34,8 @@ import {
     getCartSubtotal,
     getCartSubtotalSubPrice,
     getCartTotalSubPrice,
-    getItemsCountLabel
+    getItemsCountLabel,
+    trimCrossSellDuplicateItems
 } from 'Util/Cart';
 import history from 'Util/History';
 import { getProductInStock } from 'Util/Product/Extract';
@@ -249,20 +250,7 @@ export class CartPageContainer extends PureComponent {
             } = {}
         } = this.props;
 
-        const list = items.filter(
-            (item, index, array) => {
-                if (index === 0) {
-                    return true;
-                }
-
-                if (item.product.variants.length === 0) {
-                    return true;
-                }
-
-                const duplicate = array.find((element) => element.product.id === item.product.id);
-                return (duplicate.product.id === item.product.id && duplicate.sku === item.sku);
-            }
-        );
+        const list = trimCrossSellDuplicateItems(items);
 
         updateCrossSellProducts(list);
     }

--- a/packages/scandipwa/src/route/CartPage/CartPage.container.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.container.js
@@ -249,8 +249,20 @@ export class CartPageContainer extends PureComponent {
             } = {}
         } = this.props;
 
-        const list = items.filter((product, index) => index
-        === items.findIndex((products) => products.id === product.id));
+        const list = items.filter(
+            (item, index, array) => {
+                if (index === 0) {
+                    return true;
+                }
+
+                if (item.product.variants.length === 0) {
+                    return true;
+                }
+
+                const duplicate = array.find((element) => element.product.id === item.product.id);
+                return (duplicate.product.id === item.product.id && duplicate.sku === item.sku);
+            }
+        );
 
         updateCrossSellProducts(list);
     }

--- a/packages/scandipwa/src/util/Cart/Cart.js
+++ b/packages/scandipwa/src/util/Cart/Cart.js
@@ -240,3 +240,22 @@ export const getAllCartItemsSku = (cartItems) => cartItems.reduce((acc, item) =>
 
     return acc;
 }, []);
+
+/** @namespace Util/Cart/trimCrossSellDuplicateItems */
+export const trimCrossSellDuplicateItems = (items) => items.filter(
+    ({
+        sku: itemSku,
+        product: { variants: itemVariants, id: itemId }
+    }, index, array) => {
+        if (index === 0 || itemVariants.length === 0) {
+            return true;
+        }
+
+        const {
+            sku: duplicateSku,
+            product: { id: duplicateId }
+        } = array.find(({ product: { id: elementId } }) => elementId === itemId);
+
+        return (duplicateId === itemId && duplicateSku === itemSku);
+    }
+);

--- a/packages/scandipwa/src/util/Cart/Cart.js
+++ b/packages/scandipwa/src/util/Cart/Cart.js
@@ -247,7 +247,7 @@ export const trimCrossSellDuplicateItems = (items) => items.filter(
         sku: itemSku,
         product: { variants: itemVariants, id: itemId }
     }, index, array) => {
-        if (index === 0 || itemVariants.length === 0) {
+        if (!index || !itemVariants.length) {
             return true;
         }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes [#2608 Cross-sells products getting duplicated if user added config products to cart with different attributes options](https://github.com/scandipwa/scandipwa/issues/2608)

**Problem:**
* Cross-sells products getting duplicated in the cart if user added config products with different options to cart

**In this PR:**
* add filtering for duplicate product (configurable product) items that will be used to search Cross-sell Product
