### PR TITLE
Fix for page builder style support

### DIFF
--- a/packages/scandipwa/public/index.html
+++ b/packages/scandipwa/public/index.html
@@ -42,7 +42,7 @@
     <!-- Manifest -->
     <link rel="manifest" href="/manifest.json">
 </head>
-<body>
+<body id="html-body">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
 </body>


### PR DESCRIPTION
**Problem:**
When admin in some CMS page adjusts some paddings or margins, Magento will generate special classes to apply those styles to page elements. F.E. A padding on CMS column (https://i.imgur.com/SygvKDn.png) Class like this will be generated https://i.imgur.com/f9sqlJq.png
`id=html-body` is needed on `<body>` tag so these automatic styles work 

**In this PR:**
Will add `id=html-body` on `<body>` tag so these page builder styles work 
