### PR TITLE
#4328 added z-index to popup

### DIFF
--- a/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.style.scss
+++ b/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.style.scss
@@ -11,6 +11,7 @@
 
 .MyAccountAddressPopup {
     font-size: 12px;
+    z-index: 999;
 
     &-Address {
         margin: 12px 0;


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4328 

**Problem:**
* Popups in My account is cut by header: add new address, edit address etc

**In this PR:**
* Added z-index: 999 attribute to MyAccountAddress Popup
