### PR TITLE
[3630] - 'not-allowed' cursor on products disabled qty-control buttons

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.style.scss
+++ b/packages/scandipwa/src/component/CartItem/CartItem.style.scss
@@ -283,6 +283,11 @@
             &:not([disabled]) {
                 cursor: pointer;
             }
+
+            &:disabled {
+                pointer-events: initial;
+                cursor: not-allowed;
+            }
         }
     }
 

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -289,7 +289,8 @@
             }
 
             &:disabled {
-                cursor: default;
+                pointer-events: initial;
+                cursor: not-allowed;
             }
 
             &:hover {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3630

**Problem:**
* Default cursor on products disabled qty-control buttons

**In this PR:**
* 'not-allowed' cursor on disabled buttons
(The pointer cursor couldn't be reproduced)
