### PR TITLE
[3270] Add line-height to cart item option

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.style.scss
+++ b/packages/scandipwa/src/component/CartItem/CartItem.style.scss
@@ -104,7 +104,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        line-height: 15px;
+        line-height: 16px;
     }
 
     &-ItemLinks {

--- a/packages/scandipwa/src/component/CartItem/CartItem.style.scss
+++ b/packages/scandipwa/src/component/CartItem/CartItem.style.scss
@@ -104,6 +104,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        line-height: 14px;
     }
 
     &-ItemLinks {

--- a/packages/scandipwa/src/component/CartItem/CartItem.style.scss
+++ b/packages/scandipwa/src/component/CartItem/CartItem.style.scss
@@ -104,7 +104,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        line-height: 14px;
+        line-height: 15px;
     }
 
     &-ItemLinks {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3270

**Problem:**
* Options for product are cropped in cart/mini-cart 

**In this PR:**
* Add line-height to cart item option
