### PR TITLE
issue-4285 Add string decoding for get params in url

### DIFF
--- a/packages/scandipwa/src/util/Url/Url.js
+++ b/packages/scandipwa/src/util/Url/Url.js
@@ -9,6 +9,7 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+import { decodeString } from 'Util/Common';
 import getStore from 'Util/Store';
 
 /**
@@ -100,7 +101,7 @@ export const appendWithStoreCode = (pathname) => {
  * @namespace Util/Url/getQueryParam
  */
 export const getQueryParam = (variable, location) => {
-    const query = location.search.substring(1);
+    const query = decodeString(location.search.substring(1));
     const vars = query.split('&');
 
     return vars.reduce((acc, item) => {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4285

**Problem:**
* Described in issue.

**In this PR:**
* Added string decoding and in case if it fail, then make it as usual. So it will try to decode and in most cases fail, but it will helpful for 3-rd tools.
