### PR TITLE
[3760] Add counter to the slider on mobile PDP

### DIFF
--- a/packages/scandipwa/src/component/ProductGallery/ProductGallery.component.js
+++ b/packages/scandipwa/src/component/ProductGallery/ProductGallery.component.js
@@ -429,7 +429,7 @@ export class ProductGallery extends PureComponent {
                 <Slider
                   sliderRef={ sliderRef }
                   mix={ { block: 'ProductGallery', elem: 'Slider', mods } }
-                  showCrumbs={ isMobile && isMoreThanOnePhoto }
+                  showCounter={ isMobile }
                   showArrows={ !isMobile && isMoreThanOnePhoto }
                   activeImage={ activeImage }
                   onActiveImageChange={ onActiveImageChange }

--- a/packages/scandipwa/src/component/ProductGallery/ProductGallery.style.scss
+++ b/packages/scandipwa/src/component/ProductGallery/ProductGallery.style.scss
@@ -59,6 +59,7 @@
 
     &-SliderWrapper {
         flex: 1;
+        height: 100%;
     }
 
     &-Slider {

--- a/packages/scandipwa/src/component/Slider/Slider.component.js
+++ b/packages/scandipwa/src/component/Slider/Slider.component.js
@@ -38,6 +38,7 @@ export class Slider extends PureComponent {
     static propTypes = {
         showCrumbs: PropTypes.bool,
         showArrows: PropTypes.bool,
+        showCounter: PropTypes.bool,
         activeImage: PropTypes.number,
         onActiveImageChange: PropTypes.func,
         mix: MixType,
@@ -59,6 +60,7 @@ export class Slider extends PureComponent {
         onActiveImageChange: noopFn,
         showCrumbs: false,
         showArrows: false,
+        showCounter: false,
         isInteractionDisabled: false,
         mix: {},
         onClick: null,
@@ -81,6 +83,8 @@ export class Slider extends PureComponent {
     handleDragEnd = this.handleInteraction.bind(this, this.handleDragEnd);
 
     renderCrumb = this.renderCrumb.bind(this);
+
+    renderCounter = this.renderCounter.bind(this);
 
     goNext = this.goNext.bind(this);
 
@@ -438,6 +442,25 @@ export class Slider extends PureComponent {
         }
     }
 
+    renderCounter() {
+        const { children, showCounter, activeImage } = this.props;
+
+        if (!showCounter || children.length <= 1) {
+            return null;
+        }
+
+        return (
+            <div
+              block="Slider"
+              elem="Counter"
+            >
+                { activeImage + 1 }
+                /
+                { children.length }
+            </div>
+        );
+    }
+
     renderCrumbs() {
         const { children, showCrumbs } = this.props;
 
@@ -546,6 +569,7 @@ export class Slider extends PureComponent {
                 >
                     { this.renderSliderContent() }
                     { this.renderCrumbs() }
+                    { this.renderCounter() }
                 </div>
                 { this.renderArrows() }
             </>

--- a/packages/scandipwa/src/component/Slider/Slider.style.scss
+++ b/packages/scandipwa/src/component/Slider/Slider.style.scss
@@ -49,6 +49,17 @@
         justify-content: center;
     }
 
+    &-Counter {
+        font-size: 1.2rem;
+        color: var(--color-white);
+        background: var(--color-dark-gray);
+        border-radius: 15px;
+        padding: 2px 3px 0;
+        position: absolute;
+        inset-block-end: 5px;
+        inset-inline-end: 5px;
+    }
+
     &-Crumbs {
         height: auto;
         min-height: 16px;

--- a/packages/scandipwa/src/component/Slider/Slider.style.scss
+++ b/packages/scandipwa/src/component/Slider/Slider.style.scss
@@ -54,7 +54,7 @@
         color: var(--color-white);
         background: var(--color-dark-gray);
         border-radius: 15px;
-        padding: 2px 3px 0;
+        padding: 1px 4px 0;
         position: absolute;
         inset-block-end: 5px;
         inset-inline-end: 5px;


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/3760

**Problem:**
* Dots overlap image and PDP does not look good if the product has a lot of images

**In this PR:**
* Passed showcounter property instead of showcrumbs to Slider on PhotoGallery.
* Defined counter render method at Slider component and styled.
