### PR TITLE
#3972 Search functionality throwing error if search word contains & (Fix failed QA)

### DIFF
--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,11 +77,11 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = encodeURIComponent(searchCriteria.trim().replace('%', '%25'));
+        const search = searchCriteria.trim().replace('%', '%25');
         const trimmedSearch = searchCriteria.trim().replace('+', '');
 
         if (e.key === 'Enter' && trimmedSearch !== '') {
-            history.push(appendWithStoreCode(`/search/${ search }`));
+            history.push(appendWithStoreCode(`/search/${ encodeURIComponent(search) }`));
             hideActiveOverlay();
             onSearchBarChange({ target: { value: '' } });
             this.searchBarRef.current.blur();

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,11 +77,11 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = searchCriteria.trim().replace(/\s/g, '+');
-        const trimmedSearch = searchCriteria.trim();
+        const search = searchCriteria.trim();
+        const trimmedSearch = searchCriteria.trim().replace('+', '');
 
         if (e.key === 'Enter' && trimmedSearch !== '') {
-            history.push(appendWithStoreCode(`/search/${ search }`));
+            history.push(appendWithStoreCode(`/search/${ encodeURIComponent(search) }`));
             hideActiveOverlay();
             onSearchBarChange({ target: { value: '' } });
             this.searchBarRef.current.blur();

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,11 +77,11 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = searchCriteria.trim().replace('%', '%25');
+        const search = encodeURIComponent(searchCriteria.trim().replace('%', '%25'));
         const trimmedSearch = searchCriteria.trim().replace('+', '');
 
         if (e.key === 'Enter' && trimmedSearch !== '') {
-            history.push(appendWithStoreCode(`/search/${ encodeURIComponent(search) }`));
+            history.push(appendWithStoreCode(`/search/${ search }`));
             hideActiveOverlay();
             onSearchBarChange({ target: { value: '' } });
             this.searchBarRef.current.blur();

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,7 +77,7 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = searchCriteria.trim();
+        const search = searchCriteria.trim().replace('%', '%25');
         const trimmedSearch = searchCriteria.trim().replace('+', '');
 
         if (e.key === 'Enter' && trimmedSearch !== '') {

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.component.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.component.js
@@ -28,7 +28,7 @@ export class SearchPage extends CategoryPage {
               } }
             >
                 { __('Search results for: ') }
-                <span>{ search.replace(/\+/g, ' ') }</span>
+                <span>{ decodeURIComponent(search) }</span>
             </h1>
         );
     }

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
@@ -114,7 +114,7 @@ export class SearchPageContainer extends CategoryPageContainer {
 
     updateBreadcrumbs() {
         const { updateBreadcrumbs } = this.props;
-        const search = this.getSearchParam();
+        const search = decodeURIComponent(this.getSearchParam());
 
         updateBreadcrumbs([{
             url: '',


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3972 (issue + failed QA comments)

**Problem:**
* `&` in URL is normally used for separating pairs of query params. It should be encoded if used as part of query param.
* Ooops page appears when searching '%' symbol Error message 'URIError: URI malformed' appears in the console
* Error messages 'Error fetching Product List Information!' and 'Error fetching Product List!' when searching '+' symbol

**In this PR:**
* Removed replacement of ' ' to '+', used URL encoding instead (which handles `&` in search param among other cases). 
* make + symbol to empty space and prevent redirect to search page 
* problem with encode % symbol need to change it manually

This is a reacreated PR from @tappiola https://github.com/scandipwa/scandipwa/pull/4031