### PR TITLE
Price/Nickname, Quality/Summary and Value/Review are on the same line in a  review popup

### DIFF
--- a/packages/scandipwa/src/component/ProductReviewForm/ProductReviewForm.style.scss
+++ b/packages/scandipwa/src/component/ProductReviewForm/ProductReviewForm.style.scss
@@ -45,6 +45,10 @@
     }
 
     &-Content {
+        .Field {
+            margin-block-start: 12px;
+        }
+
         input,
         textarea {
             font-size: 12px;


### PR DESCRIPTION

**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4325

**Problem:**
* Price/Nickname, Quality/Summary and Value/Review on different lines 

**In this PR:**
* Moved fields on the right side up so they are on the same line as left side fields
