### PR TITLE
Fixed Unavailable shipping methods is not grey color

### DIFF
--- a/packages/scandipwa/i18n/da_DK.json
+++ b/packages/scandipwa/i18n/da_DK.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/de_DE.json
+++ b/packages/scandipwa/i18n/de_DE.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/es_ES.json
+++ b/packages/scandipwa/i18n/es_ES.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/fa_IR.json
+++ b/packages/scandipwa/i18n/fa_IR.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/fi_FI.json
+++ b/packages/scandipwa/i18n/fi_FI.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/fr_FR.json
+++ b/packages/scandipwa/i18n/fr_FR.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/it_IT.json
+++ b/packages/scandipwa/i18n/it_IT.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/lv_LV.json
+++ b/packages/scandipwa/i18n/lv_LV.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/nb_NO.json
+++ b/packages/scandipwa/i18n/nb_NO.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/nl_NL.json
+++ b/packages/scandipwa/i18n/nl_NL.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/pl_PL.json
+++ b/packages/scandipwa/i18n/pl_PL.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/pt_BR.json
+++ b/packages/scandipwa/i18n/pt_BR.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/ru_RU.json
+++ b/packages/scandipwa/i18n/ru_RU.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/sl_SI.json
+++ b/packages/scandipwa/i18n/sl_SI.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/sv_SE.json
+++ b/packages/scandipwa/i18n/sv_SE.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/tr_TR.json
+++ b/packages/scandipwa/i18n/tr_TR.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/i18n/zh_TW.json
+++ b/packages/scandipwa/i18n/zh_TW.json
@@ -600,5 +600,6 @@
     "Field required\nMaximum %s characters.": null,
     "If there is an account associated with %s the provided address you will receive an email with a link to reset your password": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
-    "If there is an account associated with %s you will receive an email with a link to reset your password": null
+    "If there is an account associated with %s you will receive an email with a link to reset your password": null,
+    " discount each": null
 }

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
@@ -130,13 +130,14 @@ export class CheckoutDeliveryOption extends PureComponent {
     renderRow() {
         const {
             option: {
-                carrier_title
+                carrier_title,
+                available
             } = {}
         } = this.props;
 
         return (
             <div block="CheckoutDeliveryOption" elem="Row">
-                <span>
+                <span block="CheckoutDeliveryOption" elem="Span" mods={ { isDisabled: !available } }>
                     { __('Carrier method: ') }
                     <strong>{ carrier_title }</strong>
                 </span>

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
@@ -52,6 +52,16 @@
         }
     }
 
+    &-Span {
+        &_isDisabled {
+            color: var(--color-dark-gray);
+
+            strong {
+                color: var(--color-dark-gray);
+            }
+        }
+    }
+
     &:hover {
         &:not(.CheckoutDeliveryOption_isHoverExcluded) {
             .input-control {
@@ -76,6 +86,10 @@
     &-Row {
         strong {
             display: inline-block;
+        }
+
+        &_isDisabled {
+            color: green;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes  #4337 

**Problem:**
* Unavailable shipping methods are black and not grey color

**In this PR:**
* Unavailable shipping methods now appear in grey color
