### PR TITLE
[3572] Fix ltr order of options in cart in rtl mode

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.component.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.component.js
@@ -234,6 +234,7 @@ export class CartItem extends PureComponent {
             <div
               block="CartItem"
               elem="Option"
+              mods={ { isBundle: true } }
               key={ id }
             >
                 { this.renderBundleProductOptionLabel(option) }

--- a/packages/scandipwa/src/component/CartItem/CartItem.style.scss
+++ b/packages/scandipwa/src/component/CartItem/CartItem.style.scss
@@ -104,6 +104,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        display: flex;
+        gap: 4px;
+
+        &_isBundle {
+            flex-direction: column;
+            gap: 0;
+        }
     }
 
     &-ItemLinks {


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/3572

**Problem:**
* Name of option with radio button selector is written in LTR order in cart / mini cart.

**In this PR:**
* Make option parent element flex so now LTR/RTL modes have an effect.
