### PR TITLE
#3802 Added Html Component inside the function getCheckboxLabel

### DIFF
--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -296,7 +296,7 @@ export class ProductAttributeValue extends PureComponent {
               block="ProductAttributeValue"
               elem="Label"
             >
-                { value }
+                <Html content={ value } />
                 { this.renderSublabel(subLabel) }
             </div>
         );

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -329,7 +329,7 @@ export class ProductAttributeValue extends PureComponent {
         const isSwatch = label;
 
         if (isFormattedAsText) {
-            return label || value || __('N/A');
+            return label || <Html content={ value } /> || __('N/A');
         }
 
         if (!isSwatch) {

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -329,7 +329,7 @@ export class ProductAttributeValue extends PureComponent {
         const isSwatch = label;
 
         if (isFormattedAsText) {
-            return label || <Html content={ value } /> || __('N/A');
+            return label || <Html content={ `${value}` } /> || __('N/A');
         }
 
         if (!isSwatch) {

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -230,6 +230,13 @@
         }
     }
 
+    &-Label {
+        img {
+            height: 38px;
+            width: 38px;
+        }
+    }
+
     &-SubLabel {
         font-weight: bold;
         font-size: 12px;

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -145,7 +145,6 @@
     &-Text {
         display: flex;
         border: 0;
-        align-items: baseline;
         margin: 0;
 
         label,

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -232,8 +232,8 @@
 
     &-Label {
         img {
-            height: 32px;
             width: 32px;
+            object-fit: contain;
         }
     }
 

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -232,8 +232,8 @@
 
     &-Label {
         img {
-            height: 38px;
-            width: 38px;
+            height: 32px;
+            width: 32px;
         }
     }
 

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -232,7 +232,10 @@
 
     &-Label {
         img {
-            width: 32px;
+            width: auto;
+            height: auto;
+            max-width: 32px;
+            max-height: 32px;
             object-fit: contain;
             vertical-align: middle;
         }

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -234,6 +234,7 @@
         img {
             width: 32px;
             object-fit: contain;
+            vertical-align: middle;
         }
     }
 

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -247,5 +247,9 @@
         white-space: break-spaces;
         padding-inline-start: 4px;
     }
+
+    .Image-Content {
+        text-align: inherit;
+    }
 }
 

--- a/packages/scandipwa/src/component/ProductAttributes/ProductAttributes.style.scss
+++ b/packages/scandipwa/src/component/ProductAttributes/ProductAttributes.style.scss
@@ -83,6 +83,11 @@
         text-overflow: ellipsis;
         height: 100%;
 
+        img {
+            height: 32px;
+            width: 32px;
+        }
+
         @include mobile {
             line-height: 20px;
         }

--- a/packages/scandipwa/src/component/ProductAttributes/ProductAttributes.style.scss
+++ b/packages/scandipwa/src/component/ProductAttributes/ProductAttributes.style.scss
@@ -84,8 +84,11 @@
         height: 100%;
 
         img {
-            height: 32px;
-            width: 32px;
+            width: auto;
+            height: auto;
+            max-width: 32px;
+            max-height: 32px;
+            object-fit: contain;
         }
 
         @include mobile {

--- a/packages/scandipwa/src/component/ProductCompareAttributeRow/ProductCompareAttributeRow.component.js
+++ b/packages/scandipwa/src/component/ProductCompareAttributeRow/ProductCompareAttributeRow.component.js
@@ -52,7 +52,7 @@ export class ProductCompareAttributeRow extends PureComponent {
             device: { isMobile },
             values = []
         } = this.props;
-        const renderableValues = values.map(this.renderValue);
+        const renderableValues = values.map(this.renderValue.bind(this));
 
         if (!isMobile) {
             return renderableValues;

--- a/packages/scandipwa/src/component/ProductCompareAttributeRow/ProductCompareAttributeRow.style.scss
+++ b/packages/scandipwa/src/component/ProductCompareAttributeRow/ProductCompareAttributeRow.style.scss
@@ -55,11 +55,6 @@
         width: var(--product-compare-column-width);
         text-align: justify;
 
-        img {
-            height: 32px;
-            width: 32px;
-        }
-
         .span {
             text-align: inherit;
         }

--- a/packages/scandipwa/src/component/ProductCompareAttributeRow/ProductCompareAttributeRow.style.scss
+++ b/packages/scandipwa/src/component/ProductCompareAttributeRow/ProductCompareAttributeRow.style.scss
@@ -59,6 +59,14 @@
             text-align: inherit;
         }
 
+        img {
+            width: auto;
+            height: auto;
+            max-width: 32px;
+            max-height: 32px;
+            object-fit: contain;
+        }
+
         &:last-child {
             padding-inline-end: 0;
         }

--- a/packages/scandipwa/src/component/ProductCompareAttributeRow/ProductCompareAttributeRow.style.scss
+++ b/packages/scandipwa/src/component/ProductCompareAttributeRow/ProductCompareAttributeRow.style.scss
@@ -56,7 +56,12 @@
         text-align: justify;
 
         img {
-            height: auto;
+            height: 32px;
+            width: 32px;
+        }
+
+        .span {
+            text-align: inherit;
         }
 
         &:last-child {

--- a/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.component.js
+++ b/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.component.js
@@ -50,7 +50,7 @@ export class ResetAttributes extends PureComponent {
                 <div block="ResetAttributes" elem="AttributeText">
                     <span block="ResetAttributes" elem="AttributeLabel">{ `${attribute_label}: ` }</span>
                     <span block="ResetAttributes" elem="AttributeOption">
-                    <Html content={ selectedOption.label } />
+                    <Html content={ `${selectedOption.label}` } />
                     </span>
                 </div>
             </div>

--- a/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.component.js
+++ b/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.component.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import CloseIcon from 'Component/CloseIcon';
+import Html from 'Component/Html';
 import { getFiltersCount } from 'Util/Category';
 
 import './ResetAttributes.style';
@@ -48,7 +49,9 @@ export class ResetAttributes extends PureComponent {
                 </div>
                 <div block="ResetAttributes" elem="AttributeText">
                     <span block="ResetAttributes" elem="AttributeLabel">{ `${attribute_label}: ` }</span>
-                    <span block="ResetAttributes" elem="AttributeOption">{ `${selectedOption.label}` }</span>
+                    <span block="ResetAttributes" elem="AttributeOption">
+                    <Html content={ selectedOption.label } />
+                    </span>
                 </div>
             </div>
         );

--- a/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.style.scss
+++ b/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.style.scss
@@ -38,6 +38,7 @@
         img {
             width: 32px;
             object-fit: contain;
+            vertical-align: middle;
         }
     }
 

--- a/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.style.scss
+++ b/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.style.scss
@@ -36,7 +36,10 @@
 
     &-AttributeOption {
         img {
-            width: 32px;
+            width: auto;
+            height: auto;
+            max-width: 32px;
+            max-height: 32px;
             object-fit: contain;
             vertical-align: middle;
         }

--- a/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.style.scss
+++ b/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.style.scss
@@ -36,8 +36,8 @@
 
     &-AttributeOption {
         img {
-            height: 32px;
             width: 32px;
+            object-fit: contain;
         }
     }
 

--- a/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.style.scss
+++ b/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.style.scss
@@ -40,6 +40,10 @@
             object-fit: contain;
             vertical-align: middle;
         }
+
+        .Image-Content {
+            position: initial;
+        }
     }
 
     &-CloseIcon {

--- a/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.style.scss
+++ b/packages/scandipwa/src/component/ResetAttributes/ResetAttributes.style.scss
@@ -34,6 +34,13 @@
         font-weight: bold;
     }
 
+    &-AttributeOption {
+        img {
+            height: 32px;
+            width: 32px;
+        }
+    }
+
     &-CloseIcon {
         .CloseIcon {
             height: var(--checkbox-height);


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3802

**Problem:**
* Name of attributes of 'Images Type Map' shown in html format in Layered navigation on 40SKUDEMO

**In this PR:**
* Added a Html Component inside the function getCheckboxLabel in ProductAttributeValue.component
