### PR TITLE
Fix for html style hash

### DIFF
--- a/packages/scandipwa/src/component/Html/Html.component.js
+++ b/packages/scandipwa/src/component/Html/Html.component.js
@@ -216,7 +216,7 @@ export class Html extends PureComponent {
 
     replaceStyle(elem) {
         const { children } = elem;
-        const elemHash = hash(elem);
+        const elemHash = hash(children[0].data);
 
         if (this.createdOutsideElements[elemHash]) {
             return <></>;

--- a/packages/scandipwa/src/component/RenderWhenVisible/RenderWhenVisible.component.js
+++ b/packages/scandipwa/src/component/RenderWhenVisible/RenderWhenVisible.component.js
@@ -40,7 +40,7 @@ export class RenderWhenVisible extends PureComponent {
     __construct(props) {
         super.__construct(props);
 
-        // a hack to determine if the element is on screen or not imidiatelly
+        // a hack to determine if the element is on screen or not immediately
         setTimeout(this.checkIsVisible, 0);
     }
 


### PR DESCRIPTION
Problem:
All scripts have the same hash, only one script per page can be parsed.

In this PR:
Adjusting code to use the content of the script tag that is a string when generating a hash for the script


Fix implemented for `script` tags previously in https://github.com/scandipwa/scandipwa/pull/4100 but now also for styles.
Use case where this is relevant - several similar widgets or cms blocks on a page