### PR TITLE
[3782] Extended Footer logic to scroll page up on category item click

### DIFF
--- a/packages/scandipwa/src/component/Footer/Footer.component.js
+++ b/packages/scandipwa/src/component/Footer/Footer.component.js
@@ -18,6 +18,7 @@ import Image from 'Component/Image';
 import Link from 'Component/Link';
 import NewsletterSubscription from 'Component/NewsletterSubscription';
 import { DeviceType } from 'Type/Device.type';
+import { noopFn } from 'Util/Common';
 
 import { COLUMN_MAP, NEWSLETTER_COLUMN, RENDER_NEWSLETTER } from './Footer.config';
 
@@ -33,12 +34,14 @@ export class Footer extends Component {
         copyright: PropTypes.string,
         isVisibleOnMobile: PropTypes.bool,
         device: DeviceType.isRequired,
-        newsletterActive: PropTypes.bool.isRequired
+        newsletterActive: PropTypes.bool.isRequired,
+        onItemClick: PropTypes.func
     };
 
     static defaultProps = {
         copyright: '',
-        isVisibleOnMobile: false
+        isVisibleOnMobile: false,
+        onItemClick: noopFn
     };
 
     renderMap = {
@@ -87,6 +90,7 @@ export class Footer extends Component {
 
     renderColumnItemLink({ href = '/', title, src }, i) {
         const mods = src ? { type: 'image' } : {};
+        const { onItemClick } = this.props;
 
         return (
             <Link
@@ -96,6 +100,7 @@ export class Footer extends Component {
               mods={ mods }
               key={ i }
               aria-label={ title }
+              onClick={ onItemClick }
             >
                 { this.renderColumnItemContent(src, title) }
             </Link>

--- a/packages/scandipwa/src/component/Footer/Footer.container.js
+++ b/packages/scandipwa/src/component/Footer/Footer.container.js
@@ -8,7 +8,12 @@
  * @package scandipwa/base-theme
  * @link https://github.com/scandipwa/base-theme
  */
+import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
 import { connect } from 'react-redux';
+
+import { DeviceType } from 'Type/Device.type';
+import { scrollToTop } from 'Util/Browser';
 
 import Footer from './Footer.component';
 
@@ -22,4 +27,52 @@ export const mapStateToProps = (state) => ({
 /** @namespace Component/Footer/Container/mapDispatchToProps */
 export const mapDispatchToProps = () => ({});
 
-export default connect(mapStateToProps, mapDispatchToProps)(Footer);
+/** @namespace Component/Footer/Container */
+export class FooterContainer extends PureComponent {
+    static propTypes = {
+        copyright: PropTypes.string,
+        isVisibleOnMobile: PropTypes.bool,
+        device: DeviceType.isRequired,
+        newsletterActive: PropTypes.bool.isRequired
+    };
+
+    static defaultProps = {
+        copyright: '',
+        isVisibleOnMobile: false
+    };
+
+    containerFunctions = {
+        onItemClick: this.onItemClick.bind(this)
+    };
+
+    containerProps() {
+        const {
+            copyright,
+            isVisibleOnMobile,
+            device,
+            newsletterActive
+        } = this.props;
+
+        return {
+            copyright,
+            isVisibleOnMobile,
+            device,
+            newsletterActive
+        };
+    }
+
+    onItemClick() {
+        scrollToTop();
+    }
+
+    render() {
+        return (
+            <Footer
+              { ...this.containerProps() }
+              { ...this.containerFunctions }
+            />
+        );
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(FooterContainer);


### PR DESCRIPTION

**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/3782

**Problem:**
* There was nothing happening when the user was clicking footer category item if the page was already loaded

**In this PR:**
* Modified Footer component and container files to add page scroll to top logic
