### PR TITLE
#3954 Field auto fulled if user delete last symbol of previous password in Edit email in Account information

### DIFF
--- a/packages/scandipwa/src/component/MyAccountCustomerForm/MyAccountCustomerForm.container.js
+++ b/packages/scandipwa/src/component/MyAccountCustomerForm/MyAccountCustomerForm.container.js
@@ -73,7 +73,7 @@ export class MyAccountCustomerFormContainer extends PureComponent {
             handleChangeEmailCheckbox,
             handleChangePasswordCheckbox,
             currentPassword,
-            email: email || currentCustomerEmail
+            email: email === null ? currentCustomerEmail : email
         };
     }
 

--- a/packages/scandipwa/src/component/MyAccountCustomerForm/MyAccountCustomerForm.container.js
+++ b/packages/scandipwa/src/component/MyAccountCustomerForm/MyAccountCustomerForm.container.js
@@ -48,7 +48,8 @@ export class MyAccountCustomerFormContainer extends PureComponent {
 
     state = {
         email: null,
-        currentPassword: ''
+        currentPassword: '',
+        isEmailEdit: false
     };
 
     containerProps() {
@@ -61,7 +62,7 @@ export class MyAccountCustomerFormContainer extends PureComponent {
             handleChangeEmailCheckbox,
             handleChangePasswordCheckbox
         } = this.props;
-        const { email, currentPassword } = this.state;
+        const { email, currentPassword, isEmailEdit } = this.state;
 
         return {
             customer,
@@ -73,7 +74,7 @@ export class MyAccountCustomerFormContainer extends PureComponent {
             handleChangeEmailCheckbox,
             handleChangePasswordCheckbox,
             currentPassword,
-            email: email === null ? currentCustomerEmail : email
+            email: !isEmailEdit ? currentCustomerEmail : email
         };
     }
 
@@ -91,7 +92,7 @@ export class MyAccountCustomerFormContainer extends PureComponent {
     }
 
     handleEmailInput(emailInput) {
-        this.setState({ email: emailInput.target.value });
+        this.setState({ email: emailInput.target.value, isEmailEdit: true });
     }
 
     handlePasswordInput(currentPasswordInput) {


### PR DESCRIPTION
**Related issue(s):**
* Fixes [#3954 Field auto fulled if user delete last symbol of previous password in Edit email in Account information](https://github.com/scandipwa/scandipwa/issues/3954)

**Problem:**
* Endless delete of email address possible in Edit email in Account information
Field auto fulled if user delete last symbol of previous password

**In this PR:**
* change checker to only return currentCustomerEmail when email is null

note : branch got swapped but code is fine