### PR TITLE
[4078] Loader missing on checkout (QA comment fix)

### DIFF
--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -326,14 +326,11 @@ export class CheckoutOrderSummary extends PureComponent {
     }
 
     renderExpandableContent() {
-        const { isLoading } = this.props;
-
         return (
             <ExpandableContent
               heading={ __('Summary') }
               mix={ { block: 'CheckoutOrderSummary', elem: 'ExpandableContent' } }
             >
-                <Loader isLoading={ isLoading } />
                 { this.renderItems() }
                 { this.renderCmsBlock() }
                 { this.renderTotals() }

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
@@ -11,6 +11,7 @@
 
 :root {
     --footer-totals-height: 0;
+    --loader-scale: 1;
 }
 
 .CheckoutOrderSummary {
@@ -268,6 +269,14 @@
 
         &_isEmpty {
             display: none;
+        }
+    }
+
+    .Loader {
+        &-Scale {
+            @media screen {
+                inset-block-start: calc(35% - (3px * var(--loader-scale)));
+            }
         }
     }
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4078#event-6025353507

**Problem:**
* Duplicate loader block on order summary mobile.
* loader is not visible on long carts.

**In this PR:**
* removed the duplicated loader from checkout order summary component
* Added a separate height style to the summary block loader.
