### PR TITLE
#4314 added property height to the selector FieldSelect-Clickable

### DIFF
--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -20,6 +20,7 @@ $select-arrow-width: 14px !default;
         cursor: pointer;
         display: flex;
         align-items: center;
+        height: 48px;
 
         #storeSwitcher,
         #CurrencySwitcherList {


### PR DESCRIPTION
**Related issue(s):**
* Fixes [scandipwa/scandipwa/issues/4314]

**Problem:**
* Height of dropdown fields is less than 48px

**In this PR:**
* Added property height to the selector FieldSelect-Clickable in FieldSelect.Style
