### PR TITLE
[3972] modified the search query format

### DIFF
--- a/packages/scandipwa/src/component/SearchField/SearchField.component.js
+++ b/packages/scandipwa/src/component/SearchField/SearchField.component.js
@@ -77,8 +77,8 @@ export class SearchField extends PureComponent {
 
     onSearchEnterPress(e) {
         const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
-        const search = encodeURIComponent(searchCriteria.trim().replace(/%/g, '%25'));
         const trimmedSearch = searchCriteria.trim();
+        const search = encodeURIComponent(trimmedSearch.replace(/%/g, '%25'));
 
         if (e.key === 'Enter' && trimmedSearch !== '') {
             history.push(appendWithStoreCode(`/search/${ search }`));

--- a/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.container.js
+++ b/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.container.js
@@ -86,10 +86,9 @@ export class SearchOverlayContainer extends PureComponent {
 
         if (searchCriteria) {
             clearSearchResults();
-            const search = encodeURIComponent(searchCriteria.trim().replace(/%/g, '%25'));
             makeSearchRequest({
                 args: {
-                    search,
+                    search: searchCriteria,
                     pageSize: 24,
                     currentPage: 1
                 }

--- a/packages/scandipwa/src/query/ProductList.query.js
+++ b/packages/scandipwa/src/query/ProductList.query.js
@@ -13,6 +13,7 @@ import { SORT_DIRECTION_TYPE } from 'Route/CategoryPage/CategoryPage.config';
 import { NONE_SORT_OPTION_VALUE } from 'Route/SearchPage/SearchPage.config';
 import { CUSTOMER } from 'Store/MyAccount/MyAccount.dispatcher';
 import BrowserDatabase from 'Util/BrowserDatabase';
+import { formatSearch } from 'Util/Common';
 import { Field, Fragment } from 'Util/Query';
 
 /**
@@ -121,7 +122,7 @@ export class ProductListQuery {
             },
             search: {
                 type: 'String!',
-                handler: (option) => option.replace(/\+/g, ' ')
+                handler: (option) => formatSearch(option)
             },
             sort: {
                 type: 'ProductAttributeSortInput!',

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.config.js
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.config.js
@@ -12,7 +12,8 @@
 
 export const NONE_SORT_OPTION_VALUE = 'none';
 export const BEST_MATCH_SORT_OPTION_VALUE = 'position';
-
+export const SPECIAL_CHAR = /\W/g;
+export const BACKSLASH = '\\';
 export const NONE_SORT_OPTION = {
     label: __('None'),
     value: NONE_SORT_OPTION_VALUE

--- a/packages/scandipwa/src/util/Common/index.js
+++ b/packages/scandipwa/src/util/Common/index.js
@@ -10,6 +10,8 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+import { BACKSLASH, SPECIAL_CHAR } from 'Route/SearchPage/SearchPage.config';
+
 /**
  * No-operate function.
  * Can be used as a fallback if real function wasn't passed.
@@ -27,3 +29,6 @@ export const decodeString = (string) => {
         return string;
     }
 };
+
+/** @namespace Util/Common/Index/formatSearch */
+export const formatSearch = (search) => search.trim().replace(SPECIAL_CHAR, (special) => `${BACKSLASH}${ special}`);


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3972 

**Problem:**
* If searched word contains symbol & error is thrown.
Error fetching Product List Information!
Error fetching Product List!
Also searching just & is thrown, searching for / - 404 page, ? - 404 page.
* if sign / and ? goes first, 404 appear in console , but products shown - same for other special symbols
* if sign / goes in the middle of word, products not loaded 503 error in console - same for other special symbols

**In this PR:**
* Modified the string format before doing GRAPHQL Query.
* Created formatSearch function on Util/Common
* Function adds backslash to escape string for special characters in hex string
