### PR TITLE
[4128] previously added Header-Nav border, changed zindex for popup name to 450

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -279,11 +279,6 @@
             justify-content: unset;
             padding-inline: 32px;
         }
-        
-        @include mobile {
-            // stylelint-disable declaration-no-important
-            border-bottom: 1px solid var(--primary-divider-color) !important;
-        }
     }
 
     &-MyAccount {
@@ -447,7 +442,7 @@
     }
 
     &_name_popup {
-        z-index: 400;
+        z-index: 450;
     }
 
     &-MyAccountContainer {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4128

**Problem:**
* Line under the title absent on mobile on 'Write a review', 'Confirm delete', 'EDIT ADDRESS'
* doubling under pages where it was (PDP, Cart, My account, etc)
* appeared where it is not necessary (PLP, Menu, etc)

**In this PR:**
* Undo changes from PR https://github.com/scandipwa/scandipwa/pull/4141
* Gave higher Z index for popup_name on Header.style
