### PR TITLE
issue#3569 modified the html element which rendered sublabel tag

### DIFF
--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -281,24 +281,24 @@ export class ProductAttributeValue extends PureComponent {
         }
 
         return (
-            <strong
+            <span
               block="ProductAttributeValue"
               elem="SubLabel"
             >
               { `(${subLabel})` }
-            </strong>
+            </span>
         );
     }
 
     getCheckboxLabel(value, subLabel) {
         return (
-            <span
+            <div
               block="ProductAttributeValue"
               elem="Label"
             >
                 { value }
                 { this.renderSublabel(subLabel) }
-            </span>
+            </div>
         );
     }
 


### PR DESCRIPTION
**Related issue(s):**
* https://github.com/scandipwa/scandipwa/issues/3569

**Problem:**
* Qty would render in a new line if price filter is too long

**In this PR:**
* Modified ProductAttributeValueComponent, renderSubLabel() now renders a span element instead of strong element
