### PR TITLE
#3232 Modified the vertical alignment of table cells on CMS Pages

### DIFF
--- a/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
@@ -151,6 +151,22 @@ export class CmsPageContainer extends DataContainer {
         ) {
             this.requestPage();
         }
+
+        this.getTableImages();
+    }
+
+    getTableImages() {
+        const tableCells = Array.from(document.getElementsByTagName('td'));
+        const tableCellsContent = tableCells.map((element) => element.children);
+        const htmlElements = tableCellsContent.map((element) => element[0]);
+        const tableCellImages = htmlElements.filter((element) => element !== undefined && element.tagName === 'IMG');
+
+        tableCellImages.map(this.setHeightToAuto.bind(this));
+    }
+
+    setHeightToAuto(element) {
+        const tableImage = element;
+        tableImage.style.height = 'auto';
     }
 
     setOfflineNoticeSize() {

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
@@ -157,16 +157,29 @@ export class CmsPageContainer extends DataContainer {
 
     getTableImages() {
         const tableCells = Array.from(document.getElementsByTagName('td'));
+
+        if (tableCells === undefined || tableCells === null) {
+            return;
+        }
+
         const tableCellsContent = tableCells.map((element) => element.children);
         const htmlElements = tableCellsContent.map((element) => element[0]);
         const tableCellImages = htmlElements.filter((element) => element !== undefined && element.tagName === 'IMG');
 
-        tableCellImages.map(this.setHeightToAuto.bind(this));
+        tableCellImages.map((element) => this.setCellImageHeight(
+            element, element.clientHeight, element.clientWidth
+        ));
     }
 
-    setHeightToAuto(element) {
+    setCellImageHeight(element, clientHeight, clientWidth) {
         const tableImage = element;
+        const imageHeight = clientHeight;
+        const imageWidth = clientWidth;
         tableImage.style.height = 'auto';
+
+        if (imageHeight !== imageWidth) {
+            tableImage.style = `height: ${(tableImage.clientWidth) / 2}px; object-fit: contain`;
+        }
     }
 
     setOfflineNoticeSize() {

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
@@ -166,20 +166,12 @@ export class CmsPageContainer extends DataContainer {
         const htmlElements = tableCellsContent.map((element) => element[0]);
         const tableCellImages = htmlElements.filter((element) => element !== undefined && element.tagName === 'IMG');
 
-        tableCellImages.map((element) => this.setCellImageHeight(
-            element, element.clientHeight, element.clientWidth
-        ));
+        tableCellImages.map(this.setCellImageStyle.bind(this));
     }
 
-    setCellImageHeight(element, clientHeight, clientWidth) {
+    setCellImageStyle(element) {
         const tableImage = element;
-        const imageHeight = clientHeight;
-        const imageWidth = clientWidth;
-        tableImage.style.height = 'auto';
-
-        if (imageHeight !== imageWidth) {
-            tableImage.style = `height: ${(tableImage.clientWidth) / 2}px; object-fit: contain`;
-        }
+        tableImage.style = 'height: 100%; width: 100%; position: absolute; padding-block-end: 10px;';
     }
 
     setOfflineNoticeSize() {

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
@@ -23,7 +23,14 @@
             @include default-list;
 
             td {
-                vertical-align: middle;
+                vertical-align: top;
+
+                img {
+                    height: inherit;
+                    max-height: 100%;
+                    min-height: 100%;
+                    max-width: 100%;
+                }
             }
         }
 

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
@@ -26,9 +26,8 @@
                 vertical-align: top;
 
                 img {
-                    height: inherit;
                     max-height: 100%;
-                    min-height: 100%;
+                    min-height: 0;
                     max-width: 100%;
                 }
             }

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
@@ -28,6 +28,7 @@
                 img {
                     min-height: 0;
                     max-width: 100%;
+                    object-fit: contain;
                 }
             }
         }

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
@@ -21,6 +21,10 @@
     &-Content {
         .cms-content {
             @include default-list;
+
+            td {
+                vertical-align: middle;
+            }
         }
 
         h2 {
@@ -112,7 +116,7 @@
     .widget {
         overflow-x: auto;
     }
-    
+
     ul,
     ol {
         margin-inline-start: 20px;

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
@@ -26,7 +26,6 @@
                 vertical-align: top;
 
                 img {
-                    max-height: 100%;
                     min-height: 0;
                     max-width: 100%;
                 }

--- a/packages/scandipwa/src/style/base/_table.scss
+++ b/packages/scandipwa/src/style/base/_table.scss
@@ -19,6 +19,7 @@ table {
         border-radius: 2px;
     }
 
+
     tbody tr:not(:last-child) {
         border-block-end: var(--table-body-border) ;
     }

--- a/packages/scandipwa/src/style/base/_table.scss
+++ b/packages/scandipwa/src/style/base/_table.scss
@@ -19,7 +19,6 @@ table {
         border-radius: 2px;
     }
 
-
     tbody tr:not(:last-child) {
         border-block-end: var(--table-body-border) ;
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/3232

**Problem:**
* When adding an image to table cells on CMS page the vertical alignment of the neighboring cells gets broken
* When adding an image with specified width and height the image crosses to the neighboring cells in the table 

**In this PR:**
* Added td selector with vertical-align property in CmsPage.Style in route 
* Added Added img selector inside the td selector with properties of height, max-height, min-height, and max-width
