### PR TITLE
[4202] Fix wishlish item names cut on IOS

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -138,6 +138,7 @@
             text-overflow: ellipsis;
             overflow: hidden;
             white-space: nowrap;
+            line-height: normal;
 
             @include mobile {
                 white-space: normal;


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4202

**Problem:**
* Name of the product is cut in Wishlist on IOS

**In this PR:**
* Change line-height to normal on the corresponding tag
