### PR TITLE
[3181] Make downloadable product labels clickable/hoverable

### DIFF
--- a/packages/scandipwa/src/component/FieldGroup/FieldGroup.style.scss
+++ b/packages/scandipwa/src/component/FieldGroup/FieldGroup.style.scss
@@ -35,6 +35,12 @@
                 + .input-control {
                     border-color: var(--primary-error-color);
                 }
+
+                &:hover + .input-control {
+                    @include desktop {
+                        border-color: var(--checkbox-border-color-active);
+                    }
+                }
             }
         }
     }

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
@@ -39,7 +39,7 @@ export class ProductDownloadableLinks extends PureComponent {
         links: []
     };
 
-    renderLabel(link) {
+    getLabel(link) {
         const { title, price } = link;
         const { isRequired, currencyCode = 'USD' } = this.props;
 
@@ -62,6 +62,7 @@ export class ProductDownloadableLinks extends PureComponent {
     renderCheckBox(link) {
         const { setSelectedCheckboxValues, isRequired } = this.props;
         const { uid } = link;
+        const label = this.getLabel(link);
 
         if (!isRequired) {
             return null;
@@ -79,6 +80,7 @@ export class ProductDownloadableLinks extends PureComponent {
               events={ {
                   onChange: setSelectedCheckboxValues
               } }
+              label={ label }
             />
         );
     }
@@ -109,7 +111,6 @@ export class ProductDownloadableLinks extends PureComponent {
         return (
             <div block="ProductDownloadableLink" key={ id }>
                 { this.renderCheckBox.call(this, link) }
-                { this.renderLabel(link) }
                 { this.renderLink(link) }
             </div>
         );

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.component.js
@@ -39,7 +39,7 @@ export class ProductDownloadableLinks extends PureComponent {
         links: []
     };
 
-    getLabel(link) {
+    renderLabel(link) {
         const { title, price } = link;
         const { isRequired, currencyCode = 'USD' } = this.props;
 
@@ -62,7 +62,7 @@ export class ProductDownloadableLinks extends PureComponent {
     renderCheckBox(link) {
         const { setSelectedCheckboxValues, isRequired } = this.props;
         const { uid } = link;
-        const label = this.getLabel(link);
+        const label = this.renderLabel(link);
 
         if (!isRequired) {
             return null;
@@ -106,11 +106,12 @@ export class ProductDownloadableLinks extends PureComponent {
     }
 
     renderDownloadableLink(link) {
+        const { isRequired } = this.props;
         const { id } = link;
 
         return (
             <div block="ProductDownloadableLink" key={ id }>
-                { this.renderCheckBox.call(this, link) }
+                { isRequired ? this.renderCheckBox.call(this, link) : this.renderLabel(link) }
                 { this.renderLink(link) }
             </div>
         );

--- a/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
+++ b/packages/scandipwa/src/component/ProductDownloadableLinks/ProductDownloadableLinks.style.scss
@@ -60,6 +60,7 @@
 
 .ProductDownloadableLink {
     display: flex;
+    justify-content: space-between;
     padding-block-start: 15px;
     padding-block-end: 10px;
     padding-inline: 0;
@@ -69,11 +70,10 @@
         display: inline-block;
         margin-inline-end: 10px;
         margin-block-start: 0;
-    }
-
-    &-SampleTitle {
-        flex: 1;
-        margin: auto;
+        
+        .ProductDownloadableLink-SampleTitle {
+            display: block;
+        }
     }
 
     &-SampleLink {


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/3181

**Problem:**
* Hover effect and checkmark do not appear when hovering on the label of the option of downloadable product.
* label is not part of the checkbox and acts as an independent element.

**In this PR:**
* Passed independent label in checkbox attribute label, so now it is a part of checkbox and behaves normally.
