### PR TITLE
[4161] If not logged user opens link /default/customer/account on mobile it doesn't redirect to login page fix

### DIFF
--- a/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
@@ -452,16 +452,11 @@ export class MyAccountContainer extends PureComponent {
 
     redirectIfNotSignedIn() {
         const {
-            isMobile,
             baseLinkUrl,
             showNotification
         } = this.props;
 
         if (isSignedIn()) { // do nothing for signed-in users
-            return;
-        }
-
-        if (isMobile) { // do not redirect on mobile
             return;
         }
 


### PR DESCRIPTION
If not logged user opens link /default/customer/account on mobile it doesn't redirect to login page fix

**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4161

**Problem:**
* If not logged user opens link /default/customer/account on mobile it doesn't redirect to login page and it causes incorrect header load.

**In this PR:**
* Only changed MyAccount.container.js file under /route folder, Removed part which was disabling redirect on mobile.
