### PR TITLE
Issue 3281

### DIFF
--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.container.js
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.container.js
@@ -18,6 +18,7 @@ import {
 } from 'Component/ProductCompare/ProductCompare.config';
 import { DeviceType } from 'Type/Device.type';
 import { ItemType, ProductItemsType } from 'Type/ProductList.type';
+import { scrollToTop } from 'Util/Browser';
 import { getProductInStock } from 'Util/Product/Extract';
 
 import ProductCompare from './ProductCompare.component';
@@ -84,6 +85,7 @@ export class ProductCompareContainer extends PureComponent {
 
     componentDidMount() {
         this.fetchCompareList();
+        scrollToTop({ behavior: 'smooth' });
     }
 
     componentDidUpdate() {

--- a/packages/scandipwa/src/route/CreateAccount/CreateAccount.container.js
+++ b/packages/scandipwa/src/route/CreateAccount/CreateAccount.container.js
@@ -21,6 +21,7 @@ import {
 import { ACCOUNT_LOGIN_URL, ACCOUNT_URL } from 'Route/MyAccount/MyAccount.config';
 import { toggleBreadcrumbs } from 'Store/Breadcrumbs/Breadcrumbs.action';
 import { isSignedIn } from 'Util/Auth';
+import { scrollToTop } from 'Util/Browser';
 import history from 'Util/History';
 import { appendWithStoreCode } from 'Util/Url';
 
@@ -77,6 +78,7 @@ export class CreateAccountContainer extends MyAccountOverlayContainer {
                 this.handleSignIn(e);
             }
         });
+        scrollToTop({ behavior: 'smooth' });
     }
 
     onLoginClick() {

--- a/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.container.js
+++ b/packages/scandipwa/src/route/ForgotPassword/ForgotPassword.container.js
@@ -21,6 +21,7 @@ import {
 } from 'Component/MyAccountOverlay/MyAccountOverlay.container';
 import { ACCOUNT_LOGIN_URL, ACCOUNT_REGISTRATION_URL } from 'Route/MyAccount/MyAccount.config';
 import { toggleBreadcrumbs } from 'Store/Breadcrumbs/Breadcrumbs.action';
+import { scrollToTop } from 'Util/Browser';
 import history from 'Util/History';
 import { appendWithStoreCode } from 'Util/Url';
 
@@ -66,6 +67,7 @@ export class ForgotPasswordContainer extends MyAccountOverlayContainer {
                 this.handleSignIn(e);
             }
         });
+        scrollToTop({ behavior: 'smooth' });
     }
 
     onLoginClick() {


### PR DESCRIPTION
**Related issue(s):**
* Fixes [#3281 Mobile: Make pages start from the top when you switch to them](https://github.com/scandipwa/scandipwa/issues/3281)

**Problem:**
When you are on mobile, it might be that you change to a different page and it will be scrolled down if you had scrolled down before. Please, make pages start from the top when you switch to them. This include:

2. Create account
3. Forgot password
4. Compare products


**In this PR:**
* adding scroll to top in Create account, Forgot password, Compare products container when componentDidMount() function
