### PR TITLE
[4238] user redirect to sign in page fix on desktop

### DIFF
--- a/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.js
+++ b/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.js
@@ -143,6 +143,7 @@ export class MyAccountOverlayContainer extends PureComponent {
             stateToBeUpdated.isPasswordForgotSend = isPasswordForgotSend;
             // eslint-disable-next-line max-len
             showNotification('success', __('If there is an account associated with the provided address you will receive an email with a link to reset your password.'));
+            history.push({ pathname: appendWithStoreCode(ACCOUNT_LOGIN_URL) });
             stateToBeUpdated.state = STATE_SIGN_IN;
         }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4238
**Problem:**
* user was not redirected to the login page after requesting a password change.

**In this PR:**
* MyAccountOverlay.container
	* added a history.push in line 146 to redirect user to login
