### PR TITLE
[4244] removed maxheight on FieldSelect-option

### DIFF
--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.component.js
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.component.js
@@ -36,7 +36,6 @@ export class FieldSelect extends PureComponent {
         handleSelectExpand: PropTypes.func.isRequired,
         isDisabled: PropTypes.bool.isRequired,
         isDropdownOpenUpwards: PropTypes.bool.isRequired,
-        isScrollable: PropTypes.bool.isRequired,
         isSortSelect: PropTypes.bool.isRequired
     };
 
@@ -140,8 +139,7 @@ export class FieldSelect extends PureComponent {
         const {
             options,
             isExpanded,
-            isDropdownOpenUpwards,
-            isScrollable
+            isDropdownOpenUpwards
         } = this.props;
 
         return (
@@ -151,8 +149,7 @@ export class FieldSelect extends PureComponent {
               role="menu"
               mods={ {
                   isExpanded,
-                  isDropdownOpenUpwards,
-                  isNotScrollable: !isScrollable
+                  isDropdownOpenUpwards
               } }
             >
                 { options.map(this.renderOption.bind(this)) }

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.container.js
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.container.js
@@ -20,7 +20,7 @@ import {
 } from 'Type/Field.type';
 
 import FieldSelect from './FieldSelect.component';
-import { DROPDOWN_MIN_HEIGHT, DROPDOWN_SCROLL_MIN_ITEMS } from './FieldSelect.config';
+import { DROPDOWN_MIN_HEIGHT } from './FieldSelect.config';
 
 /**
  * Field Select
@@ -49,8 +49,7 @@ export class FieldSelectContainer extends PureComponent {
         valueIndex: -1,
         searchString: '',
         isExpanded: false,
-        isDropdownOpenUpwards: false,
-        isScrollable: false
+        isDropdownOpenUpwards: false
     };
 
     containerFunctions = {
@@ -59,7 +58,6 @@ export class FieldSelectContainer extends PureComponent {
         handleSelectListOptionClick: this.handleSelectListOptionClick.bind(this),
         handleSelectListKeyPress: this.handleSelectListKeyPress.bind(this),
         setRef: this.setRef.bind(this),
-        handleIsScrollableList: this.handleIsScrollableList.bind(this),
         handleDropdownOpenDirection: this.handleDropdownOpenDirection.bind(this)
     };
 
@@ -70,10 +68,6 @@ export class FieldSelectContainer extends PureComponent {
         const { isExpanded: stateIsExpanded } = state;
 
         return { isExpanded: isExpanded || stateIsExpanded };
-    }
-
-    componentDidMount() {
-        this.handleIsScrollableList();
     }
 
     setRef(elem) {
@@ -261,16 +255,6 @@ export class FieldSelectContainer extends PureComponent {
         }
     }
 
-    handleIsScrollableList() {
-        const options = this.getOptions();
-
-        if (options.length > DROPDOWN_SCROLL_MIN_ITEMS) {
-            this.setState({ isScrollable: true });
-        } else {
-            this.setState({ isScrollable: false });
-        }
-    }
-
     containerProps() {
         const {
             attr: {
@@ -286,7 +270,7 @@ export class FieldSelectContainer extends PureComponent {
             isSortSelect
         } = this.props;
 
-        const { isExpanded, isDropdownOpenUpwards, isScrollable } = this.state;
+        const { isExpanded, isDropdownOpenUpwards } = this.state;
 
         return {
             attr: {
@@ -298,7 +282,6 @@ export class FieldSelectContainer extends PureComponent {
             isDisabled,
             isExpanded,
             isDropdownOpenUpwards,
-            isScrollable,
             isSortSelect,
             options: this.getOptions()
         };

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -62,6 +62,8 @@ $select-arrow-width: 14px !default;
 
     &-Options {
         position: absolute;
+        display: flex;
+        flex-flow: column nowrap;
         width: 100%;
         inset-block-start: 100%;
         inset-inline-start: 0;
@@ -71,8 +73,10 @@ $select-arrow-width: 14px !default;
         border-width: 0 1px 1px;
         border-color: transparent;
         transition: 200ms max-height;
-        will-change: max-height;
+        transition: 250ms opacity;
+        will-change: max-height opacity;
         max-height: 0;
+        opacity: 0;
         -webkit-overflow-scrolling: touch;
         min-width: 100%;
 
@@ -81,6 +85,7 @@ $select-arrow-width: 14px !default;
                 z-index: 15;
                 max-height: 200px;
                 border-color: var(--input-border-color);
+                opacity: 100;
                 background-color: #{$white};
             }
         }
@@ -89,23 +94,6 @@ $select-arrow-width: 14px !default;
             inset-block-start: auto;
             inset-block-end: 100%;
             border-width: 1px 1px 0;
-        }
-
-        &_isNotScrollable {
-            overflow-y: hidden;
-            // Firefox support
-            /* stylelint-disable-next-line declaration-no-important */
-            scrollbar-width: none !important;
-            /* stylelint-disable-next-line declaration-no-important */
-            scrollbar-color: none !important;
-        
-            &::-webkit-scrollbar {
-                display: none;
-            }
-
-            &::-webkit-scrollbar-thumb {
-                display: none;
-            }
         }
     }
 
@@ -116,7 +104,6 @@ $select-arrow-width: 14px !default;
         z-index: 1;
         transition: 100ms max-height ease-in;
         will-change: max-height;
-        max-height: $select-option-height;
         line-height: 36px;
         padding-inline-start: 18px;
         background: var(--color-white);


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4244 

**Problem:**
* If child product has long name in dropdown, then it is not moved to second line

**In this PR:**
* removed maxheight for FieldSelect-option
* removed logic to set isScrollable since it was useless (now is handled with css)
