### PR TITLE
[3067] MyDownloadable width parameters adjusted on mobile

### DIFF
--- a/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.style.scss
+++ b/packages/scandipwa/src/component/MyAccountDownloadable/MyAccountDownloadable.style.scss
@@ -13,7 +13,7 @@
     @include mobile {
         overflow-x: scroll;
         -webkit-overflow-scrolling: touch;
-        width: calc(100vw - 24px);
+        width: calc(100vw - 32px);
     }
 
     &-NoOrders {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3067

**Problem:**
* The navigation bar is cropped on My downloadable and My wishlist pages

**In this PR:**
* Width parameters adjusted on MyAccountDownloadable to respect screen size
