### PR TITLE
#3976 - Use grid for desktop header

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.component.js
+++ b/packages/scandipwa/src/component/Header/Header.component.js
@@ -221,9 +221,7 @@ export class Header extends NavigationAbstract {
         title: this.renderTitle.bind(this),
         logo: this.renderLogo.bind(this),
         search: this.renderSearchField.bind(this),
-        account: this.renderAccount.bind(this),
-        compare: this.renderComparePageButton.bind(this),
-        minicart: this.renderMinicart.bind(this),
+        renderDesktopIcons: this.renderDesktopIcons.bind(this),
         share: this.renderShareWishListButton.bind(this),
         ok: this.renderOkButton.bind(this)
     };
@@ -631,6 +629,19 @@ export class Header extends NavigationAbstract {
                     { this.renderMinicartOverlay() }
                 </div>
             </ClickOutside>
+        );
+    }
+
+    renderDesktopIcons() {
+        return (
+            <div
+              block="Header"
+              elem="IconsWrapper"
+            >
+                { this.renderAccount() }
+                { this.renderComparePageButton() }
+                { this.renderMinicart() }
+            </div>
         );
     }
 

--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -238,8 +238,9 @@
         }
 
         @include desktop {
-            position: absolute;
             grid-column: 1 / 2;
+            min-height: var(--header-nav-height);
+            position: absolute;
 
             @include logo-visible;
         }

--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -238,6 +238,9 @@
         }
 
         @include desktop {
+            position: absolute;
+            grid-column: 1 / 2;
+
             @include logo-visible;
         }
 
@@ -283,7 +286,7 @@
 
         @include desktop {
             display: grid;
-            grid-template-columns: 1fr minmax(auto, 660px) 1fr;
+            grid-template-columns: minmax(var(--header-logo-width), 1fr) minmax(auto, 660px) 1fr;
             justify-content: unset;
             padding-inline: 32px;
         }

--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -177,6 +177,10 @@
         }
     }
 
+    &-IconsWrapper {
+        display: flex;
+    }
+
     &-MinicartButtonWrapper {
         cursor: pointer;
         height: 100%;
@@ -273,9 +277,13 @@
         align-items: center;
         display: flex;
         height: var(--header-nav-height);
+        margin: auto;
+        max-width: var(--content-wrapper-width);
         padding-inline: 14px;
 
         @include desktop {
+            display: grid;
+            grid-template-columns: 1fr minmax(auto, 660px) 1fr;
             justify-content: unset;
             padding-inline: 32px;
         }
@@ -354,16 +362,12 @@
         }
     }
 
-    &-TopMenu,
-    &-Nav {
-        display: flex;
-        margin: auto;
-        max-width: var(--content-wrapper-width);
-    }
-
     &-TopMenu {
+        display: flex;
         justify-content: space-between;
         height: var(--header-top-menu-height);
+        margin: auto;
+        max-width: var(--content-wrapper-width);
         padding-inline: 32px;
         padding-block-start: 16px;
     }

--- a/packages/scandipwa/src/component/Logo/Logo.style.scss
+++ b/packages/scandipwa/src/component/Logo/Logo.style.scss
@@ -26,6 +26,10 @@
 
         .Image {
             height: var(--header-logo-height);
+
+            @include desktop {
+                min-height: var(--header-nav-height);
+            }
         }
     }
 

--- a/packages/scandipwa/src/component/SearchField/SearchField.style.scss
+++ b/packages/scandipwa/src/component/SearchField/SearchField.style.scss
@@ -30,6 +30,7 @@
         display: block;
         width: 90%;
         max-width: 600px;
+        grid-column: 2 / 3;
     }
 
     &_isVisible {

--- a/packages/scandipwa/src/component/SearchField/SearchField.style.scss
+++ b/packages/scandipwa/src/component/SearchField/SearchField.style.scss
@@ -28,7 +28,7 @@
 
     @include desktop {
         display: block;
-        width: 55%;
+        width: 90%;
         max-width: 600px;
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3976

**Problem:**
* Centering of the search depends on the number of icons and the size of the logo, when changing, it is necessary to align with margin/padding

**In this PR:**
* A grid is used to build a desktop header
