### PR TITLE
#3307 Tax line is displayed in empty cart on a mobile phone

### DIFF
--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -263,7 +263,8 @@ export class CheckoutOrderSummary extends PureComponent {
         const {
             totals: {
                 tax_amount = 0,
-                quote_currency_code
+                quote_currency_code,
+                items_qty
             },
             cartDisplayConfig: {
                 display_full_tax_summary,
@@ -279,6 +280,7 @@ export class CheckoutOrderSummary extends PureComponent {
             <CheckoutOrderSummaryPriceLine
               price={ tax_amount.toFixed(2) } // since we display tax even if value is 0
               currency={ quote_currency_code }
+              itemsQty={ items_qty }
               title={ __('Tax') }
               mods={ { withAppendedContent: display_full_tax_summary } }
             >

--- a/packages/scandipwa/src/component/CheckoutOrderSummaryPriceLine/CheckoutOrderSummaryPriceLine.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummaryPriceLine/CheckoutOrderSummaryPriceLine.component.js
@@ -20,6 +20,7 @@ export class CheckoutOrderSummaryPriceLine extends PureComponent {
     static propTypes = {
         price: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
         currency: PropTypes.string,
+        itemsQty: PropTypes.number.isRequired,
         title: PropTypes.string.isRequired,
         coupon_code: PropTypes.string,
         mods: ModsType,
@@ -88,10 +89,15 @@ export class CheckoutOrderSummaryPriceLine extends PureComponent {
         const {
             price,
             mods,
-            children
+            children,
+            itemsQty
         } = this.props;
 
-        if (!price) {
+        if (!itemsQty && !price) {
+            return null;
+        }
+
+        if (+price === 0 && !itemsQty) {
             return null;
         }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3307

**Problem:**
* Tax line is displayed in empty cart on a mobile phone

**In this PR:**
* Created a check that looks at price
