### PR TITLE
[3058] added empty placeholder value, added style when isValid and placeholder is shown

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -241,6 +241,10 @@
                 input,
                 textarea,
                 select {
+                    &:placeholder-shown {
+                        border: 1px solid var(--color-dark-gray);
+                    }
+
                     border: 1px solid var(--primary-success-color);
                 }
             }

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
@@ -96,12 +96,13 @@ export class ProductCustomizableOption extends PureComponent {
                   } }
                   attr={ {
                       id: uid,
-                      name: uid
+                      name: uid,
+                      placeholder: ''
                   } }
                   events={ {
                       onChange: updateSelectedValues
                   } }
-                  validateOn={ ['onBlur'] }
+                  validateOn={ ['onBlur', 'onChange'] }
                 />
             </>
         );


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3058

**Problem:**
* Text area is highlighted by green if text entered
* Text field is grey if text deleted from field
after click on free space or other object on page

**In this PR:**
* added empty placeholder value
* added style when isValid and placeholder is shown
