### PR TITLE
[4463] - Enabled concurrent add/remove from wishlist requests

### DIFF
--- a/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
+++ b/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.container.js
@@ -102,7 +102,6 @@ export class ProductWishlistButtonContainer extends PureComponent {
         const {
             magentoProduct,
             magentoProduct: [{ sku }] = [],
-            isAddingWishlistItem,
             showNotification,
             addProductToWishlist,
             removeProductFromWishlist,
@@ -111,10 +110,6 @@ export class ProductWishlistButtonContainer extends PureComponent {
 
         if (!isSignedIn()) {
             return showNotification('info', __('You must login or register to add items to your wishlist.'));
-        }
-
-        if (isAddingWishlistItem) {
-            return null;
         }
 
         this.setWishlistButtonLoading(true);


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4463

**Problem:**
* Disabled concurrent add/remove from wishlist requests

**In this PR:**
* Removed the function that returns null if WishlistReducer.isLoading (isAddingWishlistItem)
