### PR TITLE
#4283 Made the cartItem option overflow auto instead of hidden

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.component.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.component.js
@@ -187,7 +187,9 @@ export class CartItem extends PureComponent {
             return (
                 <>
                     <strong>{ `${label}: ` }</strong>
+                    <span>
                     { values.map(({ label, value }) => label || value).join(', ') }
+                    </span>
                 </>
             );
         }

--- a/packages/scandipwa/src/component/CartItem/CartItem.style.scss
+++ b/packages/scandipwa/src/component/CartItem/CartItem.style.scss
@@ -97,7 +97,7 @@
     }
 
     &-Option {
-        overflow: auto;
+        overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
         line-height: 16px;
@@ -107,6 +107,12 @@
         &_isBundle {
             flex-direction: column;
             gap: 0;
+        }
+
+        span {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
     }
 

--- a/packages/scandipwa/src/component/CartItem/CartItem.style.scss
+++ b/packages/scandipwa/src/component/CartItem/CartItem.style.scss
@@ -97,7 +97,7 @@
     }
 
     &-Option {
-        overflow: hidden;
+        overflow: auto;
         text-overflow: ellipsis;
         white-space: nowrap;
         line-height: 16px;

--- a/packages/scandipwa/src/style/cms/block.scss
+++ b/packages/scandipwa/src/style/cms/block.scss
@@ -14,3 +14,4 @@
 @import './block/homepage-jeans-preview';
 @import './block/menu-promo-preview';
 @import './block/contacts-wrapper';
+


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4283

**Problem:**
* When uploading a file with a long name in the cart the name gets cropped at the end

**In this PR:**
* Made the cartItem option overflow auto instead of hidden so when the file name is long a scrollbar appears to the user
