### PR TITLE
fixed text overflowing on second line on small devices

### DIFF
--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
@@ -133,7 +133,9 @@ export class CheckoutBilling extends PureComponent {
                       } }
                       mix={ { block: 'CheckoutBilling', elem: 'TermsAndConditions-Checkbox' } }
                     />
-                    { `${checkbox_text } - ` }
+                    <span mix={ { block: 'CheckoutBilling', elem: 'TermsAndConditions-Text' } }>
+                     { `${checkbox_text } ` }
+                    </span>
                 </label>
                 <button
                   block="CheckoutBilling"

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
@@ -35,7 +35,6 @@
         align-items: center;
 
         @include mobile {
-            font-size: 15px;
             margin-block-end: 28px;
         }
 

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
@@ -53,7 +53,7 @@
                 position: absolute;
                 inset-block-start: 50%;
                 transform: translateY(-50%);
-                inset-inline-start: calc(100% + 0.5rem);
+                inset-inline-start: calc(100% + 1rem);
             }
         }
     }
@@ -61,7 +61,7 @@
     &-TACLabel {
         display: flex;
         align-items: center;
-        margin-inline-end: 0.5em;
+        margin-inline-end: 5px;
 
         &:hover {
             cursor: pointer;
@@ -70,15 +70,20 @@
                 color: var(--primary-base-color);
             }
         }
+
+        @include mobile {
+            width: clamp(150px, 50vw, 250px);
+        }
     }
 
     &-TACLink {
         font-size: 14px;
         font-weight: 700;
         color: var(--link-color);
-        margin-inline-start: 0.5em;
         display: flex;
         cursor: pointer;
+        white-space: nowrap;
+        margin-inline-start: 2rem;
 
         &:hover {
             text-decoration: underline;

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
@@ -33,8 +33,10 @@
         margin-block-end: 24px;
         display: flex;
         align-items: center;
+        white-space: nowrap;
 
         @include mobile {
+            font-size: 15px;
             margin-block-end: 28px;
         }
 

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
@@ -33,7 +33,6 @@
         margin-block-end: 24px;
         display: flex;
         align-items: center;
-        white-space: nowrap;
 
         @include mobile {
             font-size: 15px;
@@ -47,11 +46,22 @@
                 margin-inline-end: 2px;
             }
         }
+
+        &-Text {
+            &::after {
+                content: '-';
+                position: absolute;
+                inset-block-start: 50%;
+                transform: translateY(-50%);
+                inset-inline-start: calc(100% + 0.5rem);
+            }
+        }
     }
 
     &-TACLabel {
         display: flex;
         align-items: center;
+        margin-inline-end: 0.5em;
 
         &:hover {
             cursor: pointer;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4261

**Problem:**
* The problem was that when going on small devices, terms and conditions text were stretching on two lines. instead of doing text-wrap: no wrap, decreased font size a bit so that it looks better

**In this PR:**
* changed font size by 1px .
