### PR TITLE
#4329 Fix for the buttons in 40kSKU

### DIFF
--- a/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
+++ b/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
@@ -81,27 +81,7 @@
         height: max-content;
         min-height: 48px;
         flex-wrap: wrap;
-        padding-inline: 12px;
-        padding-block: 20px;
-        overflow-wrap: break-word;
-
-        @include desktop {
-            max-width: 20vw;
-            word-break: break-all;
-        }
-
-        @include mobile {
-            max-width: 80vw;
-        }
-    }
-
-    &-Button:not([disabled]):hover {
-        align-self: center;
-        height: max-content;
-        min-height: 48px;
-        flex-wrap: wrap;
-        padding-inline: 12px;
-        padding-block: 20px;
+        padding-block: 10px;
         overflow-wrap: break-word;
 
         @include desktop {

--- a/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
+++ b/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
@@ -77,11 +77,31 @@
     }
 
     &-Button {
+        align-self: center;
         height: max-content;
-        display: inline-block;
         min-height: 48px;
         flex-wrap: wrap;
-        padding-block: 10px;
+        padding-inline: 12px;
+        padding-block: 20px;
+        overflow-wrap: break-word;
+
+        @include desktop {
+            max-width: 20vw;
+            word-break: break-all;
+        }
+
+        @include mobile {
+            max-width: 80vw;
+        }
+    }
+
+    &-Button:not([disabled]):hover {
+        align-self: center;
+        height: max-content;
+        min-height: 48px;
+        flex-wrap: wrap;
+        padding-inline: 12px;
+        padding-block: 7px;
         overflow-wrap: break-word;
 
         @include desktop {

--- a/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
+++ b/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
@@ -101,7 +101,7 @@
         min-height: 48px;
         flex-wrap: wrap;
         padding-inline: 12px;
-        padding-block: 7px;
+        padding-block: 20px;
         overflow-wrap: break-word;
 
         @include desktop {

--- a/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
+++ b/packages/scandipwa/src/style/cms/block/homepage-category-preview.scss
@@ -76,12 +76,14 @@
         display: block;
     }
 
-    &-Button {
+    &-Button,
+    &-Button:not([disabled]):hover {
         align-self: center;
         height: max-content;
         min-height: 48px;
         flex-wrap: wrap;
         padding-block: 10px;
+        padding-inline: 20px;
         overflow-wrap: break-word;
 
         @include desktop {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4329

**Problem:**
* The Buttons weren't centralized
* Text inside the Buttons wasn't aligned correctly when hovering over the Buttons.

**In this PR:**
* Added Property align-self inside Button selector in file homepage-category-preview.scss
* Added Property padding-inline inside Button selector in file homepage-category-preview.scss
* Removed Property display-block from Button selector in file homepage-category-preview.scss
* Added Selector -Button:not([disabled]):hover in file homepage-category-preview.scss