### PR TITLE
[2665 4342] check if user is signed in and if email is available

### DIFF
--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -112,7 +112,8 @@ export class Checkout extends PureComponent {
         cartTotalSubPrice: PropTypes.number,
         onShippingMethodSelect: PropTypes.func.isRequired,
         onStoreSelect: PropTypes.func.isRequired,
-        selectedStoreAddress: StoreType
+        selectedStoreAddress: StoreType,
+        isSignedIn: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -221,9 +222,14 @@ export class Checkout extends PureComponent {
             onEmailChange,
             onCreateUserChange,
             onPasswordChange,
-            isGuestEmailSaved
+            isGuestEmailSaved,
+            isSignedIn
         } = this.props;
         const isBilling = checkoutStep === BILLING_STEP;
+
+        if (isSignedIn) {
+            return null;
+        }
 
         return (
             <CheckoutGuestForm

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -71,7 +71,8 @@ export const mapStateToProps = (state) => ({
     isMobile: state.ConfigReducer.device.isMobile,
     isInStoreActivated: state.ConfigReducer.delivery_instore_active,
     isGuestNotAllowDownloadable: state.ConfigReducer.downloadable_disable_guest_checkout,
-    savedEmail: state.CheckoutReducer.email
+    savedEmail: state.CheckoutReducer.email,
+    isSignedIn: state.MyAccountReducer.isSignedIn
 });
 
 /** @namespace Route/Checkout/Container/mapDispatchToProps */
@@ -146,7 +147,8 @@ export class CheckoutContainer extends PureComponent {
         isMobile: PropTypes.bool.isRequired,
         cartTotalSubPrice: PropTypes.number,
         isInStoreActivated: PropTypes.bool.isRequired,
-        isGuestNotAllowDownloadable: PropTypes.bool.isRequired
+        isGuestNotAllowDownloadable: PropTypes.bool.isRequired,
+        isSignedIn: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -224,6 +226,8 @@ export class CheckoutContainer extends PureComponent {
             }
         } = this.props;
 
+        const { email } = this.state;
+
         if (!items.length) {
             showInfoNotification(__('Please add at least one product to cart!'));
             history.push(appendWithStoreCode('/cart'));
@@ -237,6 +241,10 @@ export class CheckoutContainer extends PureComponent {
         // if guest is not allowed to checkout with downloadable => redirect to login page
         if (!isSignedIn() && isGuestNotAllowDownloadable) {
             this.handleRedirectIfDownloadableInCart();
+        }
+
+        if (email) {
+            this.checkEmailAvailability(email);
         }
 
         updateMeta({ title: __('Checkout') });
@@ -421,7 +429,8 @@ export class CheckoutContainer extends PureComponent {
             isMobile,
             setHeaderState,
             totals,
-            isInStoreActivated
+            isInStoreActivated,
+            isSignedIn
         } = this.props;
         const {
             billingAddress,
@@ -455,6 +464,7 @@ export class CheckoutContainer extends PureComponent {
             isEmailAvailable,
             isGuestEmailSaved,
             isInStoreActivated,
+            isSignedIn,
             isLoading,
             isMobile,
             orderID,


### PR DESCRIPTION
**Related issue(s):**
* Fixes #2665 
* Fixes #4342 

**Problem:**
* An empty email field stays after the user is Logged In on the shipping page with the product. The field disappears after a refresh of the page
* 'Create account' button is displayed on Thank you page if user completed the second order with registered email

**In this PR:**
* For issue #2665 CheckoutComponent conditionally renders create account buttons if user is signed in
* For issue #4342 CheckoutContainer componentDidMount() checks if email is available or not
