### PR TITLE
#4468 - fixed url not parsing = instead of :

### DIFF
--- a/packages/scandipwa/src/util/Url/Url.js
+++ b/packages/scandipwa/src/util/Url/Url.js
@@ -108,7 +108,7 @@ export const getQueryParam = (variable, location) => {
         const splitIdx = item.indexOf('=');
         const [k, v] = [item.slice(0, splitIdx), item.slice(splitIdx + 1)];
 
-        return k === variable ? v.replaceAll('=', ':') : acc;
+        return k === variable ? v.replace(/=/g, ':') : acc;
     }, false);
 };
 

--- a/packages/scandipwa/src/util/Url/Url.js
+++ b/packages/scandipwa/src/util/Url/Url.js
@@ -105,8 +105,10 @@ export const getQueryParam = (variable, location) => {
     const vars = query.split('&');
 
     return vars.reduce((acc, item) => {
-        const [k, v] = item.split('=');
-        return k === variable ? v : acc;
+        const splitIdx = item.indexOf('=');
+        const [k, v] = [item.slice(0, splitIdx), item.slice(splitIdx + 1)];
+
+        return k === variable ? v.replaceAll('=', ':') : acc;
     }, false);
 };
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4351

**Problem:**
*  If someone changed " : " with " = " in the url, app would redirect you to the oops, not found page.

**In this PR:**
* Added a bit of parsing logic, it now changes = with : so that app works as intended
