### PR TITLE
[4273] - Footer jumping on HomepageCategoriesButtons clicking - Fixed

### DIFF
--- a/packages/scandipwa/src/component/Html/Html.component.js
+++ b/packages/scandipwa/src/component/Html/Html.component.js
@@ -17,7 +17,12 @@ import parser from 'html-react-parser';
 import attributesToProps from 'html-react-parser/lib/attributes-to-props';
 import domToReact from 'html-react-parser/lib/dom-to-react';
 import PropTypes from 'prop-types';
-import { lazy, PureComponent, Suspense } from 'react';
+import {
+    Fragment,
+    lazy,
+    PureComponent,
+    Suspense
+} from 'react';
 
 import Image from 'Component/Image';
 import Link from 'Component/Link';
@@ -135,6 +140,50 @@ export class Html extends PureComponent {
         return attributesToProps(properties);
     }
 
+    scrollToTopFunction() {
+        document.documentElement.scrollIntoView();
+    }
+
+    /**
+     * Replace links to native React Router links
+     * @param  {{ children: Array }}
+     * @return {JSX} Return JSX if link is allowed to be replaced
+     * @memberof Html
+     */
+    domToReactFunction(children) {
+        if (children[1]?.attribs.class?.includes('HomepageCategories-Button')) {
+            return [
+                <Fragment key="HomepageCategories-Button1">
+                    { domToReact(children[0], this.parserOptions) }
+                </Fragment>,
+                <button
+                  { ...attributesToProps({
+                      ...children[1].attribs,
+                      onClick: this.scrollToTopFunction,
+                      key: 'HomepageCategories-Button2'
+                  }) }
+                >
+                    { domToReact(children[1].children, this.parserOptions) }
+                </button>,
+                <Fragment key="HomepageCategories-Button3">
+                    { domToReact(children[2], this.parserOptions) }
+                </Fragment>
+            ];
+        }
+
+        if (children[0]?.attribs?.class?.includes('HomepageCategories-Button')) {
+            return (
+                <button
+                  { ...attributesToProps({ ...children[0].attribs, onClick: this.scrollToTopFunction }) }
+                >
+                    { domToReact(children[0].children, this.parserOptions) }
+                </button>
+            );
+        }
+
+        return domToReact(children, this.parserOptions);
+    }
+
     /**
      * Replace links to native React Router links
      * @param  {{ attribs: Object, children: Array }}
@@ -151,7 +200,7 @@ export class Html extends PureComponent {
             if (!isAbsoluteUrl(href) && !isSpecialLink(href)) {
                 return (
                     <Link { ...attributesToProps({ ...attrs, to: href }) }>
-                        { domToReact(children, this.parserOptions) }
+                        { this.domToReactFunction(children) }
                     </Link>
                 );
             }

--- a/packages/scandipwa/src/component/Html/Html.component.js
+++ b/packages/scandipwa/src/component/Html/Html.component.js
@@ -17,12 +17,7 @@ import parser from 'html-react-parser';
 import attributesToProps from 'html-react-parser/lib/attributes-to-props';
 import domToReact from 'html-react-parser/lib/dom-to-react';
 import PropTypes from 'prop-types';
-import {
-    Fragment,
-    lazy,
-    PureComponent,
-    Suspense
-} from 'react';
+import { lazy, PureComponent, Suspense } from 'react';
 
 import Image from 'Component/Image';
 import Link from 'Component/Link';
@@ -140,50 +135,6 @@ export class Html extends PureComponent {
         return attributesToProps(properties);
     }
 
-    scrollToTopFunction() {
-        document.documentElement.scrollIntoView();
-    }
-
-    /**
-     * Replace links to native React Router links
-     * @param  {{ children: Array }}
-     * @return {JSX} Return JSX if link is allowed to be replaced
-     * @memberof Html
-     */
-    domToReactFunction(children) {
-        if (children[1]?.attribs.class?.includes('HomepageCategories-Button')) {
-            return [
-                <Fragment key="HomepageCategories-Button1">
-                    { domToReact(children[0], this.parserOptions) }
-                </Fragment>,
-                <button
-                  { ...attributesToProps({
-                      ...children[1].attribs,
-                      onClick: this.scrollToTopFunction,
-                      key: 'HomepageCategories-Button2'
-                  }) }
-                >
-                    { domToReact(children[1].children, this.parserOptions) }
-                </button>,
-                <Fragment key="HomepageCategories-Button3">
-                    { domToReact(children[2], this.parserOptions) }
-                </Fragment>
-            ];
-        }
-
-        if (children[0]?.attribs?.class?.includes('HomepageCategories-Button')) {
-            return (
-                <button
-                  { ...attributesToProps({ ...children[0].attribs, onClick: this.scrollToTopFunction }) }
-                >
-                    { domToReact(children[0].children, this.parserOptions) }
-                </button>
-            );
-        }
-
-        return domToReact(children, this.parserOptions);
-    }
-
     /**
      * Replace links to native React Router links
      * @param  {{ attribs: Object, children: Array }}
@@ -200,7 +151,7 @@ export class Html extends PureComponent {
             if (!isAbsoluteUrl(href) && !isSpecialLink(href)) {
                 return (
                     <Link { ...attributesToProps({ ...attrs, to: href }) }>
-                        { this.domToReactFunction(children) }
+                        { domToReact(children, this.parserOptions) }
                     </Link>
                 );
             }

--- a/packages/scandipwa/src/component/Router/Router.component.js
+++ b/packages/scandipwa/src/component/Router/Router.component.js
@@ -68,6 +68,8 @@ import {
     URL_REWRITES
 } from './Router.config';
 
+import './Router.style';
+
 export const CartPage = lazy(() => import(/* webpackMode: "lazy", webpackChunkName: "cart" */ 'Route/CartPage'));
 export const Checkout = lazy(() => import(/* webpackMode: "lazy", webpackChunkName: "checkout" */ 'Route/Checkout'));
 export const CmsPage = lazy(() => import(/* webpackMode: "lazy", webpackChunkName: "cms" */ 'Route/CmsPage'));
