### PR TITLE
#4441 - adjusted menu total height

### DIFF
--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -11,7 +11,7 @@
 
 :root {
     --menu-item-height: 20px;
-    --menu-total-height: 59px;
+    --menu-total-height: 53px;
 }
 
 @mixin subcategory-visible {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4433

**Problem:**
* Space appeared between slider and header line. It was due to wrapper that had height more than a header actual height.

**In this PR:**
* adjusted menu total height
