### PR TITLE
#4455  - removed uppercasing of the user input

### DIFF
--- a/packages/scandipwa/src/route/SearchPage/SearchPage.style.scss
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.style.scss
@@ -14,7 +14,6 @@
         text-transform: none;
 
         span {
-            text-transform: uppercase;
             color: var(--primary-base-color);
         }
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4455

**Problem:**
* title and breadcrumbs are written in capital letters on search result page

**In this PR:**
* removed text-transform: uppercase; on the element
