### PR TITLE
#4283 added a div selector  inside the selector Option with the properties overflow, text-overflow, and white-space

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.style.scss
+++ b/packages/scandipwa/src/component/CartItem/CartItem.style.scss
@@ -109,7 +109,8 @@
             gap: 0;
         }
 
-        span,div {
+        span,
+        div {
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;

--- a/packages/scandipwa/src/component/CartItem/CartItem.style.scss
+++ b/packages/scandipwa/src/component/CartItem/CartItem.style.scss
@@ -109,7 +109,7 @@
             gap: 0;
         }
 
-        span {
+        span,div {
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4283

**Problem:**
* When uploading a file with a long name in the cart the name gets cropped at the end

**In this PR:**
* Made the cartItem bundle options overflow appears as three dots
