### PR TITLE
[3456] modified advertising string, removed TierPrice rendering

### DIFF
--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
@@ -35,7 +35,6 @@ export class ProductPrice extends PureComponent {
         price: ProductPriceType,
         priceType: PropTypes.oneOf(Object.values(PRODUCT_TYPE)),
         originalPrice: OriginalPriceType,
-        tierPrice: PropTypes.string,
         configuration: PriceConfiguration,
         priceCurrency: PropTypes.string,
         discountPercentage: PropTypes.number,
@@ -57,7 +56,6 @@ export class ProductPrice extends PureComponent {
         isSchemaRequired: false,
         variantsCount: 0,
         mix: {},
-        tierPrice: '',
         label: '',
         configuration: {},
         displayTaxInPrice: DISPLAY_PRODUCT_PRICES_IN_CATALOG_INCL_TAX
@@ -266,7 +264,6 @@ export class ProductPrice extends PureComponent {
                 <>
                     { minValue < minRegularValue && this.renderRegularPrice(minRegularPrice) }
                     { renderer }
-                    { this.renderTierPrice() }
                 </>
             );
         }
@@ -394,28 +391,6 @@ export class ProductPrice extends PureComponent {
         );
     }
 
-    renderTierPrice() {
-        const {
-            tierPrice,
-            price: {
-                finalPrice: {
-                    valueFormatted = 0
-                } = {}
-            } = {}
-        } = this.props;
-
-        if (!tierPrice || tierPrice === valueFormatted) {
-            return null;
-        }
-
-        return (
-            <p block="ProductPrice" elem="TierPrice">
-                { __('As low as') }
-                <strong>{ ` ${tierPrice}` }</strong>
-            </p>
-        );
-    }
-
     render() {
         const {
             price: {
@@ -446,7 +421,6 @@ export class ProductPrice extends PureComponent {
             >
                 { isPreview && renderer && renderer() }
                 { (!isPreview || !renderer) && this.renderDefaultPrice() }
-                { priceType !== PRODUCT_TYPE.bundle && this.renderTierPrice() }
             </div>
         );
     }

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
@@ -35,6 +35,7 @@ export class ProductPrice extends PureComponent {
         price: ProductPriceType,
         priceType: PropTypes.oneOf(Object.values(PRODUCT_TYPE)),
         originalPrice: OriginalPriceType,
+        tierPrice: PropTypes.string,
         configuration: PriceConfiguration,
         priceCurrency: PropTypes.string,
         discountPercentage: PropTypes.number,
@@ -56,6 +57,7 @@ export class ProductPrice extends PureComponent {
         isSchemaRequired: false,
         variantsCount: 0,
         mix: {},
+        tierPrice: '',
         label: '',
         configuration: {},
         displayTaxInPrice: DISPLAY_PRODUCT_PRICES_IN_CATALOG_INCL_TAX
@@ -391,6 +393,28 @@ export class ProductPrice extends PureComponent {
         );
     }
 
+    renderTierPrice() {
+        const {
+            tierPrice,
+            price: {
+                finalPrice: {
+                    valueFormatted = 0
+                } = {}
+            } = {}
+        } = this.props;
+
+        if (!tierPrice || tierPrice === valueFormatted) {
+            return null;
+        }
+
+        return (
+            <p block="ProductPrice" elem="TierPrice">
+                { __('As low as') }
+                <strong>{ ` ${tierPrice}` }</strong>
+            </p>
+        );
+    }
+
     render() {
         const {
             price: {
@@ -421,6 +445,7 @@ export class ProductPrice extends PureComponent {
             >
                 { isPreview && renderer && renderer() }
                 { (!isPreview || !renderer) && this.renderDefaultPrice() }
+                { priceType !== PRODUCT_TYPE.bundle && this.renderTierPrice() }
             </div>
         );
     }

--- a/packages/scandipwa/src/component/TierPrices/TierPrices.component.js
+++ b/packages/scandipwa/src/component/TierPrices/TierPrices.component.js
@@ -93,7 +93,7 @@ export class TierPrices extends PureComponent {
             ) }
             <strong>
                 { __(
-                    '%s% each',
+                    '%s% discount each',
                     Math.round(percent_off)
                 ) }
             </strong>

--- a/packages/scandipwa/src/component/TierPrices/TierPrices.component.js
+++ b/packages/scandipwa/src/component/TierPrices/TierPrices.component.js
@@ -55,6 +55,7 @@ export class TierPrices extends PureComponent {
         if (value >= minPriceForOneUnit) {
             return null;
         }
+
         const formattedPrice = formatPrice(value, currency);
 
         return (
@@ -69,11 +70,11 @@ export class TierPrices extends PureComponent {
     renderProductTierPrice(quantity, formattedPrice, percent_off) {
         return (
             <>
-            { __(
-                'Buy %s for %s each and ',
-                quantity,
-                formattedPrice
-            ) }
+                { __(
+                    'Buy %s for %s each and ',
+                    quantity,
+                    formattedPrice
+                ) }
                 <strong>
                     { __(
                         'save %s%',
@@ -87,16 +88,16 @@ export class TierPrices extends PureComponent {
     renderBundleTierPrice(quantity, percent_off) {
         return (
             <>
-            { __(
-                'Buy %s with ',
-                quantity
-            ) }
-            <strong>
                 { __(
-                    '%s% discount each',
-                    Math.round(percent_off)
+                    'Buy %s with ',
+                    quantity
                 ) }
-            </strong>
+                <strong>
+                    { __(
+                        '%s% discount each',
+                        Math.round(percent_off)
+                    ) }
+                </strong>
             </>
         );
     }

--- a/packages/scandipwa/src/component/TierPrices/TierPrices.component.js
+++ b/packages/scandipwa/src/component/TierPrices/TierPrices.component.js
@@ -11,8 +11,9 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
+import PRODUCT_TYPE from 'Component/Product/Product.config';
 import { ProductType } from 'Type/ProductList.type';
-import { getLowestPriceTiersPrice } from 'Util/Price';
+import { formatPrice, getLowestPriceTiersPrice } from 'Util/Price';
 
 import './TierPrices.style';
 
@@ -32,7 +33,8 @@ export class TierPrices extends PureComponent {
             percent_off
         },
         final_price: {
-            value
+            value,
+            currency
         },
         quantity
     }) {
@@ -44,7 +46,8 @@ export class TierPrices extends PureComponent {
                             value: minPriceForOneUnit
                         }
                     }
-                }
+                },
+                type_id
             }
         } = this.props;
 
@@ -52,20 +55,49 @@ export class TierPrices extends PureComponent {
         if (value >= minPriceForOneUnit) {
             return null;
         }
+        const formattedPrice = formatPrice(value, currency);
 
         return (
             <li block="TierPrices" elem="Item" key={ quantity }>
-                { __(
-                    'Buy %s and ',
-                    quantity
-                ) }
+                { type_id === PRODUCT_TYPE.bundle
+                    ? this.renderBundleTierPrice(quantity, percent_off)
+                    : this.renderProductTierPrice(quantity, formattedPrice, percent_off) }
+            </li>
+        );
+    }
+
+    renderProductTierPrice(quantity, formattedPrice, percent_off) {
+        return (
+            <>
+            { __(
+                'Buy %s for %s each and ',
+                quantity,
+                formattedPrice
+            ) }
                 <strong>
                     { __(
                         'save %s%',
                         Math.round(percent_off)
                     ) }
                 </strong>
-            </li>
+            </>
+        );
+    }
+
+    renderBundleTierPrice(quantity, percent_off) {
+        return (
+            <>
+            { __(
+                'Buy %s with ',
+                quantity
+            ) }
+            <strong>
+                { __(
+                    '%s% each',
+                    Math.round(percent_off)
+                ) }
+            </strong>
+            </>
         );
     }
 

--- a/packages/scandipwa/src/component/TierPrices/TierPrices.component.js
+++ b/packages/scandipwa/src/component/TierPrices/TierPrices.component.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import { ProductType } from 'Type/ProductList.type';
-import { formatPrice, getLowestPriceTiersPrice } from 'Util/Price';
+import { getLowestPriceTiersPrice } from 'Util/Price';
 
 import './TierPrices.style';
 
@@ -32,8 +32,7 @@ export class TierPrices extends PureComponent {
             percent_off
         },
         final_price: {
-            value,
-            currency
+            value
         },
         quantity
     }) {
@@ -54,14 +53,11 @@ export class TierPrices extends PureComponent {
             return null;
         }
 
-        const formattedPrice = formatPrice(value, currency);
-
         return (
             <li block="TierPrices" elem="Item" key={ quantity }>
                 { __(
-                    'Buy %s for %s each and ',
-                    quantity,
-                    formattedPrice
+                    'Buy %s and ',
+                    quantity
                 ) }
                 <strong>
                     { __(


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3456

**Problem:**
* Advertising message shows Price value per item.
* Product Card rendered "As Low As" tag price

**In this PR:**
* Modified string for advertising message
* Removed As Low As tag
