### PR TITLE
Accont icon shifted right in checkout page

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -383,6 +383,10 @@
 
     &_isCheckout {
         .Header {
+            &-IconsWrapper {
+                width: 1335px;
+            }
+
             &-Button_type_account {
                 display: block;
             }
@@ -396,7 +400,7 @@
 
             &-MyAccount {
                 @include desktop {
-                    margin-inline-start: auto;
+                    // margin-inline-start: auto;
                     height: 24px;
                 }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4294

**Problem:**
* Account icon was shifted left on checkout page

**In this PR:**
* Account icon is now shifted right
