### PR TITLE
[4017] modified to render top border instead of bottom

### DIFF
--- a/packages/scandipwa/src/component/MyAccountOrderItemsTableRow/MyAccountOrderItemsTableRow.style.scss
+++ b/packages/scandipwa/src/component/MyAccountOrderItemsTableRow/MyAccountOrderItemsTableRow.style.scss
@@ -62,7 +62,7 @@
         }
 
         @include mobile {
-            border-block-end: var(--my-account-content-border);
+            border-block-start: var(--my-account-content-border);
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4017

**Problem:**
* Order product list last product rendered border bottom on mobile 

**In this PR:**
* Modified Style to render border top instead
