### PR TITLE
'discount each' for bundle product  is now written in normal font instead of bold.

### DIFF
--- a/packages/scandipwa/src/component/TierPrices/TierPrices.component.js
+++ b/packages/scandipwa/src/component/TierPrices/TierPrices.component.js
@@ -105,10 +105,13 @@ export class TierPrices extends PureComponent {
                 ) }
                 <strong>
                     { __(
-                        '%s% discount each',
+                        '%s% ',
                         Math.round(percentOff)
                     ) }
                 </strong>
+                { __(
+                    'discount each'
+                ) }
             </>
         );
     }

--- a/packages/scandipwa/src/component/TierPrices/TierPrices.component.js
+++ b/packages/scandipwa/src/component/TierPrices/TierPrices.component.js
@@ -104,14 +104,9 @@ export class TierPrices extends PureComponent {
                     quantity
                 ) }
                 <strong>
-                    { __(
-                        '%s% ',
-                        Math.round(percentOff)
-                    ) }
+                    { Math.round(percentOff) }
                 </strong>
-                { __(
-                    'discount each'
-                ) }
+                { __(' discount each') }
             </>
         );
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4304

**Problem:**
* 'discount each' is written by bold font for bundle product with tier price

**In this PR:**
* I removed bold font for 'discount each' for bundle products and now it is written in normal font.
