### PR TITLE
#4417 - fixed image jumping in firefox

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -322,7 +322,7 @@ export class ProductCard extends Product {
 
         return (
             this.renderCardLinkWrapper((
-                <>
+                <div block="ProductCard" elem="LinkInnerWrapper">
                     <div block="ProductCard" elem="FigureReview">
                         <figure block="ProductCard" elem="Figure">
                             { this.renderPicture() }
@@ -337,7 +337,7 @@ export class ProductCard extends Product {
                     <div block="ProductCard" elem="VisibleOnHover">
                         { this.renderVisibleOnHover() }
                     </div>
-                </>
+                </div>
             ))
         );
     }

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
@@ -199,6 +199,11 @@
         inset-block-start: 0;
     }
 
+    &-LinkInnerWrapper {
+        width: 100%;
+        height: 100%;
+    }
+
     &-FigureReview {
         background: var(--product-card-background);
         display: flex;
@@ -242,7 +247,7 @@
 
     &-Color,
     &-Image {
-        display: inline-block;
+        // display: inline-block;
         width: var(--product-card-color-size);
         height: var(--product-card-color-size);
         border-radius: 50%;
@@ -298,11 +303,11 @@
         display: flex;
         flex-direction: column;
         width: 100%;
-
+        
         &:hover,
         &:focus {
-            text-decoration: none;
             color: initial;
+            text-decoration: none;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4321

**Problem:**
* In firefox(it treats something differently), absolutely positioned image was jumping oh hovering.

**In this PR:**
* Introduced new wrapper, it stabilised images