@@ -345,7 +347,7 @@ export class Router extends PureComponent {
 
     renderFallbackPage() {
         return (
-            <main style={ { height: '100vh' } }>
+            <main block="Router" elem="Loader">
                 <Loader isLoading />
             </main>
         );
@@ -359,7 +361,7 @@ export class Router extends PureComponent {
         return (
             <>
                 { this.renderSectionOfType(BEFORE_ITEMS_TYPE) }
-                <div style={ { minHeight: 'calc(100vh - var(--header-total-height) + 10px)' } }>
+                <div block="Router" elem="MainItems">
                     { this.renderMainItems() }
                 </div>
                 { this.renderSectionOfType(AFTER_ITEMS_TYPE) }

--- a/packages/scandipwa/src/component/Router/Router.component.js
+++ b/packages/scandipwa/src/component/Router/Router.component.js
@@ -359,7 +359,9 @@ export class Router extends PureComponent {
         return (
             <>
                 { this.renderSectionOfType(BEFORE_ITEMS_TYPE) }
-                { this.renderMainItems() }
+                <div style={ { minHeight: 'calc(100vh - var(--header-total-height) + 10px)' } }>
+                    { this.renderMainItems() }
+                </div>
                 { this.renderSectionOfType(AFTER_ITEMS_TYPE) }
             </>
         );

--- a/packages/scandipwa/src/component/Router/Router.style.scss
+++ b/packages/scandipwa/src/component/Router/Router.style.scss
@@ -1,0 +1,20 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+.Router {
+    &-MainItems {
+        min-height: calc(100vh - var(--header-total-height) + 10px);
+    }
+
+    &-Loader {
+        height: 100vh;
+    }
+}


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4273

**Problem:**
* Footer jumping on clicking HomepageCategoriesButtons on the homepage as a result of collapsing the components above the footer and rendering new ones.

**In this PR:**
Made the page scroll to top on clicking those buttons and therefore not focusing the screen on the collapsing part and the footer.

The new functions added:
* scrollToTopFunction
* domToReactFunction:
The purpose is to add onClick prop to those 3 buttons.
So, it checks the links' children, 
-- if the right class (intended buttons) -> modifies the button and uses domToReact to return the rest of the siblings,
-- else returns domToReact(children)

* the original **replaceLinks** function is modified to use the new domToReactFunction instead of domToReact()
