### PR TITLE
#3766 added correct notification when adding product to cart in offline mode

### DIFF
--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
@@ -143,6 +143,11 @@ export class CartDispatcher {
             await this.updateInitialCartData(dispatch);
             dispatch(showNotification('success', __('Product was added to cart!')));
         } catch (error) {
+            if (!navigator.onLine) {
+                dispatch(showNotification('error', __('Not possible to fetch while offline')));
+                return Promise.reject();
+            }
+
             dispatch(showNotification('error', getErrorMessage(error)));
             return Promise.reject();
         }


### PR DESCRIPTION

**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/3766

**Problem:**
* PDP page shows Incorrect message when adding product to cart in offline mode

**In this PR:**
* Added condition in cart dispatcher which will detect if the page is offline and send the correct message
