### PR TITLE
[4338] initialized current address values, set input values to current values

### DIFF
--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
@@ -59,7 +59,7 @@ export class MyAccountAddressFormContainer extends PureComponent {
         isStateRequired: !!this.getCountry()?.is_state_required,
         currentCity: this.getCurrentAddress().city,
         currentRegion: this.getCurrentAddress().region,
-        currentZipcode: this.getCurrentAddress().zipCode,
+        currentZipcode: this.getCurrentAddress().postcode,
         currentRegionId: this.getCurrentAddress().regionId
     };
 
@@ -120,7 +120,7 @@ export class MyAccountAddressFormContainer extends PureComponent {
     getCurrentAddress() {
         const { address } = this.props;
 
-        if (!address.length) {
+        if (!address.id) {
             return {
                 region: '',
                 regionId: 1,
@@ -128,12 +128,12 @@ export class MyAccountAddressFormContainer extends PureComponent {
                 city: ''
             };
         }
-        const { region: { region, region_id: regionId = 1 }, zipCode, city } = address;
+        const { region: { region, region_id: regionId }, postcode, city } = address;
 
         return {
             region,
             regionId,
-            zipCode,
+            postcode,
             city
         };
     }

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
@@ -57,10 +57,10 @@ export class MyAccountAddressFormContainer extends PureComponent {
         countryId: this.getCountry()?.value || 'US',
         availableRegions: this.getAvailableRegions() || [],
         isStateRequired: !!this.getCountry()?.is_state_required,
-        currentCity: null,
-        currentRegion: null,
-        currentZipcode: null,
-        currentRegionId: null
+        currentCity: this.getCurrentAddress().city || null,
+        currentRegion: this.getCurrentAddress().region || null,
+        currentZipcode: this.getCurrentAddress().zipCode || null,
+        currentRegionId: this.getCurrentAddress().regionId || null
     };
 
     containerFunctions = {
@@ -117,6 +117,17 @@ export class MyAccountAddressFormContainer extends PureComponent {
         return countries.find(({ value }) => value === countryIdFixed);
     }
 
+    getCurrentAddress() {
+        const { address: { region: { region, region_id: regionId = 1 }, zipCode, city } } = this.props;
+
+        return {
+            region,
+            regionId,
+            zipCode,
+            city
+        };
+    }
+
     /**
      * Returns available regions based on country and zip
      * @param countryId
@@ -165,8 +176,13 @@ export class MyAccountAddressFormContainer extends PureComponent {
         } = country;
 
         this.getAvailableRegions(countryId, currentZipcode);
-
-        this.setState({ availableRegions, isStateRequired: isStateRequired || false, countryId });
+        this.setState({
+            availableRegions,
+            isStateRequired: isStateRequired || false,
+            countryId,
+            currentRegionId: 1,
+            currentRegion: ''
+        });
     }
 
     onZipcodeChange(event, field) {

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
@@ -117,9 +117,9 @@ export class MyAccountAddressFormContainer extends PureComponent {
     }
 
     getCurrentAddress() {
-        const { address } = this.props;
+        const { address, address: { id: addressId } } = this.props;
 
-        if (!address.id) {
+        if (!addressId) {
             return {
                 region: '',
                 regionId: 1,
@@ -127,6 +127,7 @@ export class MyAccountAddressFormContainer extends PureComponent {
                 city: ''
             };
         }
+
         const { region: { region, region_id: regionId }, postcode, city } = address;
 
         return {

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
@@ -178,7 +178,8 @@ export class MyAccountAddressFormContainer extends PureComponent {
             this.setState({
                 currentRegion: '',
                 currentRegionId: 1,
-                countryId: ''
+                countryId: '',
+                availableRegions: []
             });
 
             return;

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
@@ -113,7 +113,6 @@ export class MyAccountAddressFormContainer extends PureComponent {
     getCountry(countryId = null) {
         const { countries, defaultCountry, address: { country_id: countryIdAddress } = {} } = this.props;
         const countryIdFixed = countryId || countryIdAddress || defaultCountry;
-
         return countries.find(({ value }) => value === countryIdFixed);
     }
 
@@ -176,6 +175,12 @@ export class MyAccountAddressFormContainer extends PureComponent {
         const country = countries.find(({ value }) => value === fieldValue);
 
         if (!country) {
+            this.setState({
+                currentRegion: '',
+                currentRegionId: 1,
+                countryId: ''
+            });
+
             return;
         }
 

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
@@ -57,10 +57,10 @@ export class MyAccountAddressFormContainer extends PureComponent {
         countryId: this.getCountry()?.value || 'US',
         availableRegions: this.getAvailableRegions() || [],
         isStateRequired: !!this.getCountry()?.is_state_required,
-        currentCity: this.getCurrentAddress().city || null,
-        currentRegion: this.getCurrentAddress().region || null,
-        currentZipcode: this.getCurrentAddress().zipCode || null,
-        currentRegionId: this.getCurrentAddress().regionId || null
+        currentCity: this.getCurrentAddress().city,
+        currentRegion: this.getCurrentAddress().region,
+        currentZipcode: this.getCurrentAddress().zipCode,
+        currentRegionId: this.getCurrentAddress().regionId
     };
 
     containerFunctions = {
@@ -118,7 +118,17 @@ export class MyAccountAddressFormContainer extends PureComponent {
     }
 
     getCurrentAddress() {
-        const { address: { region: { region, region_id: regionId = 1 }, zipCode, city } } = this.props;
+        const { address } = this.props;
+
+        if (!address.length) {
+            return {
+                region: '',
+                regionId: 1,
+                zipCode: '',
+                city: ''
+            };
+        }
+        const { region: { region, region_id: regionId = 1 }, zipCode, city } = address;
 
         return {
             region,

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.form.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.form.js
@@ -72,7 +72,8 @@ export const getStreetFields = (props) => {
  */
 export const getRegionFields = (props, events) => {
     const {
-        region: { region_id: regionId = 1 } = {},
+        currentRegion,
+        currentRegionId,
         regionDisplayAll,
         availableRegions,
         isStateRequired
@@ -92,6 +93,7 @@ export const getRegionFields = (props, events) => {
                 attr: {
                     id: 'address-region-id',
                     name: 'region_string',
+                    value: currentRegion,
                     placeholder: __('Your state / province')
                 },
                 events: {
@@ -112,7 +114,7 @@ export const getRegionFields = (props, events) => {
             label: __('State / Province'),
             attr: {
                 name: 'region_id',
-                defaultValue: regionId,
+                value: currentRegionId,
                 selectPlaceholder: __('Select region...')
             },
             events: {

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.form.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.form.js
@@ -72,7 +72,7 @@ export const getStreetFields = (props) => {
  */
 export const getRegionFields = (props, events) => {
     const {
-        region: { region, region_id: regionId = 1 } = {},
+        region: { region_id: regionId = 1 } = {},
         regionDisplayAll,
         availableRegions,
         isStateRequired
@@ -92,7 +92,6 @@ export const getRegionFields = (props, events) => {
                 attr: {
                     id: 'address-region-id',
                     name: 'region_string',
-                    defaultValue: region,
                     placeholder: __('Your state / province')
                 },
                 events: {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4338

**Problem:**
* Name of state saved for field without dropdown when user selected other country

**In this PR:**
* initialized current address values, set input values to current values

**Related PR(s):**
* #4359 
