### PR TITLE
#3566 Success message can appear a couple of times if user often clicks on wishlist

### DIFF
--- a/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
+++ b/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
@@ -65,7 +65,8 @@ export class ProductWishlistButtonContainer extends PureComponent {
     };
 
     state = {
-        isWishlistButtonLoading: false
+        isWishlistButtonLoading: false,
+        isAddedToWishList: false
     };
 
     containerFunctions = {
@@ -109,6 +110,10 @@ export class ProductWishlistButtonContainer extends PureComponent {
             wishlistId
         } = this.props;
 
+        const {
+            isAddedToWishList
+        } = this.state;
+
         if (!isSignedIn()) {
             return showNotification('info', __('You must login or register to add items to your wishlist.'));
         }
@@ -119,16 +124,25 @@ export class ProductWishlistButtonContainer extends PureComponent {
 
         this.setWishlistButtonLoading(true);
 
+        const wishlistItem = this.getWishlistItem(sku);
+
+        if (wishlistItem) {
+            this.setState({ isAddedToWishList: true })
+        } else {
+            this.setState({ isAddedToWishList: false })
+        }
+
         if (add) {
-            await addProductToWishlist({
-                items: magentoProduct,
-                wishlistId
-            });
+            if (!isAddedToWishList) {
+                await addProductToWishlist({
+                    items: magentoProduct,
+                    wishlistId
+                });
+            }
 
             return;
         }
 
-        const wishlistItem = this.getWishlistItem(sku);
         if (!wishlistItem) {
             return;
         }

--- a/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
+++ b/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
@@ -132,14 +132,11 @@ export class ProductWishlistButtonContainer extends PureComponent {
             this.setState({ isAddedToWishList: false })
         }
 
-        if (add) {
-            if (!isAddedToWishList) {
-                await addProductToWishlist({
-                    items: magentoProduct,
-                    wishlistId
-                });
-            }
-
+        if (add && !isAddedToWishList) {
+            await addProductToWishlist({
+                items: magentoProduct,
+                wishlistId
+            });
             return;
         }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3566

**Problem:**
* Success message can appear a couple of times if user often clicks on wishlist sign on PDP

**In this PR:**
* Created a check whether there is a product in the wish list removed the possibility of several clicks in a row
