### PR TITLE
[4263] Set DefaultOption in ProductBundleOption

### DIFF
--- a/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.component.js
+++ b/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.component.js
@@ -286,7 +286,8 @@ export class ProductBundleOption extends PureComponent {
                   attr={ {
                       id: `bundle-options-dropdown-${ uid }`,
                       name: `bundle-options-dropdown-${ uid }`,
-                      selectPlaceholder: __('Select product...')
+                      selectPlaceholder: __('Select product...'),
+                      value: activeOption ? optionUid : ''
                   } }
                   mix={ { block: 'ProductBundleItem', elem: 'Select' } }
                   options={ getDropdownOptions() }

--- a/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.container.js
+++ b/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.container.js
@@ -58,8 +58,13 @@ export class ProductBundleOptionContainer extends PureComponent {
         setQuantity: this.setQuantity.bind(this),
         setActiveSelectUid: this.setActiveSelectUid.bind(this),
         getUidWithQuantity: this.getUidWithQuantity.bind(this),
-        getDropdownOptions: this.getDropdownOptions.bind(this)
+        getDropdownOptions: this.getDropdownOptions.bind(this),
+        setDefaultOption: this.setDefaultOption.bind(this)
     };
+
+    componentDidMount() {
+        this.setDefaultOption();
+    }
 
     componentDidUpdate(prevProps, prevState) {
         const { quantity } = this.state;
@@ -92,6 +97,16 @@ export class ProductBundleOptionContainer extends PureComponent {
         this.setState({
             activeSelectUid: uid
         });
+    }
+
+    setDefaultOption() {
+        const { options } = this.props;
+
+        const [defaultOption = null] = bundleOptionsToSelectTransform(options).filter(({ isDefault }) => isDefault);
+
+        if (defaultOption) {
+            this.setActiveSelectUid(defaultOption.value);
+        }
     }
 
     getDropdownOptions() {

--- a/packages/scandipwa/src/util/Product/Transform.js
+++ b/packages/scandipwa/src/util/Product/Transform.js
@@ -180,7 +180,8 @@ export const bundleOptionsToSelectTransform = (options, currencyCode = 'USD', qu
         const {
             uid: sourceUid = '',
             quantity: defaultQuantity = 1,
-            position
+            position,
+            is_default
         } = option;
 
         const {
@@ -197,7 +198,8 @@ export const bundleOptionsToSelectTransform = (options, currencyCode = 'USD', qu
             value: uid,
             label: baseLabel,
             subLabel: priceLabel,
-            sort_order: position
+            sort_order: position,
+            isDefault: is_default
         });
 
         return result;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4263

**Problem:**
* Product option isn't selected by default for bundle product in dropdown on PDP

**In this PR:**
* Return isDefault prop in Util/Product/Transform bundleOptionsToSelectTransform()
* setDefaultOption on mount in ProductBundleOption Container
* set value equal to activeOption in ProductBundleOption component in render renderSelectValue()
