### PR TITLE
fixed padding bottom issue in older firefox and older edge

### DIFF
--- a/packages/scandipwa/src/component/Popup/Popup.style.scss
+++ b/packages/scandipwa/src/component/Popup/Popup.style.scss
@@ -71,11 +71,17 @@
     &-Content {
         background-color: var(--popup-content-background);
         border-radius: 5px;
-        padding: var(--popup-content-padding);
+        padding: var(--popup-content-padding) var(--popup-content-padding) 0 var(--popup-content-padding);
         min-width: var(--popup-min-width);
         max-width: calc(var(--content-wrapper-width) * .8);
         max-height: var(--popup-max-height);
         overflow-y: auto;
+
+        &::after {
+            content: '';
+            display: block;
+            padding-block-end: var(--popup-content-padding);
+        }
 
         @include mobile {
             border-radius: 0;

--- a/packages/scandipwa/src/component/Popup/Popup.style.scss
+++ b/packages/scandipwa/src/component/Popup/Popup.style.scss
@@ -71,7 +71,8 @@
     &-Content {
         background-color: var(--popup-content-background);
         border-radius: 5px;
-        padding: var(--popup-content-padding) var(--popup-content-padding) 0 var(--popup-content-padding);
+        padding: var(--popup-content-padding);
+        padding-block-end: 0;
         min-width: var(--popup-min-width);
         max-width: calc(var(--content-wrapper-width) * .8);
         max-height: var(--popup-max-height);


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/1657

**Problem:**
* For older firefox and edge browsers, padding-bottom wasn't showing. According to this - https://stackoverflow.com/questions/48687129/padding-bottom-not-working-in-firefox-ie11 , I did use pseudo element to make it work.

**In this PR:**
* instead of, set padding on every side, but the bottom. then, in pseudo element, set padding-bottom
