### PR TITLE
[4164] Remove border on MyOrder subfield

### DIFF
--- a/packages/scandipwa/src/component/MyAccountOrderItemsTableRow/MyAccountOrderItemsTableRow.style.scss
+++ b/packages/scandipwa/src/component/MyAccountOrderItemsTableRow/MyAccountOrderItemsTableRow.style.scss
@@ -60,10 +60,6 @@
                 }
             }
         }
-
-        @include mobile {
-            border-block-end: var(--my-account-content-border);
-        }
     }
 
     &-Row {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4164

**Problem:**
* Bottom border on MyOrder subfield

**In this PR:**
* Remove mobile border on MyAccountOrderItemsTableRow-RowWrapper
