### PR TITLE
issue-3705 - Remove compare uid on log out

### DIFF
--- a/packages/scandipwa/src/store/MyAccount/MyAccount.dispatcher.js
+++ b/packages/scandipwa/src/store/MyAccount/MyAccount.dispatcher.js
@@ -30,6 +30,7 @@ import {
 } from 'Util/Auth';
 import BrowserDatabase from 'Util/BrowserDatabase';
 import { deleteGuestQuoteId, getGuestQuoteId, setGuestQuoteId } from 'Util/Cart';
+import { removeUid } from 'Util/Compare';
 import history from 'Util/History';
 import { prepareQuery } from 'Util/Query';
 import { executePost, fetchMutation, getErrorMessage } from 'Util/Request';
@@ -98,6 +99,7 @@ export class MyAccountDispatcher {
 
         deleteGuestQuoteId();
         BrowserDatabase.deleteItem(CUSTOMER);
+        removeUid();
 
         dispatch(updateCustomerSignInStatus(false));
         dispatch(updateCustomerDetails({}));


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3705 

**Problem:**
* When manually using log out compare uid still present.

**In this PR:**
* Remove compare uid on log out
