### PR TITLE
fixed close button spacing

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
@@ -182,13 +182,24 @@ export class WishlistItem extends PureComponent {
     }
 
     renderRemove() {
-        const { removeItem } = this.props;
+        const { removeItem, product: { rating_summary, wishlist: { options } } } = this.props;
+
+        const isOnlyNameShown = options.length === 0 && rating_summary === 0;
+        const isOptionsAndNameShown = options.length > 0;
+        const isOnlyRatingAndNameShown = rating_summary > 0;
+        const isAllShown = !isOnlyNameShown;
 
         return (
             <button
               block="WishlistItem"
               elem="Remove"
               onClick={ removeItem }
+              mods={ {
+                  isOnlyNameShown,
+                  isOptionsAndNameShown,
+                  isOnlyRatingAndNameShown,
+                  isAllShown
+              } }
               aria-label={ __('Remove') }
             >
                 <CloseIcon />

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -154,10 +154,10 @@
         }
     }
 
-    &-Remove[aria-label='Remove'] {
+    &-Remove {
         position: absolute;
         inset-inline-end: 4px;
-        inset-block-start: 4px;
+        inset-block-start: 5px;
 
         .CloseIcon {
             height: 30px;
@@ -165,9 +165,23 @@
         }
 
         @include mobile {
-            inset-block-start: -4px;
             inset-inline-end: -4px;
-            margin-block-start: -4px;
+
+            &_isOnlyNameShown {
+                inset-block-start: -4px;
+            }
+    
+            &_isOptionsAndNameShown {
+                inset-block-start: 2px;
+            }
+    
+            &_isOnlyRatingAndNameShown {
+                inset-block-start: 4px;
+            }
+    
+            &_isAllShown {
+                inset-block-start: 12px;
+            }
 
             .CloseIcon {
                 width: 24px;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4069

**Problem:**
* close button that was position absolutely, didn't have right spacing and wasn't appearing in the middle.

**In this PR:**
* Created modifiers to align it correctly according if only name, name and options, name and rating or name+options+rating is shown.
