### PR TITLE
[4327] set loading cart to false when loading guest empty cart

### DIFF
--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
@@ -53,7 +53,7 @@ export class CartDispatcher {
             } = await fetchMutation(CartQuery.getCreateEmptyCartMutation());
 
             setGuestQuoteId(quoteId);
-            dispatch(updateIsLoadingCart(true));
+            dispatch(updateIsLoadingCart(false));
 
             return quoteId;
         } catch (error) {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4327 

**Problem:**
* Infinity loader if user goes to cart after logout

**In this PR:**
* Set loading state to false when loading Empty guest cart
