### PR TITLE
[3588] Fix ProductDownloadableSamples not using business logic

### DIFF
--- a/packages/scandipwa/src/component/Product/Product.component.js
+++ b/packages/scandipwa/src/component/Product/Product.component.js
@@ -24,7 +24,7 @@ import ProductCompareButton from 'Component/ProductCompareButton';
 import ProductConfigurableAttributes from 'Component/ProductConfigurableAttributes/ProductConfigurableAttributes.container';
 import ProductCustomizableOptions from 'Component/ProductCustomizableOptions';
 import ProductDownloadableLinks from 'Component/ProductDownloadableLinks';
-import ProductDownloadableSamples from 'Component/ProductDownloadableSamples/ProductDownloadableSamples.component';
+import ProductDownloadableSamples from 'Component/ProductDownloadableSamples';
 import ProductPrice from 'Component/ProductPrice';
 import ProductReviewRating from 'Component/ProductReviewRating';
 import ProductWishlistButton from 'Component/ProductWishlistButton';


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/3588

**Problem:**
* Sample for downloadable product opens in the same window if setting Open Links in New Window is set to yes. 
* The thing is that ProductDownloadableSamples component is called instead of the container and that cause use of component without business logic.

**In this PR:**
* Import ProductDownloadableSamples from its index in the Product component.
