### PR TITLE
[3280] Add padding bottom to IOS devices

### DIFF
--- a/packages/scandipwa/src/route/CreateAccount/CreateAccount.style.scss
+++ b/packages/scandipwa/src/route/CreateAccount/CreateAccount.style.scss
@@ -7,6 +7,10 @@
         @include desktop() {
             padding-block-start: 25px;
         }
+
+        @supports (-webkit-touch-callout: none) {
+            padding-block-end: 80px;
+        }
     }
 
     &-InnerWrapper {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3280

**Problem:**
* The 'Sign Up' button on 'Create Account' form is half hidden, even if you scroll down as much as possible.

**In this PR:**
* Add padding bottom in Create Account route for IOS devices
