### PR TITLE
[3105] plus symbol is displayed in title fix

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.component.js
+++ b/packages/scandipwa/src/component/Header/Header.component.js
@@ -406,7 +406,7 @@ export class Header extends NavigationAbstract {
               elem="Title"
               mods={ { isVisible } }
             >
-                { title }
+                { title ? (<span>{ title.replace(/\+/g, ' ') }</span>) : (<span>{ title }</span>) }
             </h1>
         );
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/3105

**Problem:**
* '+' symbol is present in the title instead of space.

**In this PR:**
* Header.component.js
	* line 409 modified the returned title and added a conditional statement in case title was undefined
