### PR TITLE
Add postscss to top-level dependency

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -20,6 +20,7 @@
         "history": "^4.9.0",
         "html-react-parser": "^0.13.0",
         "intersection-observer": "^0.12.0",
+        "postcss": "^8.4.5",
         "prop-types": "^15.6.2",
         "react": "^16.13.1",
         "react-datepicker": "^4.3.0",
@@ -307,7 +308,10 @@
                 1,
                 {
                     "forbid": [
-                        { "element": "a", "message": "Use the <Link> component instead of <a>." }
+                        {
+                            "element": "a",
+                            "message": "Use the <Link> component instead of <a>."
+                        }
                     ]
                 }
             ],


### PR DESCRIPTION
**Problem:**
* when installing with npm error appears: `Class extends value undefined is not a constructor or null`. It is related to how npm install packages and since new package style-lint requires postcss to be version 8, other require it to be 7. Adding dependency to top-level requires version 8.
