### PR TITLE
[4379] - Fixed the offline mode icon in RTL mode

### DIFF
--- a/packages/scandipwa/src/component/OfflineNotice/OfflineNotice.style.scss
+++ b/packages/scandipwa/src/component/OfflineNotice/OfflineNotice.style.scss
@@ -99,6 +99,10 @@
             &::after {
                 border-radius: 50%;
                 box-shadow: calc(3px * var(--diameter)) calc(-3px * var(--diameter)) 0 0 var(--fill-color), calc(1px * var(--diameter)) 0 0 0 var(--fill-color), calc(7px * var(--diameter)) calc(-3px * var(--diameter)) 0 calc(-1px * var(--diameter)) var(--fill-color), calc(3px * var(--diameter)) 0 0 0 var(--fill-color), calc(5px * var(--diameter)) 0 0 0 var(--fill-color), calc(8px * var(--diameter)) 0 0 0 var(--fill-color);
+            
+                [dir="rtl"] & {
+                    transform: scaleX(-1);
+                }
             }
 
             &::before {
@@ -125,6 +129,10 @@
                 -webkit-transform: rotate(45deg);
                 transform: rotate(45deg);
                 inset-block-start: 0;
+
+                [dir="rtl"] & {
+                    transform: rotate(135deg)
+                }
             }
 
             &::before {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4379

**Problem:**
* Offline mode icon was broken in RTL mode

**In this PR:**
* Mirrored the cloud and stick icons 
* The rest of SVGs follow Amazon's RTL pattern

![o1](https://user-images.githubusercontent.com/13037254/158150957-921d3879-fc4d-41b8-9ef9-9dec6c08a1dd.PNG)
![o2](https://user-images.githubusercontent.com/13037254/158150963-ea78b10f-e4e0-49ac-a5fd-16c96c8392e4.PNG)

