### PR TITLE
[4282] attribute label gets trimmed before rendering

### DIFF
--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -94,7 +94,7 @@ export class ProductAttributeValue extends PureComponent {
                 return {
                     ...optionValues,
                     label: `${adjustedLabel} (${count})`,
-                    labelText: adjustedLabel,
+                    labelText: adjustedLabel.trim(),
                     count
                 };
             }


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4282 

**Problem:**
* Count for options is moved to the next line without the last word in Layered Navigation
* The above happened only when there was is an additional white space at the end of the string.

**In this PR:**
* Attribute label now gets trimmed before rendering
