### PR TITLE
[3218] Add image horizontal alignment fix 

### DIFF
--- a/packages/scandipwa/src/component/Image/Image.style.scss
+++ b/packages/scandipwa/src/component/Image/Image.style.scss
@@ -52,6 +52,8 @@
 
         td & {
             max-width: 100%;
+            display: block;
+            margin: auto;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3218

**Problem:**
* Image in table does not save proportions and does not centralize by the height in cell on CMS page if it set in admin

**In this PR:**
* Set image display to block and margin to auto
