### PR TITLE
#3972 Search functionality throwing error if search word contains & (Fix failed QA) 

### DIFF
--- a/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.component.js
+++ b/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.component.js
@@ -54,7 +54,8 @@ export class Breadcrumb extends PureComponent {
     renderLink() {
         const {
             index,
-            isDisabled
+            isDisabled,
+            name
         } = this.props;
 
         const url = this.getLinkUrl() || {};
@@ -68,20 +69,11 @@ export class Breadcrumb extends PureComponent {
             >
                 <meta itemProp="item" content={ window.location.origin + url.pathname } />
                 <span itemProp="name">
-                    { this.renderName() }
+                    <TextPlaceholder content={ name } />
                 </span>
                 <ChevronIcon />
                 <meta itemProp="position" content={ index } />
             </Link>
-        );
-    }
-
-    renderName() {
-        const { name } = this.props;
-        const cleanName = name.replace(/([+])/g, ' ');
-
-        return (
-            <TextPlaceholder content={ cleanName } />
         );
     }
 

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,11 +77,11 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = encodeURIComponent(searchCriteria.trim().replace('%', '%25'));
+        const search = searchCriteria.trim().replace('%', '%25');
         const trimmedSearch = searchCriteria.trim().replace('+', '');
 
         if (e.key === 'Enter' && trimmedSearch !== '') {
-            history.push(appendWithStoreCode(`/search/${ search }`));
+            history.push(appendWithStoreCode(`/search/${ encodeURIComponent(search) }`));
             hideActiveOverlay();
             onSearchBarChange({ target: { value: '' } });
             this.searchBarRef.current.blur();

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -78,7 +78,7 @@ export class SearchField extends PureComponent {
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
         const search = encodeURIComponent(searchCriteria.trim().replace(/%/g, '%25'));
-        const trimmedSearch = searchCriteria.trim().replace(/\+/g, '');
+        const trimmedSearch = searchCriteria.trim();
 
         if (e.key === 'Enter' && trimmedSearch !== '') {
             history.push(appendWithStoreCode(`/search/${ search }`));

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,11 +77,11 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = searchCriteria.trim().replace(/\s/g, '+');
-        const trimmedSearch = searchCriteria.trim();
+        const search = searchCriteria.trim();
+        const trimmedSearch = searchCriteria.trim().replace('+', '');
 
         if (e.key === 'Enter' && trimmedSearch !== '') {
-            history.push(appendWithStoreCode(`/search/${ search }`));
+            history.push(appendWithStoreCode(`/search/${ encodeURIComponent(search) }`));
             hideActiveOverlay();
             onSearchBarChange({ target: { value: '' } });
             this.searchBarRef.current.blur();

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,11 +77,11 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = searchCriteria.trim().replace('%', '%25');
+        const search = encodeURIComponent(searchCriteria.trim().replace('%', '%25'));
         const trimmedSearch = searchCriteria.trim().replace('+', '');
 
         if (e.key === 'Enter' && trimmedSearch !== '') {
-            history.push(appendWithStoreCode(`/search/${ encodeURIComponent(search) }`));
+            history.push(appendWithStoreCode(`/search/${ search }`));
             hideActiveOverlay();
             onSearchBarChange({ target: { value: '' } });
             this.searchBarRef.current.blur();

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,7 +77,7 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = searchCriteria.trim();
+        const search = searchCriteria.trim().replace('%', '%25');
         const trimmedSearch = searchCriteria.trim().replace('+', '');
 
         if (e.key === 'Enter' && trimmedSearch !== '') {

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,7 +77,7 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = encodeURIComponent(searchCriteria.trim().replace(/%/g, '%25'));
+        const search = encodeURIComponent(searchCriteria.trim().replace(/%/g, '%2525'));
         const trimmedSearch = searchCriteria.trim();
 
         if (e.key === 'Enter' && trimmedSearch !== '') {

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,8 +77,8 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = encodeURIComponent(searchCriteria.trim().replace('%', '%25'));
-        const trimmedSearch = searchCriteria.trim().replace('+', '');
+        const search = encodeURIComponent(searchCriteria.trim().replace(/%/g, '%25'));
+        const trimmedSearch = searchCriteria.trim().replace(/\+/g, '');
 
         if (e.key === 'Enter' && trimmedSearch !== '') {
             history.push(appendWithStoreCode(`/search/${ search }`));

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,7 +77,7 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = encodeURIComponent(searchCriteria.trim().replace(/%/g, '%2525'));
+        const search = encodeURIComponent(searchCriteria.trim().replace(/%/g, '%25'));
         const trimmedSearch = searchCriteria.trim();
 
         if (e.key === 'Enter' && trimmedSearch !== '') {

--- a/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.container.js
+++ b/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.container.js
@@ -86,7 +86,7 @@ export class SearchOverlayContainer extends PureComponent {
 
         if (searchCriteria) {
             clearSearchResults();
-            const search = encodeURIComponent(searchCriteria.trim().replace('%', '%25'));
+            const search = encodeURIComponent(searchCriteria.trim().replace(/%/g, '%25'));
             makeSearchRequest({
                 args: {
                     search,

--- a/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.container.js
+++ b/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.container.js
@@ -86,10 +86,10 @@ export class SearchOverlayContainer extends PureComponent {
 
         if (searchCriteria) {
             clearSearchResults();
-
+            const search = encodeURIComponent(searchCriteria.trim().replace('%', '%25'));
             makeSearchRequest({
                 args: {
-                    search: searchCriteria,
+                    search,
                     pageSize: 24,
                     currentPage: 1
                 }

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.component.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.component.js
@@ -28,7 +28,7 @@ export class SearchPage extends CategoryPage {
               } }
             >
                 { __('Search results for: ') }
-                <span>{ search.replace(/\+/g, ' ') }</span>
+                <span>{ decodeURIComponent(search) }</span>
             </h1>
         );
     }

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.component.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.component.js
@@ -10,6 +10,7 @@
  */
 
 import CategoryPage from 'Route/CategoryPage/CategoryPage.component';
+import { decodeString } from 'Util/Common';
 
 import './SearchPage.style';
 
@@ -28,7 +29,7 @@ export class SearchPage extends CategoryPage {
               } }
             >
                 { __('Search results for: ') }
-                <span>{ decodeURIComponent(search) }</span>
+                <span>{ decodeString(search) }</span>
             </h1>
         );
     }

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
@@ -22,7 +22,7 @@ import { BOTTOM_NAVIGATION_TYPE, TOP_NAVIGATION_TYPE } from 'Store/Navigation/Na
 import { setBigOfflineNotice } from 'Store/Offline/Offline.action';
 import { toggleOverlayByKey } from 'Store/Overlay/Overlay.action';
 import { updateInfoLoadStatus } from 'Store/ProductListInfo/ProductListInfo.action';
-import { noopFn } from 'Util/Common';
+import { decodeString, noopFn } from 'Util/Common';
 import { withReducers } from 'Util/DynamicReducer';
 import { debounce } from 'Util/Request';
 import { appendWithStoreCode } from 'Util/Url';
@@ -114,7 +114,7 @@ export class SearchPageContainer extends CategoryPageContainer {
 
     updateBreadcrumbs() {
         const { updateBreadcrumbs } = this.props;
-        const search = decodeURIComponent(this.getSearchParam());
+        const search = decodeString(this.getSearchParam());
 
         updateBreadcrumbs([{
             url: '',

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.container.js
@@ -114,7 +114,7 @@ export class SearchPageContainer extends CategoryPageContainer {
 
     updateBreadcrumbs() {
         const { updateBreadcrumbs } = this.props;
-        const search = this.getSearchParam();
+        const search = decodeURIComponent(this.getSearchParam());
 
         updateBreadcrumbs([{
             url: '',

--- a/packages/scandipwa/src/util/Common/index.js
+++ b/packages/scandipwa/src/util/Common/index.js
@@ -18,3 +18,12 @@
  * @namespace Util/Common/Index/noopFn
  */
 export const noopFn = () => {};
+
+/** @namespace Util/Common/Index/decodeString */
+export const decodeString = (string) => {
+    try {
+        return decodeURIComponent(string);
+    } catch (e) {
+        return string;
+    }
+};


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3972 (issue + failed QA comments)

**Problem:**
* `&` in URL is normally used for separating pairs of query params. It should be encoded if used as part of query param.
* Ooops page appears when searching '%' symbol Error message 'URIError: URI malformed' appears in the console
* Error messages 'Error fetching Product List Information!' and 'Error fetching Product List!' when searching '+' symbol

**In this PR:**
* Removed replacement of ' ' to '+', used URL encoding instead (which handles `&` in search param among other cases). 
* make + symbol to empty space and prevent redirect to search page 
* problem with encode % symbol need to change it manually

This is a reacreated PR from @tappiola https://github.com/scandipwa/scandipwa/pull/4191