### PR TITLE
#4092 - Add date sorting for comments

### DIFF
--- a/packages/scandipwa/src/component/MyAccountOrderItemsTable/MyAccountOrderItemsTable.component.js
+++ b/packages/scandipwa/src/component/MyAccountOrderItemsTable/MyAccountOrderItemsTable.component.js
@@ -182,7 +182,9 @@ export class MyAccountOrderItemsTable extends PureComponent {
             return null;
         }
 
-        const commentOrder = comments.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+        const commentOrder = comments.sort(
+            ({ timestamp: first }, { timestamp: second }) => new Date(second) - new Date(first)
+        );
 
         return (
             <div block="MyAccountOrderItemsTable" elem="Comments">

--- a/packages/scandipwa/src/component/MyAccountOrderItemsTable/MyAccountOrderItemsTable.component.js
+++ b/packages/scandipwa/src/component/MyAccountOrderItemsTable/MyAccountOrderItemsTable.component.js
@@ -182,6 +182,8 @@ export class MyAccountOrderItemsTable extends PureComponent {
             return null;
         }
 
+        const commentOrder = comments.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+
         return (
             <div block="MyAccountOrderItemsTable" elem="Comments">
                 <div
@@ -191,7 +193,7 @@ export class MyAccountOrderItemsTable extends PureComponent {
                     { __('About Your %s', activeTab) }
                 </div>
                 <div block="MyAccountOrderItemsTable" elem="CommentsList">
-                    { comments.map(({ timestamp, message }) => (
+                    { commentOrder.map(({ timestamp, message }) => (
                         <dl
                           block="MyAccountOrderItemsTable"
                           elem="Comment"

--- a/packages/scandipwa/src/component/MyAccountOrderItemsTable/MyAccountOrderItemsTable.style.scss
+++ b/packages/scandipwa/src/component/MyAccountOrderItemsTable/MyAccountOrderItemsTable.style.scss
@@ -110,7 +110,7 @@
 
         &List {
             display: flex;
-            flex-direction: column-reverse;
+            flex-direction: column;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4092

**Problem:**
* Wrong comments order for Refund tab

**In this PR:**
* Add sorting for comments using date
