### PR TITLE
issue - 4376 - Handle listen for broadcast not for all datacontainers

### DIFF
--- a/packages/scandipwa/src/component/CmsBlock/CmsBlock.container.js
+++ b/packages/scandipwa/src/component/CmsBlock/CmsBlock.container.js
@@ -25,8 +25,8 @@ export class CmsBlockContainer extends DataContainer {
         cmsBlock: {}
     };
 
-    __construct() {
-        super.__construct('CmsBlockContainer');
+    __construct(props) {
+        super.__construct(props, 'CmsBlockContainer');
     }
 
     containerProps() {

--- a/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.container.js
+++ b/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.container.js
@@ -44,8 +44,8 @@ export class CurrencySwitcherContainer extends DataContainer {
         handleCurrencySelect: this._handleCurrencySelect.bind(this)
     };
 
-    __construct() {
-        super.__construct('CurrencySwitcherContainer');
+    __construct(props) {
+        super.__construct(props, 'CurrencySwitcherContainer');
     }
 
     _handleCurrencySelect(currencyCode) {

--- a/packages/scandipwa/src/component/Menu/Menu.container.js
+++ b/packages/scandipwa/src/component/Menu/Menu.container.js
@@ -40,8 +40,8 @@ export class MenuContainer extends DataContainer {
         onCategoryHover: this.onCategoryHover.bind(this)
     };
 
-    __construct() {
-        super.__construct('MenuContainer');
+    __construct(props) {
+        super.__construct(props, 'MenuContainer');
 
         const {
             stack: activeMenuItemsStack = []

--- a/packages/scandipwa/src/component/ProductListWidget/ProductListWidget.container.js
+++ b/packages/scandipwa/src/component/ProductListWidget/ProductListWidget.container.js
@@ -58,6 +58,10 @@ export class ProductListWidgetContainer extends DataContainer {
         getIsNewCategory: this.getIsNewCategory.bind(this)
     };
 
+    __construct(props) {
+        super.__construct(props, 'ProductListWidgetContainer', false);
+    }
+
     containerProps() {
         const {
             currentPage,

--- a/packages/scandipwa/src/component/SliderWidget/SliderWidget.container.js
+++ b/packages/scandipwa/src/component/SliderWidget/SliderWidget.container.js
@@ -42,8 +42,8 @@ export class SliderWidgetContainer extends DataContainer {
         }
     };
 
-    __construct() {
-        super.__construct('SliderWidgetContainer');
+    __construct(props) {
+        super.__construct(props, 'SliderWidgetContainer', false);
     }
 
     componentDidMount() {

--- a/packages/scandipwa/src/component/StoreSwitcher/StoreSwitcher.container.js
+++ b/packages/scandipwa/src/component/StoreSwitcher/StoreSwitcher.container.js
@@ -54,8 +54,8 @@ export class StoreSwitcherContainer extends DataContainer {
         onStoreSwitcherOutsideClick: this.onStoreSwitcherOutsideClick.bind(this)
     };
 
-    __construct() {
-        super.__construct('StoreSwitcherContainer');
+    __construct(props) {
+        super.__construct(props, 'StoreSwitcherContainer');
     }
 
     componentDidMount() {

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.container.js
@@ -85,8 +85,8 @@ export class CmsPageContainer extends DataContainer {
 
     setOfflineNoticeSize = this.setOfflineNoticeSize.bind(this);
 
-    __construct() {
-        super.__construct('CmsPageContainer');
+    __construct(props) {
+        super.__construct(props, 'CmsPageContainer');
 
         this.updateBreadcrumbs();
     }

--- a/packages/scandipwa/src/route/ContactPage/ContactPage.container.js
+++ b/packages/scandipwa/src/route/ContactPage/ContactPage.container.js
@@ -57,8 +57,8 @@ export class ContactPageContainer extends DataContainer {
         isEnabled: false
     };
 
-    __construct() {
-        super.__construct('ContactPageContainer');
+    __construct(props) {
+        super.__construct(props, 'ContactPageContainer');
 
         this.updateBreadcrumbs();
     }

--- a/packages/scandipwa/src/route/ProductComparePage/ProductComparePage.container.js
+++ b/packages/scandipwa/src/route/ProductComparePage/ProductComparePage.container.js
@@ -57,8 +57,8 @@ export class ProductComparePageContainer extends DataContainer {
         isLoading: false
     };
 
-    __construct() {
-        super.__construct('ProductComparePageContainer');
+    __construct(props) {
+        super.__construct(props, 'ProductComparePageContainer');
     }
 
     componentDidMount() {

--- a/packages/scandipwa/src/util/Request/DataContainer.js
+++ b/packages/scandipwa/src/util/Request/DataContainer.js
@@ -21,9 +21,10 @@ import { ONE_MONTH_IN_SECONDS } from './QueryDispatcher';
 
 /** @namespace Util/Request/DataContainer */
 export class DataContainer extends PureComponent {
-    __construct(dataModelName, cacheTTL = ONE_MONTH_IN_SECONDS) {
-        super.__construct();
+    __construct(props, dataModelName, isShouldListenForBroadcast = true, cacheTTL = ONE_MONTH_IN_SECONDS) {
+        super.__construct(props);
         this.dataModelName = dataModelName;
+        this.isShouldListenForBroadcast = isShouldListenForBroadcast;
         this.cacheTTL = cacheTTL;
         this.promise = null;
     }
@@ -63,10 +64,12 @@ export class DataContainer extends PureComponent {
             (err) => onError(err)
         );
 
-        listenForBroadCast(this.dataModelName).then(
-            /** @namespace Util/Request/DataContainer/DataContainer/fetchData/listenForBroadCast/then/onSuccess */
-            onSuccess
-        );
+        if (this.isShouldListenForBroadcast) {
+            listenForBroadCast(this.dataModelName).then(
+                /** @namespace Util/Request/DataContainer/DataContainer/fetchData/listenForBroadCast/then/onSuccess */
+                onSuccess
+            );
+        }
     }
 }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4376 

**Problem:**
* Updates not only 1 widget, but all with same type of datacontainername

**In this PR:**
* Handle listen for broadcast not for all datacontainers
