### PR TITLE
#4092 - Change symbols in timestamp for IOs

### DIFF
--- a/packages/scandipwa/src/component/MyAccountOrderItemsTable/MyAccountOrderItemsTable.component.js
+++ b/packages/scandipwa/src/component/MyAccountOrderItemsTable/MyAccountOrderItemsTable.component.js
@@ -183,7 +183,9 @@ export class MyAccountOrderItemsTable extends PureComponent {
         }
 
         const commentOrder = comments.sort(
-            ({ timestamp: first }, { timestamp: second }) => new Date(second) - new Date(first)
+            ({ timestamp: first }, { timestamp: second }) => (
+                new Date(second.replace(/-/g, '/')) - new Date(first.replace(/-/g, '/'))
+            )
         );
 
         return (


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4092

**Problem:**
* Wrong comments order on IOS

**In this PR:**
* Change symbols in timestamp for right comments order on IOs