### PR TITLE
#4295 added property margin-block-start to Quantity Control Buttons

### DIFF
--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
@@ -91,6 +91,7 @@
                 &_type {
                     &_number {
                         margin-inline-start: 16px;
+                        margin-block-start: 0px;
                     }
                 }
             }

--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
@@ -91,7 +91,7 @@
                 &_type {
                     &_number {
                         margin-inline-start: 16px;
-                        margin-block-start: 0px;
+                        margin-block-start: 0;
                     }
                 }
             }

--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
@@ -99,7 +99,7 @@
             [type="number"] {
                 & ~ button {
                     width: 44px;
-                    height: 44px;
+                    height: 48px;
                 }
             }
         }


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4295

**Problem:**
* Quantity control buttons for product option is shifted down for bundle product on PDP

**In this PR:**
* Added property margin-block-start to DropdownWrapper_customQuantity Field_type_number in ProductBundleOptions.style
* Modified the height of the Quantity Control Buttons to 48 instead of 44
