### PR TITLE
[1533] Sort order for custom and bundle options

### DIFF
--- a/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.config.js
+++ b/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.config.js
@@ -1,0 +1,14 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export const DEFAULT_SORT_FIELD = 'position';
+
+export default DEFAULT_SORT_FIELD;

--- a/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.container.js
+++ b/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.container.js
@@ -14,9 +14,11 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import { ItemOptionsType } from 'Type/ProductList.type';
+import { sortBySortOrder } from 'Util/Product';
 import { bundleOptionsToSelectTransform, getEncodedBundleUid } from 'Util/Product/Transform';
 
 import ProductBundleOption from './ProductBundleOption.component';
+import DEFAULT_SORT_FIELD from './ProductBundleOption.config';
 
 /** @namespace Component/ProductBundleOption/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
@@ -92,7 +94,17 @@ export class ProductBundleOptionContainer extends PureComponent {
         const { options, currencyCode } = this.props;
         const { quantity } = this.state;
 
-        return bundleOptionsToSelectTransform(options, currencyCode, quantity);
+        return sortBySortOrder(bundleOptionsToSelectTransform(options, currencyCode, quantity));
+    }
+
+    getSortedOptions() {
+        const { options = {} } = this.props;
+
+        if (!Array.isArray(options)) {
+            return options;
+        }
+
+        return sortBySortOrder(options, DEFAULT_SORT_FIELD);
     }
 
     containerProps() {
@@ -101,7 +113,6 @@ export class ProductBundleOptionContainer extends PureComponent {
             title,
             isRequired,
             type,
-            options,
             updateSelectedValues,
             currencyCode
         } = this.props;
@@ -116,7 +127,7 @@ export class ProductBundleOptionContainer extends PureComponent {
             title,
             isRequired,
             type,
-            options,
+            options: this.getSortedOptions(),
             updateSelectedValues,
             currencyCode,
             activeSelectUid,

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.container.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.container.js
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 
 import FIELD_TYPE from 'Component/Field/Field.config';
 import { CustomizableOptionsType } from 'Type/ProductList.type';
+import { sortBySortOrder } from 'Util/Product';
 import { customizableOptionsToSelectTransform } from 'Util/Product/Transform';
 
 import ProductCustomizableOption from './ProductCustomizableOption.component';
@@ -62,7 +63,17 @@ export class ProductCustomizableOptionContainer extends PureComponent {
             return null;
         }
 
-        return customizableOptionsToSelectTransform(options, currencyCode);
+        return sortBySortOrder(customizableOptionsToSelectTransform(options, currencyCode));
+    }
+
+    getSortedOptions() {
+        const { options = {} } = this.props;
+
+        if (!Array.isArray(options)) {
+            return options;
+        }
+
+        return sortBySortOrder(options);
     }
 
     containerProps() {
@@ -71,7 +82,6 @@ export class ProductCustomizableOptionContainer extends PureComponent {
             title,
             isRequired,
             type,
-            options,
             updateSelectedValues,
             currencyCode
         } = this.props;
@@ -81,7 +91,7 @@ export class ProductCustomizableOptionContainer extends PureComponent {
             title,
             isRequired,
             type,
-            options,
+            options: this.getSortedOptions(),
             updateSelectedValues,
             currencyCode,
             fieldType: this.getFieldType()

--- a/packages/scandipwa/src/util/Product/Transform.js
+++ b/packages/scandipwa/src/util/Product/Transform.js
@@ -239,7 +239,8 @@ export const customizableOptionsToSelectTransform = (options, currencyCode = 'US
         const {
             uid,
             title,
-            position
+            position,
+            sort_order = 0
         } = option;
 
         const {
@@ -253,7 +254,7 @@ export const customizableOptionsToSelectTransform = (options, currencyCode = 'US
             value: uid,
             label: baseLabel,
             subLabel: priceLabel,
-            sort_order: position
+            sort_order: position || sort_order
         });
 
         return result;


### PR DESCRIPTION
**Related issue(s):**
* Fixes #1533 

**Problem:**
* BE option order for bundle and custom options doesn't match FE, due to missing sort implementation.

**In this PR:**
* Sorting values by "sort_order" (for custom) and "position" (for bundle) before render
