### PR TITLE
fixed bold line under currency and store switcher

### DIFF
--- a/packages/scandipwa/i18n/da_DK.json
+++ b/packages/scandipwa/i18n/da_DK.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/de_DE.json
+++ b/packages/scandipwa/i18n/de_DE.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/es_ES.json
+++ b/packages/scandipwa/i18n/es_ES.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/fa_IR.json
+++ b/packages/scandipwa/i18n/fa_IR.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/fi_FI.json
+++ b/packages/scandipwa/i18n/fi_FI.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/fr_FR.json
+++ b/packages/scandipwa/i18n/fr_FR.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/it_IT.json
+++ b/packages/scandipwa/i18n/it_IT.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/lv_LV.json
+++ b/packages/scandipwa/i18n/lv_LV.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/nb_NO.json
+++ b/packages/scandipwa/i18n/nb_NO.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/nl_NL.json
+++ b/packages/scandipwa/i18n/nl_NL.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/pl_PL.json
+++ b/packages/scandipwa/i18n/pl_PL.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/pt_BR.json
+++ b/packages/scandipwa/i18n/pt_BR.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/ru_RU.json
+++ b/packages/scandipwa/i18n/ru_RU.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/sl_SI.json
+++ b/packages/scandipwa/i18n/sl_SI.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/sv_SE.json
+++ b/packages/scandipwa/i18n/sv_SE.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/tr_TR.json
+++ b/packages/scandipwa/i18n/tr_TR.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/i18n/zh_TW.json
+++ b/packages/scandipwa/i18n/zh_TW.json
@@ -587,5 +587,6 @@
     "%s% discount each": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password.": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
-    " discount each": null
+    " discount each": null,
+    "Sort by": null
 }

--- a/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.style.scss
+++ b/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.style.scss
@@ -16,6 +16,7 @@
 
     @include mobile {
         margin: 0 16px;
+        padding-block-end: 1px;
     }
 
     .Field {
@@ -39,10 +40,6 @@
                 opacity: 1;
                 padding-inline-start: 0;
                 line-height: 23px;
-
-                @include mobile {
-                    padding-block-end: 12px;
-                }
             }
 
             &::after {

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -25,10 +25,6 @@ $select-arrow-width: 14px !default;
         #CurrencySwitcherList {
             line-height: 20px;
         }
-
-        @include mobile {
-            border-block-end: 1px solid var(--primary-divider-color);
-        }
     }
 
     .ChevronIcon {

--- a/packages/scandipwa/src/component/StoreSwitcher/StoreSwitcher.style.scss
+++ b/packages/scandipwa/src/component/StoreSwitcher/StoreSwitcher.style.scss
@@ -23,6 +23,7 @@
 
     @include mobile {
         margin: 0 16px;
+        padding-block-end: 1px;
     }
 
     .Field {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4350 

**Problem:**
* Lines between currency and store switchers, store switcher and compare list are bold

**In this PR:**
* Fixed the bold lines
