### PR TITLE
[4242] Add word break to paragraphs

### DIFF
--- a/packages/scandipwa/src/style/base/_reset.scss
+++ b/packages/scandipwa/src/style/base/_reset.scss
@@ -329,6 +329,7 @@ p {
 
     @include mobile {
         margin-block-end: 17px;
+        word-break: break-word;
     }
 
     &.caption {


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4242

**Problem:**
* If a paragraph contains a long word it goes out from the screen, the word is not breaking and starting on another line.

**In this PR:**
* Set the word-break property to paragraph styles.
