### PR TITLE
[4005] Merging multiple page loaders into one (PDP / CMS / Home Page / Checkout)

### DIFF
--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.component.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.component.js
@@ -16,6 +16,7 @@ import CheckoutAddressForm from 'Component/CheckoutAddressForm';
 import CheckoutAddressTable from 'Component/CheckoutAddressTable';
 import Link from 'Component/Link';
 import Loader from 'Component/Loader';
+import GROUP_CODE from 'Component/LoaderGroup/LoaderGroup.config';
 import { BILLING_STEP, SHIPPING_STEP } from 'Route/Checkout/Checkout.config';
 import { ACCOUNT_URL } from 'Route/MyAccount/MyAccount.config';
 import { ADDRESS_BOOK, CustomerType } from 'Type/Account.type';
@@ -79,7 +80,7 @@ export class CheckoutAddressBook extends PureComponent {
 
     renderLoading() {
         return (
-            <Loader isLoading />
+            <Loader isLoading subscribeTo={ GROUP_CODE.body } />
         );
     }
 

--- a/packages/scandipwa/src/component/Html/Html.component.js
+++ b/packages/scandipwa/src/component/Html/Html.component.js
@@ -21,7 +21,8 @@ import { lazy, PureComponent, Suspense } from 'react';
 
 import Image from 'Component/Image';
 import Link from 'Component/Link';
-import Loader from 'Component/Loader/Loader.component';
+import Loader from 'Component/Loader';
+import GROUP_CODE from 'Component/LoaderGroup/LoaderGroup.config';
 import { hash } from 'Util/Request/Hash';
 
 export const WidgetFactory = lazy(() => import(
@@ -208,7 +209,7 @@ export class Html extends PureComponent {
      */
     replaceWidget({ attribs }) {
         return (
-            <Suspense fallback={ <Loader isLoading /> }>
+            <Suspense fallback={ <Loader isLoading subscribeTo={ GROUP_CODE.body } /> }>
                 <WidgetFactory { ...this.attributesToProps(attribs) } />
             </Suspense>
         );

--- a/packages/scandipwa/src/component/Loader/Loader.component.js
+++ b/packages/scandipwa/src/component/Loader/Loader.component.js
@@ -12,6 +12,8 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
+import { MixType } from 'Type/Common.type';
+
 import './Loader.style';
 
 /**
@@ -22,11 +24,13 @@ import './Loader.style';
  */
 export class Loader extends PureComponent {
     static propTypes = {
-        isLoading: PropTypes.bool
+        isLoading: PropTypes.bool,
+        mix: MixType
     };
 
     static defaultProps = {
-        isLoading: true
+        isLoading: true,
+        mix: {}
     };
 
     renderMain() {
@@ -38,14 +42,14 @@ export class Loader extends PureComponent {
     }
 
     render() {
-        const { isLoading } = this.props;
+        const { isLoading, mix } = this.props;
 
         if (!isLoading) {
             return null;
         }
 
         return (
-            <div block="Loader">
+            <div block="Loader" mix={ mix }>
                 <div block="Loader" elem="Scale">
                     { this.renderMain() }
                 </div>

--- a/packages/scandipwa/src/component/Loader/Loader.container.js
+++ b/packages/scandipwa/src/component/Loader/Loader.container.js
@@ -84,8 +84,10 @@ export class LoaderContainer extends PureComponent {
     }
 
     shouldRender(renderSeparately) {
-        this.setState({ shouldRender: renderSeparately });
-        this.state.shouldRender = renderSeparately;
+        const { isLoading } = this.props;
+        const render = renderSeparately && isLoading;
+        this.setState({ shouldRender: render });
+        this.state.shouldRender = render;
     }
 
     render() {

--- a/packages/scandipwa/src/component/Loader/Loader.container.js
+++ b/packages/scandipwa/src/component/Loader/Loader.container.js
@@ -1,0 +1,105 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import Loader from 'Component/Loader/Loader.component';
+import { MixType } from 'Type/Common.type';
+import { invoke, subscribe, unsubscribe } from 'Util/ObserverPool/ObserverPool';
+
+/**
+ * Loader component
+ * Loaders overlay to identify loading
+ * @class Loader
+ * @namespace Component/Loader/Container
+ */
+export class LoaderContainer extends PureComponent {
+    static propTypes = {
+        isLoading: PropTypes.bool,
+        mix: MixType,
+        subscribeTo: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+    };
+
+    static defaultProps = {
+        isLoading: true,
+        mix: {},
+        subscribeTo: false
+    };
+
+    state = {
+        shouldRender: true
+    };
+
+    poolUid = false;
+
+    __construct(props) {
+        super.__construct(props);
+        const { subscribeTo, isLoading } = props;
+
+        if (!subscribeTo) {
+            return;
+        }
+
+        if (this.poolUid) {
+            unsubscribe(subscribeTo, this.poolUid);
+        }
+
+        this.poolUid = subscribe(subscribeTo, this.shouldRender.bind(this), isLoading);
+
+        if (this.poolUid !== false) {
+            this.setState({ shouldRender: false });
+            invoke(subscribeTo, [this.poolUid, isLoading]);
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        const { isLoading, subscribeTo } = this.props;
+        const { isLoading: prevPropsIsLoading } = prevProps;
+
+        if (this.poolUid !== false && subscribeTo && isLoading !== prevPropsIsLoading) {
+            invoke(subscribeTo, [this.poolUid, isLoading]);
+        }
+    }
+
+    componentWillUnmount() {
+        const { subscribeTo } = this.props;
+
+        if (!subscribeTo || this.poolUid === false) {
+            return;
+        }
+
+        this.shouldRender(false);
+
+        invoke(subscribeTo, [this.poolUid, false]);
+        unsubscribe(subscribeTo, this.poolUid);
+    }
+
+    shouldRender(renderSeparately) {
+        this.setState({ shouldRender: renderSeparately });
+        this.state.shouldRender = renderSeparately;
+    }
+
+    render() {
+        const { isLoading, mix, subscribeTo } = this.props;
+        const { shouldRender } = this.state;
+
+        if (subscribeTo && !shouldRender) {
+            return null;
+        }
+
+        return (
+            <Loader mix={ mix } isLoading={ isLoading } />
+        );
+    }
+}
+
+export default LoaderContainer;

--- a/packages/scandipwa/src/component/Loader/Loader.style.scss
+++ b/packages/scandipwa/src/component/Loader/Loader.style.scss
@@ -39,4 +39,18 @@
             transform: translate(50%, -50%) scale(var(--loader-scale));
         }
     }
+
+    &-Page {
+        position: fixed;
+        margin-block-start: 0;
+        inset-block-start: 0;
+        height: 100vh;
+        width: 100vw;
+        z-index: 1000;
+    }
+
+    &-Body {
+        width: 100%;
+        height: 100%;
+    }
 }

--- a/packages/scandipwa/src/component/LoaderGroup/LoaderGroup.config.js
+++ b/packages/scandipwa/src/component/LoaderGroup/LoaderGroup.config.js
@@ -9,4 +9,11 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-export { default } from './Loader.container';
+export const GROUP_CODE = {
+    page: 'PAGE',
+    header: 'HEADER',
+    body: 'BODY',
+    footer: 'FOOTER'
+};
+
+export default GROUP_CODE;

--- a/packages/scandipwa/src/component/LoaderGroup/LoaderGroup.config.js
+++ b/packages/scandipwa/src/component/LoaderGroup/LoaderGroup.config.js
@@ -10,10 +10,14 @@
  */
 
 export const GROUP_CODE = {
+    // Main page sections:
     page: 'PAGE',
     header: 'HEADER',
     body: 'BODY',
-    footer: 'FOOTER'
+    footer: 'FOOTER',
+
+    // Misc sections:
+    checkout: 'CHECKOUT'
 };
 
 export default GROUP_CODE;

--- a/packages/scandipwa/src/component/LoaderGroup/LoaderGroup.container.js
+++ b/packages/scandipwa/src/component/LoaderGroup/LoaderGroup.container.js
@@ -65,7 +65,7 @@ export class LoaderGroup extends PureComponent {
             return;
         }
 
-        const isLoading = !!this.getRendererCount();
+        const isLoading = this.getRendererCount() > 0;
         this.poolUid = subscribe(
             subscribeTo,
             this.shouldRender.bind(this),
@@ -97,6 +97,7 @@ export class LoaderGroup extends PureComponent {
 
     shouldRender(renderSeparately) {
         this.setState({ shouldRender: renderSeparately });
+        this.state.shouldRender = renderSeparately;
     }
 
     shouldChildrenRender(data) {
@@ -105,11 +106,12 @@ export class LoaderGroup extends PureComponent {
 
         this.registerLoader(uid, isLoading);
 
-        const shouldChildrenRenderSeparate = this.getRendererCount() <= loadingElementThreshold;
+        const loaderCount = this.getRendererCount();
+        const shouldChildrenRenderSeparate = loaderCount <= loadingElementThreshold;
         this.setState({ shouldChildrenRenderSeparate });
 
         if (subscribeTo) {
-            invoke(subscribeTo, [this.poolUid, !!this.getRendererCount()]);
+            invoke(subscribeTo, [this.poolUid, loaderCount > 0]);
         }
 
         const { shouldRender } = this.state;

--- a/packages/scandipwa/src/component/LoaderGroup/LoaderGroup.container.js
+++ b/packages/scandipwa/src/component/LoaderGroup/LoaderGroup.container.js
@@ -1,0 +1,141 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import Loader from 'Component/Loader';
+import { MixType } from 'Type/Common.type';
+import {
+    invoke, register, subscribe, unsubscribe
+} from 'Util/ObserverPool/ObserverPool';
+
+/**
+ * LoaderGroup container
+ * Creates container for multiple <Loader> components in page.
+ * This component handles whether one combined loader on multiple loaders should be rendered.
+ * LoaderGroup can also contain other loader groups, thus splitting loading regions.
+ * - Each group contains unique ID - groupCode
+ * - To add loader or loaderGroup to group use prop - subscribeTo
+ * @class Loader
+ * @namespace Component/LoaderGroup/Container
+ */
+export class LoaderGroup extends PureComponent {
+    static propTypes = {
+        // eslint-disable-next-line react/no-unused-prop-types
+        groupCode: PropTypes.string.isRequired,
+        subscribeTo: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+        // How many unloaded elements there can be, before uniting them into one
+        loadingElementThreshold: PropTypes.number,
+        mix: MixType
+    };
+
+    static defaultProps = {
+        loadingElementThreshold: 1,
+        mix: {},
+        subscribeTo: false
+    };
+
+    state = {
+        register: {},
+        shouldRender: true,
+        shouldChildrenRenderSeparate: true
+    };
+
+    poolUid = false;
+
+    __construct(props) {
+        super.__construct(props);
+        const { groupCode, subscribeTo } = props;
+
+        register(groupCode, {
+            onSubscribe: this.registerLoader.bind(this),
+            getInvokeData: this.shouldChildrenRender.bind(this)
+        });
+
+        if (!subscribeTo || this.poolUid !== false) {
+            return;
+        }
+
+        const isLoading = !!this.getRendererCount();
+        this.poolUid = subscribe(
+            subscribeTo,
+            this.shouldRender.bind(this),
+            isLoading
+        );
+
+        if (this.poolUid !== false) {
+            invoke(subscribeTo, [this.poolUid, isLoading]);
+        }
+    }
+
+    componentWillUnmount() {
+        const { subscribeTo } = this.props;
+
+        if (!subscribeTo || this.poolUid === false) {
+            return;
+        }
+
+        invoke(subscribeTo, [this.poolUid, false]);
+        unsubscribe(subscribeTo, this.poolUid);
+    }
+
+    registerLoader(uid, isLoading) {
+        const { register } = this.state;
+
+        register[uid] = isLoading;
+        this.setState({ register });
+    }
+
+    shouldRender(renderSeparately) {
+        this.setState({ shouldRender: renderSeparately });
+    }
+
+    shouldChildrenRender(data) {
+        const [uid, isLoading] = data;
+        const { loadingElementThreshold, subscribeTo } = this.props;
+
+        this.registerLoader(uid, isLoading);
+
+        const shouldChildrenRenderSeparate = this.getRendererCount() <= loadingElementThreshold;
+        this.setState({ shouldChildrenRenderSeparate });
+
+        if (subscribeTo) {
+            invoke(subscribeTo, [this.poolUid, !!this.getRendererCount()]);
+        }
+
+        const { shouldRender } = this.state;
+
+        return shouldChildrenRenderSeparate && shouldRender;
+    }
+
+    getRendererCount() {
+        const { register } = this.state;
+
+        return Object.values(register).filter((isLoading) => isLoading).length;
+    }
+
+    render() {
+        const { shouldChildrenRenderSeparate, shouldRender } = this.state;
+
+        if (shouldChildrenRenderSeparate || (!shouldRender && this.poolUid)) {
+            return null;
+        }
+
+        const { mix } = this.props;
+
+        return (
+            <Loader mix={ mix } isLoading />
+        );
+    }
+}
+
+export default LoaderGroup;

--- a/packages/scandipwa/src/component/LoaderGroup/index.js
+++ b/packages/scandipwa/src/component/LoaderGroup/index.js
@@ -9,4 +9,4 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-export { default } from './Loader.container';
+export { default } from './LoaderGroup.container';

--- a/packages/scandipwa/src/component/Router/Router.component.js
+++ b/packages/scandipwa/src/component/Router/Router.component.js
@@ -24,6 +24,8 @@ import { Router as ReactRouter } from 'react-router';
 import { Route, Switch } from 'react-router-dom';
 
 import Loader from 'Component/Loader';
+import LoaderGroup from 'Component/LoaderGroup';
+import GROUP_CODE from 'Component/LoaderGroup/LoaderGroup.config';
 import Meta from 'Component/Meta';
 import UrlRewrites from 'Route/UrlRewrites';
 import {
@@ -61,6 +63,7 @@ import {
     NAVIGATION_TABS,
     NEW_VERSION_POPUP,
     NOTIFICATION_LIST,
+    PAGE_LOADER,
     SEARCH,
     SHARED_WISHLIST,
     STYLE_GUIDE,
@@ -109,6 +112,11 @@ export class Router extends PureComponent {
     };
 
     [BEFORE_ITEMS_TYPE] = [
+        {
+            component: <LoaderGroup groupCode={ GROUP_CODE.page } mix={ { block: 'Loader', elem: 'Page' } } />,
+            position: 40,
+            name: PAGE_LOADER
+        },
         {
             component: <NotificationList />,
             position: 10,
@@ -312,7 +320,7 @@ export class Router extends PureComponent {
 
     renderSectionOfType(type) {
         return (
-            <Suspense fallback={ <Loader isLoading /> }>
+            <Suspense fallback={ <Loader isLoading subscribeTo={ GROUP_CODE.page } /> }>
                 { this.renderComponentsOfType(type) }
             </Suspense>
         );

--- a/packages/scandipwa/src/component/Router/Router.config.js
+++ b/packages/scandipwa/src/component/Router/Router.config.js
@@ -19,6 +19,7 @@ export const DEMO_NOTICE = 'DEMO_NOTICE';
 export const HEADER = 'HEADER';
 export const BREADCRUMBS = 'BREADCRUMBS';
 export const NEW_VERSION_POPUP = 'NEW_VERSION_POPUP';
+export const PAGE_LOADER = 'PAGE_LOADER';
 
 // SWITCH_ITEMS_TYPE
 export const HOME = 'HOME';

--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -21,6 +21,7 @@ import {
 import ClickOutside from 'Component/ClickOutside';
 import CloseIcon from 'Component/CloseIcon';
 import Loader from 'Component/Loader';
+import GROUP_CODE from 'Component/LoaderGroup/LoaderGroup.config';
 import SearchIcon from 'Component/SearchIcon';
 import { DeviceType } from 'Type/Device.type';
 import { scrollToTop } from 'Util/Browser';
@@ -133,7 +134,7 @@ export class SearchField extends PureComponent {
     }
 
     renderOverlayFallback() {
-        return <Loader isLoading />;
+        return <Loader isLoading subscribeTo={ GROUP_CODE.page } />;
     }
 
     renderSearch() {

--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -17,6 +17,8 @@ import ContentWrapper from 'Component/ContentWrapper';
 import Form from 'Component/Form';
 import { CHECKOUT, CHECKOUT_SUCCESS } from 'Component/Header/Header.config';
 import Loader from 'Component/Loader';
+import LoaderGroup from 'Component/LoaderGroup';
+import GROUP_CODE from 'Component/LoaderGroup/LoaderGroup.config';
 import { Addresstype } from 'Type/Account.type';
 import {
     CheckoutStepType,
@@ -237,6 +239,10 @@ export class Checkout extends PureComponent {
         );
     }
 
+    renderStepFallback() {
+        return <Loader isLoading subscribeTo={ GROUP_CODE.body } />;
+    }
+
     renderShippingStep() {
         const {
             shippingMethods,
@@ -257,7 +263,7 @@ export class Checkout extends PureComponent {
         } = this.props;
 
         return (
-            <Suspense fallback={ <Loader /> }>
+            <Suspense fallback={ this.renderStepFallback() }>
                 <CheckoutShipping
                   isLoading={ isDeliveryOptionsLoading }
                   shippingMethods={ shippingMethods }
@@ -290,7 +296,7 @@ export class Checkout extends PureComponent {
         } = this.props;
 
         return (
-            <Suspense fallback={ <Loader /> }>
+            <Suspense fallback={ this.renderStepFallback() }>
                 <CheckoutBilling
                   setLoading={ setLoading }
                   paymentMethods={ paymentMethods }
@@ -315,7 +321,7 @@ export class Checkout extends PureComponent {
         } = this.props;
 
         return (
-            <Suspense fallback={ <Loader /> }>
+            <Suspense fallback={ this.renderStepFallback() }>
                 <CheckoutSuccess
                   email={ email }
                   firstName={ firstname }
@@ -341,7 +347,7 @@ export class Checkout extends PureComponent {
     renderLoader() {
         const { isLoading } = this.props;
 
-        return <Loader isLoading={ isLoading } />;
+        return <Loader isLoading={ isLoading } subscribeTo={ GROUP_CODE.body } />;
     }
 
     renderSummary(showOnMobile = false) {
@@ -446,6 +452,12 @@ export class Checkout extends PureComponent {
     render() {
         return (
             <main block="Checkout">
+                <LoaderGroup
+                  groupCode={ GROUP_CODE.body }
+                  subscribeTo={ GROUP_CODE.page }
+                  loadingElementThreshold={ 0 }
+                  mix={ { block: 'Loader', elem: 'Body' } }
+                />
                 <ContentWrapper
                   wrapperMix={ { block: 'Checkout', elem: 'Wrapper' } }
                   label={ __('Checkout page') }
@@ -466,7 +478,7 @@ export class Checkout extends PureComponent {
                         </div>
                     </Form>
                     <div>
-                        <Suspense fallback={ <Loader /> }>
+                        <Suspense fallback={ this.renderStepFallback() }>
                             { this.renderSummary() }
                             { this.renderPromo() }
                         </Suspense>

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.component.js
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.component.js
@@ -13,6 +13,8 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import Html from 'Component/Html';
+import LoaderGroup from 'Component/LoaderGroup';
+import GROUP_CODE from 'Component/LoaderGroup/LoaderGroup.config';
 import TextPlaceholder from 'Component/TextPlaceholder';
 import NoMatch from 'Route/NoMatch';
 import { BlockListType } from 'Type/CMS.type';
@@ -87,6 +89,12 @@ export class CmsPage extends PureComponent {
               block="CmsPage"
               mods={ { isBreadcrumbsHidden: !isBreadcrumbsActive } }
             >
+                <LoaderGroup
+                  groupCode={ GROUP_CODE.body }
+                  subscribeTo={ GROUP_CODE.page }
+                  loadingElementThreshold={ 0 }
+                  mix={ { block: 'Loader', elem: 'Body' } }
+                />
                 <div block="CmsPage" elem="Wrapper" mods={ { page_width } }>
                     { this.renderHeading() }
                     <div block="CmsPage" elem="Content">

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.component.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.component.js
@@ -13,7 +13,9 @@ import PropTypes from 'prop-types';
 import { lazy, PureComponent, Suspense } from 'react';
 
 import ContentWrapper from 'Component/ContentWrapper';
-import Loader from 'Component/Loader/Loader.component';
+import Loader from 'Component/Loader';
+import LoaderGroup from 'Component/LoaderGroup';
+import GROUP_CODE from 'Component/LoaderGroup/LoaderGroup.config';
 import Popup from 'Component/Popup/Popup.container';
 import ProductActions from 'Component/ProductActions';
 import ProductLinks from 'Component/ProductLinks';
@@ -104,7 +106,7 @@ export class ProductPage extends PureComponent {
 
         return (
             <>
-                <Suspense fallback={ <Loader /> }>
+                <Suspense fallback={ <Loader subscribeTo={ GROUP_CODE.body } isLoading /> }>
                     <ProductGallery
                       product={ activeProduct }
                       areDetailsLoaded={ areDetailsLoaded }
@@ -123,6 +125,10 @@ export class ProductPage extends PureComponent {
         );
     }
 
+    renderTabFallback() {
+        return <Loader subscribeTo={ GROUP_CODE.body } isLoading mix={ { block: 'Loader', elem: 'Tab' } } />;
+    }
+
     renderProductInformationTab(key) {
         const {
             dataSource,
@@ -131,7 +137,7 @@ export class ProductPage extends PureComponent {
         } = this.props;
 
         return (
-            <Suspense fallback={ <Loader /> } key={ key }>
+            <Suspense fallback={ this.renderTabFallback() } key={ key }>
                 <ProductInformation
                   product={ { ...dataSource, parameters } }
                   areDetailsLoaded={ areDetailsLoaded }
@@ -148,7 +154,7 @@ export class ProductPage extends PureComponent {
         } = this.props;
 
         return (
-            <Suspense fallback={ <Loader /> } key={ key }>
+            <Suspense fallback={ this.renderTabFallback() } key={ key }>
                 <ProductAttributes
                   product={ activeProduct }
                   areDetailsLoaded={ areDetailsLoaded }
@@ -165,7 +171,7 @@ export class ProductPage extends PureComponent {
         } = this.props;
 
         return (
-            <Suspense fallback={ <Loader /> } key={ key }>
+            <Suspense fallback={ this.renderTabFallback() } key={ key }>
                 <ProductReviews
                   product={ dataSource }
                   areDetailsLoaded={ areDetailsLoaded }
@@ -237,6 +243,12 @@ export class ProductPage extends PureComponent {
                   itemScope
                   itemType="http://schema.org/Product"
                 >
+                    <LoaderGroup
+                      groupCode={ GROUP_CODE.body }
+                      subscribeTo={ GROUP_CODE.page }
+                      loadingElementThreshold={ 0 }
+                      mix={ { block: 'Loader', elem: 'Body' } }
+                    />
                     <ContentWrapper
                       wrapperMix={ { block: 'ProductPage', elem: 'Wrapper' } }
                       label={ __('Main product details') }

--- a/packages/scandipwa/src/util/ObserverPool/ObserverPool.js
+++ b/packages/scandipwa/src/util/ObserverPool/ObserverPool.js
@@ -1,0 +1,128 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+/**
+ * Register
+ * - Creates new pool which can be accessed via unique code
+ * @param code unique code
+ * @param events callback events for: onSubscribe, onUnSubscribe, onInvoke, getInvokeData
+ * @namespace Util/ObserverPool/register
+ */
+export const register = (code, events = {}) => {
+    if (!window.pool) {
+        window.pool = {};
+    }
+
+    if (window.pool[code]) {
+        window.pool[code].events = events;
+
+        return;
+    }
+
+    window.pool[code] = {
+        uid: 0,
+        events,
+        pool: {}
+    };
+};
+
+/**
+ * Subscribe
+ * - Adds function to specific pool.
+ * @param code pool to which to subscribe
+ * @param fn function that will be called on invoke
+ * @param data optional data that can be passed to onSubscribe event
+ * @returns {*} uid on success / false on fail
+ * @namespace Util/ObserverPool/subscribe
+ */
+export const subscribe = (code, fn, data = null) => {
+    if (!window.pool || !window.pool[code]) {
+        return false;
+    }
+
+    const {
+        uid,
+        events: {
+            onSubscribe
+        } = {},
+        pool
+    } = window.pool[code];
+
+    pool[uid] = fn;
+
+    if (typeof onSubscribe === 'function') {
+        onSubscribe(uid, data);
+    }
+
+    window.pool[code].uid++;
+
+    return uid;
+};
+
+/**
+ * Unsubscribe
+ * - Removes function from pool
+ * @param code pool code
+ * @param uid function uid, that was gotten from subscribe
+ * @namespace Util/ObserverPool/unsubscribe
+ */
+export const unsubscribe = (code, uid) => {
+    if (!window.pool || !window.pool[code]) {
+        return;
+    }
+
+    const {
+        events: {
+            onUnSubscribe
+        } = {},
+        pool
+    } = window.pool[code];
+
+    // eslint-disable-next-line fp/no-delete
+    delete pool[uid];
+
+    if (typeof onUnSubscribe === 'function') {
+        onUnSubscribe(uid);
+    }
+};
+
+/**
+ * Invoke
+ * - When called all subscribed pool functions will be called, by passing
+ * - data from getInvokeData event (fallback: @param data).
+ * @param code pool to invoke
+ * @param data optional data to pass.
+ * @namespace Util/ObserverPool/invoke
+ */
+export const invoke = (code, data = []) => {
+    if (!window.pool || !window.pool[code]) {
+        return;
+    }
+
+    const {
+        events: {
+            getInvokeData,
+            onInvoke
+        } = {},
+        pool
+    } = window.pool[code];
+
+    const invokeData = typeof getInvokeData === 'function' ? getInvokeData(data) : data;
+    const collectedOutput = {};
+
+    Object.keys(pool).forEach((uid) => {
+        collectedOutput[uid] = pool[uid](invokeData);
+    });
+
+    if (typeof onInvoke === 'function') {
+        onInvoke(collectedOutput);
+    }
+};


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4005 

**Problem:**
* Multiple loaders are displayed due to different loading times, loading components and grpahql requests.

**In this PR:**
* Created new component `LoaderGroup` to which Loaders can subscribe. When `Loader` is subscribed to `LoaderGroup`, `LoaderGroup` manages when should there be outputted single or multiple loaders via `loadingElementThreshold` - this prop indicates maximum amount of loaders in pool before they are merged into one _(for example if loadingElementThreshold is set to 2 and there are 3 loaders that are still loading, then they will be merged into one, and after one of them loads they will be again outputted separately)_ (LoaderGroup can also subscribe to different LoaderGroups)
* Added `LoaderGroup` for `Page` and `Body` regions, thus when both elements in header and in body are loading then there will be one merged loader covering whole page, but when header is loaded then there will be only loader covering main content region.
* Created two way data observer utility.
