### PR TITLE
fixed not found page error when redirected from the wishlist page

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
@@ -271,6 +271,7 @@ export class WishlistItemContainer extends PureComponent {
         const {
             type_id,
             variants,
+            url,
             wishlist: {
                 id,
                 sku
@@ -285,7 +286,7 @@ export class WishlistItemContainer extends PureComponent {
             const configurableVariantIndex = this.getConfigurableVariantIndex(sku, variants);
 
             if (!configurableVariantIndex) {
-                history.push({ pathname: appendWithStoreCode(item.url) });
+                history.push({ pathname: appendWithStoreCode(url) });
                 showNotification('info', __('Please, select product options!'));
 
                 return;
@@ -305,7 +306,7 @@ export class WishlistItemContainer extends PureComponent {
             this.removeItem(id);
         } catch {
             this.setState({ isLoading: false });
-            history.push({ pathname: appendWithStoreCode(item.url) });
+            history.push({ pathname: appendWithStoreCode(url) });
         }
     }
 

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.container.js
@@ -304,7 +304,8 @@ export class WishlistItemContainer extends PureComponent {
             await addProductToCart({ products });
             this.removeItem(id);
         } catch {
-            this.setState({ isLoading: false }, this.redirectToProductPage);
+            this.setState({ isLoading: false });
+            history.push({ pathname: appendWithStoreCode(item.url) });
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4427

**Problem:**
* 404 page opened for a sec when adding product to cart from wishlist if product has required options

**In this PR:**
* I couldn't reproduce the issue, no matter what - tried incoginito, other browser's and so on. The error was caught in the dispatcher. Changed how the redirection, error is treated in that case (re-used the logic that will be executed if configurableVariantIndex isn't found) - set the state first, did history.push();
