### PR TITLE
Fix for script tags with external source

### DIFF
--- a/packages/scandipwa/src/component/Html/Html.component.js
+++ b/packages/scandipwa/src/component/Html/Html.component.js
@@ -236,7 +236,9 @@ export class Html extends PureComponent {
 
     replaceScript(elem) {
         const { attribs, children } = elem;
-        const elemHash = hash(children[0].data);
+        const { src = '' } = attribs;
+        const scriptContent = children[0] ? children[0].data : '';
+        const elemHash = hash(src + scriptContent);
 
         if (this.createdOutsideElements[elemHash]) {
             return <></>;


### PR DESCRIPTION
**Problem:**
Scripts with external source all have empty script content and have the same hash

**In this PR:**
Added changes to calculate hash from script src and content to cover also cases with scripts with external sources