### PR TITLE
#4451 - fixed share whishlist not showing loading state

### DIFF
--- a/packages/scandipwa/src/component/ShareWishlistForm/ShareWishlistForm.component.js
+++ b/packages/scandipwa/src/component/ShareWishlistForm/ShareWishlistForm.component.js
@@ -40,10 +40,10 @@ export class ShareWishlistForm extends FieldForm {
 
         return (
             <>
-           { isFormLoading && <Loader isLoading /> }
-            <button type="submit" block="Button">
-                { __('Share Wishlist') }
-            </button>
+                { isFormLoading && <Loader isLoading /> }
+                <button type="submit" block="Button">
+                    { __('Share Wishlist') }
+                </button>
             </>
         );
     }

--- a/packages/scandipwa/src/component/ShareWishlistForm/ShareWishlistForm.component.js
+++ b/packages/scandipwa/src/component/ShareWishlistForm/ShareWishlistForm.component.js
@@ -11,6 +11,7 @@
 import PropTypes from 'prop-types';
 
 import FieldForm from 'Component/FieldForm';
+import Loader from 'Component/Loader';
 import transformToNameValuePair from 'Util/Form/Transform';
 
 import shareWishlistForm from './ShareWishlistForm.form';
@@ -18,7 +19,8 @@ import shareWishlistForm from './ShareWishlistForm.form';
 /** @namespace Component/ShareWishlistForm/Component */
 export class ShareWishlistForm extends FieldForm {
     static propTypes = {
-        onSave: PropTypes.func.isRequired
+        onSave: PropTypes.func.isRequired,
+        isFormLoading: PropTypes.bool.isRequired
     };
 
     onFormSuccess = this.onFormSuccess.bind(this);
@@ -27,16 +29,20 @@ export class ShareWishlistForm extends FieldForm {
         return shareWishlistForm();
     }
 
-    onFormSuccess(form, fields) {
+    async onFormSuccess(form, fields) {
         const { onSave } = this.props;
-        onSave(transformToNameValuePair(fields));
+
+        await onSave(transformToNameValuePair(fields));
     }
 
     renderActions() {
         return (
+            <>
+           { this.props.isFormLoading && <Loader isLoading /> }
             <button type="submit" block="Button">
                 { __('Share Wishlist') }
             </button>
+            </>
         );
     }
 

--- a/packages/scandipwa/src/component/ShareWishlistForm/ShareWishlistForm.component.js
+++ b/packages/scandipwa/src/component/ShareWishlistForm/ShareWishlistForm.component.js
@@ -36,9 +36,11 @@ export class ShareWishlistForm extends FieldForm {
     }
 
     renderActions() {
+        const { isFormLoading } = this.props;
+
         return (
             <>
-           { this.props.isFormLoading && <Loader isLoading /> }
+           { isFormLoading && <Loader isLoading /> }
             <button type="submit" block="Button">
                 { __('Share Wishlist') }
             </button>

--- a/packages/scandipwa/src/component/ShareWishlistPopup/ShareWishlistPopup.component.js
+++ b/packages/scandipwa/src/component/ShareWishlistPopup/ShareWishlistPopup.component.js
@@ -24,13 +24,19 @@ export class ShareWishlistPopup extends PureComponent {
     state = {};
 
     static propTypes = {
-        handleFormData: PropTypes.func.isRequired
+        handleFormData: PropTypes.func.isRequired,
+        isFormLoading: PropTypes.bool.isRequired
     };
 
     renderContent() {
-        const { handleFormData } = this.props;
+        const { handleFormData, isFormLoading } = this.props;
 
-        return <ShareWishlistForm onSave={ handleFormData } />;
+        return (
+            <ShareWishlistForm
+              onSave={ handleFormData }
+              isFormLoading={ isFormLoading }
+            />
+        );
     }
 
     render() {

--- a/packages/scandipwa/src/component/ShareWishlistPopup/ShareWishlistPopup.container.js
+++ b/packages/scandipwa/src/component/ShareWishlistPopup/ShareWishlistPopup.container.js
@@ -33,6 +33,10 @@ export const mapStateToProps = () => ({});
 
 /** @namespace Component/ShareWishlistPopup/Container */
 export class ShareWishlistPopupContainer extends PureComponent {
+    state = {
+        isLoading: false
+    };
+
     static propTypes = {
         showError: PropTypes.func.isRequired,
         hidePopup: PropTypes.func.isRequired,
@@ -43,6 +47,14 @@ export class ShareWishlistPopupContainer extends PureComponent {
         handleFormData: this.handleFormData.bind(this)
     };
 
+    containerProps() {
+        const { isLoading } = this.state;
+
+        return {
+            isFormLoading: isLoading
+        };
+    }
+
     handleFormData(fields) {
         const { hidePopup, showError, showNotification } = this.props;
         const { message, emails: initialEmails } = fields;
@@ -52,20 +64,27 @@ export class ShareWishlistPopupContainer extends PureComponent {
             return;
         }
 
+        this.setState({ isLoading: true });
+
         fetchMutation(WishlistQuery.getShareWishlistMutation({ message, emails })).then(
             /** @namespace Component/ShareWishlistPopup/Container/ShareWishlistPopupContainer/handleFormData/fetchMutation/then */
             () => {
                 showNotification(__('Wishlist has been shared'));
                 hidePopup();
+                this.setState({ isLoading: false });
             },
-            /** @namespace Component/ShareWishlistPopup/Container/ShareWishlistPopupContainer/handleFormData/fetchMutation/then/showError/catch */
-            (error) => showError(getErrorMessage(error))
+            /** @namespace Component/ShareWishlistPopup/Container/ShareWishlistPopupContainer/handleFormData/fetchMutation/then/catch */
+            (error) => {
+                showError(getErrorMessage(error));
+                this.setState({ isLoading: false });
+            }
         );
     }
 
     render() {
         return (
             <ShareWishlistPopup
+              { ...this.containerProps() }
               { ...this.containerFunctions }
             />
         );


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4451

**Problem:**
* Loader was missing in share wishlist pop-up

**In this PR:**
* Added a bit of state logic to the parent element, made sure that the component gets isFormLoading prop so that it can determine if the loader should show up
