### PR TITLE
[4400] - Radio and Checkbox inputs on resizing - Fixed

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -311,7 +311,7 @@
             margin-inline-end: 11px;
 
             @include desktop {
-                width: var(--checkbox-width);
+                max-width: var(--checkbox-width);
                 height: var(--checkbox-height);
             }
 

--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
@@ -16,8 +16,9 @@
 
 .ProductBundleItem {
     &-Label {
-        width: 100%;
+        width: calc(100% - max(21px, var(--checkbox-width)));
         word-break: break-word;
+        min-width: 50px;
     }
 
     &-Wrapper {

--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
@@ -15,6 +15,11 @@
 }
 
 .ProductBundleItem {
+    &-Label {
+        width: 100%;
+        word-break: break-word;
+    }
+
     &-Wrapper {
         margin-block-start: 26px;
 

--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
@@ -15,6 +15,12 @@
 }
 
 .ProductCustomizableItem {
+    &-Label {
+        width: calc(100% - max(21px, var(--checkbox-width)));
+        word-break: break-word;
+        min-width: 50px;
+    }
+
     &-PriceLabel {
         white-space: nowrap;
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4400

**Problem:**
* Radio buttons and checkboxes are narrowed on window resizing and their sizes depended on their ProductBundleItem-Labels

**In this PR:**
* Assigned width and word-breaking to the labels
* Assigned max-width to the inputs (instead of width - width is assigned in px in later codes) 
