### PR TITLE
#4226 - removed extra bottom border

### DIFF
--- a/packages/scandipwa/src/route/CartPage/CartPage.style.scss
+++ b/packages/scandipwa/src/route/CartPage/CartPage.style.scss
@@ -178,11 +178,12 @@
         }
     }
 
-    &-Discount {
+    & &-Discount {// hack to obtain required specificity
         border-block-start: 0;
 
         @include mobile {
             border-block-start: 1px solid var(--expandable-content-divider-color);
+            border-block-end: 0;
         }
 
         @include desktop {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4226

**Problem:**
* extra border-bottom was showing on the mobile view. had to remove it. in the process, because of the specificity, I had to use a trick which had already been used(did global find).

**In this PR:**
* removed border-bottom on the Expandable element on mobile view.
