### PR TITLE
[4437] - 'Same shipping and billing addresses' checkbox is no longer checked if user has different default billing address

### DIFF
--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -166,6 +166,7 @@ export class CheckoutBillingContainer extends PureComponent {
         return (
             (!newShippingId && newShippingStreet.length === 0 && default_billing === default_shipping)
             || (default_billing && parseInt(default_billing, 10) === newShippingId)
+            || (!default_billing)
         )
         && selectedShippingMethod !== STORE_IN_PICK_UP_METHOD_CODE;
     }

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -73,14 +73,13 @@ export class CheckoutBillingContainer extends PureComponent {
         setDetailsStep: PropTypes.func.isRequired,
         setLoading: PropTypes.func.isRequired,
         termsAreEnabled: PropTypes.bool,
-        newShippingId: PropTypes.number,
+        newShippingId: PropTypes.number.isRequired,
         newShippingStreet: PropTypes.arrayOf(PropTypes.string).isRequired
     };
 
     static defaultProps = {
         termsAreEnabled: false,
-        cartTotalSubPrice: null,
-        newShippingId: undefined
+        cartTotalSubPrice: null
     };
 
     static getDerivedStateFromProps(props, state) {
@@ -164,7 +163,7 @@ export class CheckoutBillingContainer extends PureComponent {
         }
 
         return (
-            (!newShippingId && newShippingStreet.length === 0 && default_billing === default_shipping)
+            (!newShippingId && !newShippingStreet.length && default_billing === default_shipping)
             || (default_billing && parseInt(default_billing, 10) === newShippingId)
             || (!default_billing)
         )

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -41,7 +41,9 @@ export const mapStateToProps = (state) => ({
     termsAreEnabled: state.ConfigReducer.terms_are_enabled,
     termsAndConditions: state.ConfigReducer.checkoutAgreements,
     addressLinesQty: state.ConfigReducer.address_lines_quantity,
-    cartTotalSubPrice: getCartTotalSubPrice(state)
+    cartTotalSubPrice: getCartTotalSubPrice(state),
+    newShippingId: state.CheckoutReducer.shippingFields.id,
+    newShippingStreet: state.CheckoutReducer.shippingFields.street
 });
 
 /** @namespace Component/CheckoutBilling/Container/mapDispatchToProps */
@@ -70,12 +72,15 @@ export class CheckoutBillingContainer extends PureComponent {
         cartTotalSubPrice: PropTypes.number,
         setDetailsStep: PropTypes.func.isRequired,
         setLoading: PropTypes.func.isRequired,
-        termsAreEnabled: PropTypes.bool
+        termsAreEnabled: PropTypes.bool,
+        newShippingId: PropTypes.number,
+        newShippingStreet: PropTypes.arrayOf(PropTypes.string).isRequired
     };
 
     static defaultProps = {
         termsAreEnabled: false,
-        cartTotalSubPrice: null
+        cartTotalSubPrice: null,
+        newShippingId: undefined
     };
 
     static getDerivedStateFromProps(props, state) {
@@ -147,13 +152,22 @@ export class CheckoutBillingContainer extends PureComponent {
     }
 
     isSameShippingAddress({ default_billing, default_shipping }) {
-        const { totals: { is_virtual }, selectedShippingMethod } = this.props;
+        const {
+            totals: { is_virtual },
+            selectedShippingMethod,
+            newShippingId,
+            newShippingStreet
+        } = this.props;
 
         if (is_virtual) {
             return false;
         }
 
-        return default_billing === default_shipping && selectedShippingMethod !== STORE_IN_PICK_UP_METHOD_CODE;
+        return (
+            (!newShippingId && newShippingStreet.length === 0 && default_billing === default_shipping)
+            || (default_billing && parseInt(default_billing, 10) === newShippingId)
+        )
+        && selectedShippingMethod !== STORE_IN_PICK_UP_METHOD_CODE;
     }
 
     onAddressSelect(id) {

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
@@ -222,7 +222,8 @@ export class CheckoutShippingContainer extends PureComponent {
             saveAddressInformation,
             updateShippingFields,
             addressLinesQty,
-            selectedStoreAddress
+            selectedStoreAddress,
+            customer: { default_shipping }
         } = this.props;
 
         const {
@@ -265,7 +266,14 @@ export class CheckoutShippingContainer extends PureComponent {
 
         saveAddressInformation(data);
         const shippingMethod = `${shipping_carrier_code}_${shipping_method_code}`;
-        updateShippingFields({ ...formattedFields, shippingMethod });
+        updateShippingFields({
+            ...(
+                formattedFields.street.length > 0
+                || (default_shipping && parseInt(default_shipping, 10) === data.shipping_address.id)
+                    ? formattedFields : data.shipping_address
+            ),
+            shippingMethod
+        });
     }
 
     _getAddressById(addressId) {

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
@@ -266,9 +266,11 @@ export class CheckoutShippingContainer extends PureComponent {
 
         saveAddressInformation(data);
         const shippingMethod = `${shipping_carrier_code}_${shipping_method_code}`;
+        const { street = [] } = formattedFields;
+
         updateShippingFields({
             ...(
-                formattedFields.street.length > 0
+                street.length
                 || (default_shipping && parseInt(default_shipping, 10) === data.shipping_address.id)
                     ? formattedFields : data.shipping_address
             ),


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4437

**Problem:**
* checkbox is checked only when the default shipping === default billing (customer data in the redux store), not accounting for changing the address (custom address or choosing another previously saved address (non-default)) in the checkout shipping step.

**In this PR:**
* In the checkout shipping file:
When selecting a previously saved address other than the default, the checkout reducer.shippingFields are updated.
* In the checkout billing file:
> New constants were created: newShippingStreet, newShippingId - (from the checkout reducer's shippingFields)
> -- newShippingId is:
> ----- undefined: if the default shipping address is used, and if custom shipping address
> ----- number: if a previously saved address was selected.
> 
> -- newShippingStreet is:
> ------ empty array : if default shipping
> ------ array of strings : otherwise
> 
> ----> the changes in isSameShippingAddress -> function returns true if:
> -- no custom address ( undefined newShippingId && newShippingStreet.length === 0) and default_billing === default_shipping
> or 
> -- the previously saved address is the same as the default billing (comparing IDs)


