### PR TITLE
[4063] Fix Mobile horizontal scroll on long delivery method name

### DIFF
--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
@@ -76,7 +76,6 @@
     &-Row {
         strong {
             display: inline-block;
-            white-space: pre;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4063

**Problem:**
* Mobile: Horizontal scroll appears on checkout if the delivery method has a long title and/or method name

**In this PR:**
* deleted "white-space: pre;" on corresponding tag which was causing unusual behavior
