### PR TITLE
[3551] Added div wrapper Checkout-Promo, applied 24px padding on desktop

### DIFF
--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -388,7 +388,11 @@ export class Checkout extends PureComponent {
             return null;
         }
 
-        return <CmsBlock identifier={ promo } />;
+        return (
+            <div block="Checkout" elem="Promo">
+                <CmsBlock identifier={ promo } />
+            </div>
+        );
     }
 
     renderStoreInPickUpMethod() {

--- a/packages/scandipwa/src/route/Checkout/Checkout.style.scss
+++ b/packages/scandipwa/src/route/Checkout/Checkout.style.scss
@@ -160,6 +160,12 @@
         }
     }
 
+    &-Promo {
+        @include desktop {
+            padding-block-start: 24px;
+        }
+    }
+
     .Checkout-ExpandableContentContent {
         margin-block-start: 0;
         padding: 0 16px;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3551

**Problem:**
* Missing space between order summary and promo block

**In this PR:**
* Added new wrapper (Checkout-Promo) and added top-padding
