### PR TITLE
[4251] - File's name toLowerCase on validation

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.container.js
+++ b/packages/scandipwa/src/component/Field/Field.container.js
@@ -122,7 +122,12 @@ export class FieldContainer extends PureComponent {
         const value = type === FIELD_TYPE.checkbox || type === FIELD_TYPE.radio
             ? !!this.fieldRef.checked
             : this.fieldRef.value;
-        const response = validate(value, validationRule);
+
+        const response = validate(type === FIELD_TYPE.file
+            ? value.toLowerCase()
+            : value,
+        validationRule);
+
         const output = response !== true ? { ...response, type, name } : response;
 
         // If validation is called from different object you can pass object


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4251

**Problem:**
* Gave error 'Incorrect File extension upload!' if uploaded a correct file extension but capitalized.

**In this PR:**
* Converted the file field's value to lower case (only if type===file) when it gets passed to the validation function.
