### PR TITLE
Set postcss version

### DIFF
--- a/build-packages/csa-generator-theme/index.js
+++ b/build-packages/csa-generator-theme/index.js
@@ -124,6 +124,7 @@ const run = async (options) => {
     let mosaicVersion = '0.0.0';
     let eslintConfigVersion = '0.0.0';
     let mosaicCracoVersion = '0.0.0';
+    const postcssVersion = '8.4.5';
 
     try {
         scandipwaVersion = await getLatestVersion('@scandipwa/scandipwa');
@@ -171,6 +172,7 @@ const run = async (options) => {
         name,
         mosaicVersion,
         mosaicCracoVersion,
+        postcssVersion,
         proxy: DEFAULT_PROXY,
         eslintConfigVersion
     };

--- a/build-packages/csa-generator-theme/template/package.json
+++ b/build-packages/csa-generator-theme/template/package.json
@@ -7,7 +7,8 @@
         "@scandipwa/scandipwa-scripts": "<%= scandipwaScriptsVersion %>",
         "@scandipwa/eslint-config": "<%= eslintConfigVersion %>",
         "@tilework/mosaic": "<%= mosaicVersion %>",
-        "@tilework/mosaic-craco": "<%= mosaicCracoVersion %>"
+        "@tilework/mosaic-craco": "<%= mosaicCracoVersion %>",
+        "postcss": "<%= postcssVersion %>"
     },
     "scandipwa": {
         "type": "theme",

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -21,6 +21,7 @@
         "html-react-parser": "^0.13.0",
         "intersection-observer": "^0.12.0",
         "prop-types": "^15.6.2",
+        "postcss": "8.4.5",
         "react": "^16.13.1",
         "react-datepicker": "^4.3.0",
         "react-dom": "^16.13.1",


### PR DESCRIPTION
**Problem:**
* when installing with npm error appears: Class extends value undefined is not a constructor or null. It is related to how npm install packages and since new package style-lint requires postcss to be version 8, other require it to be 7. Adding dependency to top-level requires version 8.

