### PR TITLE
[4228] moved rendercms function below renderTotals fn

### DIFF
--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -332,8 +332,8 @@ export class CheckoutOrderSummary extends PureComponent {
               mix={ { block: 'CheckoutOrderSummary', elem: 'ExpandableContent' } }
             >
                 { this.renderItems() }
-                { this.renderCmsBlock() }
                 { this.renderTotals() }
+                { this.renderCmsBlock() }
             </ExpandableContent>
         );
     }

--- a/packages/scandipwa/src/route/CartPage/CartPage.style.scss
+++ b/packages/scandipwa/src/route/CartPage/CartPage.style.scss
@@ -100,6 +100,10 @@
             margin-block-start: 24px;
         }
 
+        @include mobile {
+            padding: 10px 0;
+        }
+
         &Block {
             display: flex;
             align-items: center;


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4228 

**Problem:**
* Mobile: CMS block is displayed between products and price on checkout

**In this PR:**
* Moved renderCms() below renderTotals() on CategorySummaryComponent