### PR TITLE
Issue 4314

### DIFF
--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -44,6 +44,7 @@ $select-arrow-width: 14px !default;
         min-width: 100%;
         padding-inline-end: 40px;
         width: 100%;
+        height: 48px;
 
         @include desktop {
             pointer-events: none;

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -20,7 +20,6 @@ $select-arrow-width: 14px !default;
         cursor: pointer;
         display: flex;
         align-items: center;
-        height: 48px;
 
         #storeSwitcher,
         #CurrencySwitcherList {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4314

**Problem:**
* Height of dropdown fields is less than 48 px in the mobile view.

**In this PR:**
* Removed the height property from the Clickable Selector in the file FieldSelect.style
* Added the height property in the Select selector in the file FieldSelect.style
