### PR TITLE
[4233] added function to extract quantities if items are in stock

### DIFF
--- a/packages/scandipwa/src/component/Product/Product.container.js
+++ b/packages/scandipwa/src/component/Product/Product.container.js
@@ -24,6 +24,7 @@ import getFieldsData from 'Util/Form/Extract';
 import { ADD_TO_CART, getNewParameters, getVariantIndex } from 'Util/Product';
 import {
     getAdjustedPrice,
+    getGroupedProductsInStockQuantity,
     getMaxQuantity,
     getMinQuantity,
     getName,
@@ -32,8 +33,6 @@ import {
 } from 'Util/Product/Extract';
 import { magentoProductTransform, transformParameters } from 'Util/Product/Transform';
 import { validateGroup } from 'Util/Validator';
-
-import { getGroupedProductsInStockQuantity } from '../../util/Product/Extract';
 
 export const CartDispatcher = import(
     /* webpackMode: "lazy", webpackChunkName: "dispatchers" */

--- a/packages/scandipwa/src/component/Product/Product.container.js
+++ b/packages/scandipwa/src/component/Product/Product.container.js
@@ -33,6 +33,8 @@ import {
 import { magentoProductTransform, transformParameters } from 'Util/Product/Transform';
 import { validateGroup } from 'Util/Validator';
 
+import { getGroupedProductsInStockQuantity } from '../../util/Product/Extract';
+
 export const CartDispatcher = import(
     /* webpackMode: "lazy", webpackChunkName: "dispatchers" */
     'Store/Cart/Cart.dispatcher'
@@ -166,9 +168,7 @@ export class ProductContainer extends PureComponent {
         }
 
         if (typeId === PRODUCT_TYPE.grouped) {
-            const { items = [] } = product;
-
-            return items.reduce((o, { qty = 1, product: { id } }) => ({ ...o, [id]: qty }), {});
+            return getGroupedProductsInStockQuantity(product);
         }
 
         const minQty = getMinQuantity(selectedProduct || product);

--- a/packages/scandipwa/src/util/Product/Extract.js
+++ b/packages/scandipwa/src/util/Product/Extract.js
@@ -167,13 +167,9 @@ export const getProductInStock = (product, parentProduct = {}) => {
  * @param products: products in stock
  * @namespace Util/Product/Extract/getGroupedProductsInStockQuantity */
 
-export const getGroupedProductsInStockQuantity = (product) => {
-    const { items = [] } = product;
-
-    return items.reduce((acc, {
-        product, product: { id }, qty = 1
-    }) => (getProductInStock(product) ? { ...acc, [id]: qty } : null), {});
-};
+export const getGroupedProductsInStockQuantity = ({ items = [] }) => items.reduce((acc, {
+    product, product: { id }, qty = 1
+}) => (getProductInStock(product) ? { ...acc, [id]: qty } : null), {});
 
 /**
  * Checks if bundle option exist in options (ignoring quantity)

--- a/packages/scandipwa/src/util/Product/Extract.js
+++ b/packages/scandipwa/src/util/Product/Extract.js
@@ -162,6 +162,20 @@ export const getProductInStock = (product, parentProduct = {}) => {
 };
 
 /**
+ * Checks if items in Grouped Product are in stock
+ * @param product: productGroup
+ * @param products: products in stock
+ * @namespace Util/Product/Extract/getGroupedProductsInStockQuantity */
+
+export const getGroupedProductsInStockQuantity = (product) => {
+    const { items = [] } = product;
+
+    return items.reduce((acc, {
+        product, product: { id }, qty = 1
+    }) => (getProductInStock(product) ? { ...acc, [id]: qty } : null), {});
+};
+
+/**
  * Checks if bundle option exist in options (ignoring quantity)
  * @param uid
  * @param options


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4233 

**Problem:**
* Grouped product is not added to cart if it has Out of stock child product
message: "There are no source items with the in stock status"

**In this PR:**
* Added function to Util/Product/Extract to get quantities for products in stock
* Added function to getDefaultQuantities in Product container

