### PR TITLE
[4341] - Removed tag <meta name="title">

### DIFF
--- a/packages/scandipwa/src/component/Meta/Meta.container.js
+++ b/packages/scandipwa/src/component/Meta/Meta.container.js
@@ -91,12 +91,6 @@ export class MetaContainer extends PureComponent {
         ), []);
     }
 
-    _getTitle() {
-        const { title, default_title } = this.props;
-
-        return title || default_title;
-    }
-
     _getDescription() {
         const { description, default_description } = this.props;
 
@@ -123,7 +117,6 @@ export class MetaContainer extends PureComponent {
 
     _getMetadata() {
         const meta = {
-            title: this._getTitle(),
             description: this._getDescription(),
             keywords: this._getKeywords(),
             robots: this._getRobots(),


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4341

**Problem:**
* Useless \<meta name="title"\> 

**In this PR:**
* Deleted the dict's key-value pair producing it and its function
