### PR TITLE
[3446] Add arrow near 'Sort' on mobile

### DIFF
--- a/packages/scandipwa/src/component/CategorySort/CategorySort.style.scss
+++ b/packages/scandipwa/src/component/CategorySort/CategorySort.style.scss
@@ -59,17 +59,41 @@
             }
         }
 
+        &-Options {
+            @include mobile {
+                width: 180px;
+                inset-block-start: 14px;
+            }
+
+            &_isExpanded {
+                @include mobile {
+                    z-index: 15;
+                    max-height: 200px;
+                    border-color: var(--input-border-color);
+                    overflow-y: auto;
+                    background-color: #{$white};
+                }
+            }
+        }
+
+        &-Clickable {
+            @include mobile {
+                position: absolute;
+                inset-block-start: -29px;
+                width: calc( 100% + 17px );
+            }
+        }
+
         &-Select {
             background: none;
             border: none;
             color: var(--color-black);
             padding-block: 13px;
-            padding-inline: 20px 40px;
 
             @include mobile {
-                position: absolute;
-                inset-block-start: -35px;
                 opacity: 0;
+                pointer-events: none;
+                padding-inline: 0;
             }
 
             &_isExpanded {
@@ -85,7 +109,7 @@
 
         .ChevronIcon {
             @include mobile {
-                display: none;
+                inset-inline-end: 0;
             }
         }
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/3446

**Problem:**
* Arrow near 'Sort' on PLP is missing on mobile
* On mobile native select is appearing instead of the corresponding menu element.
* If we only make the arrow visible, it will not correspond correctly with the native select.

**In this PR:**
* Change CategorySort styles.
* Make the arrow visible on mobile.
* Make select field show correspond menu instead of its native select.

(NOTE it will only work on the CategorySort components, if we want to make this behavior for all SelectField components we should change its files)
