### PR TITLE
#4454 - fixed button covering another button on small height devices

### DIFF
--- a/packages/scandipwa/src/component/CheckoutSuccess/CheckoutSuccess.style.scss
+++ b/packages/scandipwa/src/component/CheckoutSuccess/CheckoutSuccess.style.scss
@@ -15,9 +15,12 @@
     }
 
     &-ButtonWrapper {
+        z-index: 1;
+        background-color: var(--color-white);
+
         @include mobile {
             padding: 14px;
-            position: absolute;
+            position: fixed;
             inset-inline-start: 0;
             width: 100%;
             inset-block-end: var(--navigation-tabs-height);

--- a/packages/scandipwa/src/component/CheckoutSuccess/CheckoutSuccess.style.scss
+++ b/packages/scandipwa/src/component/CheckoutSuccess/CheckoutSuccess.style.scss
@@ -1,7 +1,6 @@
 .CheckoutSuccess {
     @include mobile {
         margin-block-start: 28px;
-        position: unset;
     }
 
     &-ContinueButton {
@@ -23,7 +22,7 @@
             position: fixed;
             inset-inline-start: 0;
             width: 100%;
-            inset-block-end: var(--navigation-tabs-height);
+            inset-block-end: calc(var(--navigation-tabs-height) - 2px);
             border-block-start: 1px solid var(--primary-divider-color);
         }
     }

--- a/packages/scandipwa/src/component/CheckoutSuccess/CheckoutSuccess.style.scss
+++ b/packages/scandipwa/src/component/CheckoutSuccess/CheckoutSuccess.style.scss
@@ -20,7 +20,7 @@
             position: absolute;
             inset-inline-start: 0;
             width: 100%;
-            inset-block-end: 0;
+            inset-block-end: var(--navigation-tabs-height);
             border-block-start: 1px solid var(--primary-divider-color);
         }
     }

--- a/packages/scandipwa/src/component/CheckoutSuccess/CheckoutSuccess.style.scss
+++ b/packages/scandipwa/src/component/CheckoutSuccess/CheckoutSuccess.style.scss
@@ -1,6 +1,7 @@
 .CheckoutSuccess {
     @include mobile {
         margin-block-start: 28px;
+        position: unset;
     }
 
     &-ContinueButton {
@@ -16,10 +17,10 @@
     &-ButtonWrapper {
         @include mobile {
             padding: 14px;
-            position: fixed;
+            position: absolute;
             inset-inline-start: 0;
             width: 100%;
-            inset-block-end: var(--navigation-tabs-height);
+            inset-block-end: 0;
             border-block-start: 1px solid var(--primary-divider-color);
         }
     }

--- a/packages/scandipwa/src/route/Checkout/Checkout.style.scss
+++ b/packages/scandipwa/src/route/Checkout/Checkout.style.scss
@@ -16,11 +16,6 @@
 .Checkout {
     padding-block-end: var(--header-nav-height);
 
-    section,
-    &-Step {
-        position: unset;
-    }
-
     @include desktop {
         margin-block-start: var(--header-total-height);
     }
@@ -65,13 +60,7 @@
     &-Wrapper {
         margin: auto;
         padding: 0 16px;
-        position: unset;
 
-        form {
-            @include mobile {
-                position: unset;
-            }
-        }
 
         @include desktop {
             display: grid;

--- a/packages/scandipwa/src/route/Checkout/Checkout.style.scss
+++ b/packages/scandipwa/src/route/Checkout/Checkout.style.scss
@@ -16,6 +16,11 @@
 .Checkout {
     padding-block-end: var(--header-nav-height);
 
+    section,
+    &-Step {
+        position: unset;
+    }
+
     @include desktop {
         margin-block-start: var(--header-total-height);
     }
@@ -60,6 +65,13 @@
     &-Wrapper {
         margin: auto;
         padding: 0 16px;
+        position: unset;
+
+        form {
+            @include mobile {
+                position: unset;
+            }
+        }
 
         @include desktop {
             display: grid;

--- a/packages/scandipwa/src/route/Checkout/Checkout.style.scss
+++ b/packages/scandipwa/src/route/Checkout/Checkout.style.scss
@@ -61,7 +61,6 @@
         margin: auto;
         padding: 0 16px;
 
-
         @include desktop {
             display: grid;
             grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4454

**Problem:**
* On very small devices, like iphone 7 or older, two buttons were covering each other on the Thank You page. The 'continue Shopping button' was position fixed and it's okay when the device height is big enough. However, on very small devices, that positioning didn't really work.

**In this PR:**
*  So, what I did was to, instead of fixed, make the button position absolute. Now, by default, all the wrappers between the button and the main (the element I wanted the button to be relative to) had position relative by default. Made sure that all the wrappers has a position relative. that way, you get the default fixed position behaviour, but also no covering when device height is too small. 
