### PR TITLE
[4069] product name and cross sign alignment fix

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -166,6 +166,7 @@
         @include mobile {
             inset-block-start: -4px;
             inset-inline-end: -4px;
+            margin-block-start: -4px;
 
             .CloseIcon {
                 width: 24px;


### PR DESCRIPTION
**Related issue(s):**
* scandipwa/scandipwa/issues/4069

**Problem:**
* cross sign was not aligned with the product name or starts whichever comes first.

**In this PR:**
* WishListItem.style.scss
	* line 169 added a margin
