### PR TITLE
#4315 added height property inside .ProductCustomizableItem-Wrapper Field_type_text input in ProductCustomizableOptions.Style

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -54,7 +54,7 @@
 
         &:hover {
             cursor: pointer;
-            
+
             @include desktop {
                 color: var(--primary-base-color);
             }

--- a/packages/scandipwa/src/component/NewsletterSubscription/NewsletterSubscription.style.scss
+++ b/packages/scandipwa/src/component/NewsletterSubscription/NewsletterSubscription.style.scss
@@ -36,7 +36,6 @@
                 input {
                     background-color: var(--newsletter-subscription-input-background);
                     padding: 14px 12px;
-                    height: 45px;
 
                     &::placeholder {
                         color: var(--newsletter-subscription-placeholder-color);

--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
@@ -39,6 +39,7 @@
                 &_text {
                     input {
                         width: 100%;
+                        height: 48px;
                     }
                 }
 

--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
@@ -39,7 +39,6 @@
                 &_text {
                     input {
                         width: 100%;
-                        height: 48px;
                     }
                 }
 

--- a/packages/scandipwa/src/style/base/_input.scss
+++ b/packages/scandipwa/src/style/base/_input.scss
@@ -51,6 +51,10 @@ select {
     }
 }
 
+input {
+    height: 48px;
+}
+
 textarea {
     width: 300px;
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4315

**Problem:**
* Height of text field is 44.6 px, same for any other text input fields, not only customizable options on PDP

**In this PR:**
* Added height property inside .ProductCustomizableItem-Wrapper Field_type_text input in ProductCustomizableOptions.Style
* Removed height property inside .ProductCustomizableItem-Wrappe .Field_type_text input in ProductCustomizableOptions.Style
* Removed height property inside .NewsletterSubscription .FieldForm-Fieldset .Field input in file NewsletterSubscription.style
* Added new input selector with height property in file _input.scss