### PR TITLE
#4178 Additional space present between title and drop-down option

### DIFF
--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
@@ -23,7 +23,7 @@
         }
 
         .Field {
-            margin-block-start: 16px;
+            margin-block-start: 0px;
 
             &_type_select + .Field-ErrorMessages {
                 position: absolute;

--- a/packages/scandipwa/src/component/ProductConfigurableAttributeDropdown/ProductConfigurableAttributeDropdown.style.scss
+++ b/packages/scandipwa/src/component/ProductConfigurableAttributeDropdown/ProductConfigurableAttributeDropdown.style.scss
@@ -1,5 +1,5 @@
 .ProductConfigurableAttributeDropdown {
-    margin-block-start: 16px;
+    margin-block-start: 0px;
 
     @include desktop {
         width: 45%;


### PR DESCRIPTION
**Related issue(s):**
* Fixes [#4178 Additional space present between title and drop-down option](https://github.com/scandipwa/scandipwa/issues/4178)

**Problem:**
* Additional space present between title and drop-down option

**In this PR:**
* change dropdown productbundleoptions & productconfigurable margin-block-start to 0px
