### PR TITLE
[4247] update navigation state on share wishlist

### DIFF
--- a/packages/scandipwa/src/component/ShareWishlistPopup/ShareWishlistPopup.container.js
+++ b/packages/scandipwa/src/component/ShareWishlistPopup/ShareWishlistPopup.container.js
@@ -14,6 +14,8 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import WishlistQuery from 'Query/Wishlist.query';
+import { goToPreviousNavigationState } from 'Store/Navigation/Navigation.action';
+import { TOP_NAVIGATION_TYPE } from 'Store/Navigation/Navigation.reducer';
 import { showNotification } from 'Store/Notification/Notification.action';
 import { showPopup } from 'Store/Popup/Popup.action';
 import { isSignedIn } from 'Util/Auth';
@@ -25,7 +27,8 @@ import ShareWishlistPopup from './ShareWishlistPopup.component';
 export const mapDispatchToProps = (dispatch) => ({
     showNotification: (message) => dispatch(showNotification('success', message)),
     showError: (message) => dispatch(showNotification('error', message)),
-    hidePopup: () => dispatch(showPopup('', {}))
+    hidePopup: () => dispatch(showPopup('', {})),
+    goToPreviousNavigationState: () => dispatch(goToPreviousNavigationState(TOP_NAVIGATION_TYPE))
 });
 
 /** @namespace Component/ShareWishlistPopup/Container/mapStateToProps */
@@ -36,7 +39,8 @@ export class ShareWishlistPopupContainer extends PureComponent {
     static propTypes = {
         showError: PropTypes.func.isRequired,
         hidePopup: PropTypes.func.isRequired,
-        showNotification: PropTypes.func.isRequired
+        showNotification: PropTypes.func.isRequired,
+        goToPreviousNavigationState: PropTypes.func.isRequired
     };
 
     containerFunctions = {
@@ -44,7 +48,9 @@ export class ShareWishlistPopupContainer extends PureComponent {
     };
 
     handleFormData(fields) {
-        const { hidePopup, showError, showNotification } = this.props;
+        const {
+            hidePopup, showError, showNotification, goToPreviousNavigationState
+        } = this.props;
         const { message, emails: initialEmails } = fields;
         const emails = initialEmails.split(',').map((email) => email.trim());
 
@@ -57,6 +63,7 @@ export class ShareWishlistPopupContainer extends PureComponent {
             () => {
                 showNotification(__('Wishlist has been shared'));
                 hidePopup();
+                goToPreviousNavigationState();
             },
             /** @namespace Component/ShareWishlistPopup/Container/ShareWishlistPopupContainer/handleFormData/fetchMutation/then/showError/catch */
             (error) => showError(getErrorMessage(error))


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4247 

**Problem:**
* Mobile: Title 'Share Wishlist' stays in wishlist after sharing wishlist

**In this PR:**
* Update navigation state on share wishlist
