### PR TITLE
[4365] set name to lowercase and then capitalize with css

### DIFF
--- a/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.component.js
+++ b/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.component.js
@@ -59,7 +59,7 @@ export class Breadcrumb extends PureComponent {
         } = this.props;
 
         const url = this.getLinkUrl() || {};
-
+        const lowercaseName = name.toLowerCase();
         return (
             <Link
               block="Breadcrumb"
@@ -68,8 +68,8 @@ export class Breadcrumb extends PureComponent {
               tabIndex={ isDisabled ? '-1' : '0' }
             >
                 <meta itemProp="item" content={ window.location.origin + url.pathname } />
-                <span itemProp="name">
-                    <TextPlaceholder content={ name } />
+                <span block="Breadcrumb" elem="Link-Name" itemProp="name">
+                    <TextPlaceholder content={ lowercaseName } />
                 </span>
                 <ChevronIcon />
                 <meta itemProp="position" content={ index } />

--- a/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.style.scss
+++ b/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.style.scss
@@ -45,7 +45,6 @@
     }
 
     &-Link {
-        text-transform: capitalize;
         color: var(--breadcrumbs-color);
         display: inline-block;
         font-weight: 400;
@@ -55,7 +54,8 @@
             color: var(--link-color);
         }
 
-        span {
+        &-Name {
+            text-transform: capitalize;
             color: inherit;
         }
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4365

**Problem:**
* One of letters is written as capital letter in the middle of word in breadcrumbs in my account and compare list

**In this PR:**
* Set name to lowercase and then capitalize with css
