### PR TITLE
#4261 - fixed text overflowing on second line on small devices

### DIFF
--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
@@ -22,6 +22,7 @@ import { STORE_IN_PICK_UP_METHOD_CODE } from 'Component/StoreInPickUp/StoreInPic
 import { BILLING_STEP } from 'Route/Checkout/Checkout.config';
 import { Addresstype } from 'Type/Account.type';
 import { PaymentMethodsType } from 'Type/Checkout.type';
+import { DeviceType } from 'Type/Device.type';
 import { TotalsType } from 'Type/MiniCart.type';
 import { formatPrice } from 'Util/Price';
 
@@ -52,7 +53,8 @@ export class CheckoutBilling extends PureComponent {
         termsAndConditions: PropTypes.arrayOf(PropTypes.shape({
             checkbox_text: PropTypes.string
         })).isRequired,
-        selectedShippingMethod: PropTypes.string.isRequired
+        selectedShippingMethod: PropTypes.string.isRequired,
+        device: DeviceType.isRequired
     };
 
     static defaultProps = {
@@ -96,8 +98,11 @@ export class CheckoutBilling extends PureComponent {
     renderTermsAndConditions() {
         const {
             termsAreEnabled,
-            termsAndConditions
+            termsAndConditions,
+            device: { isMobile }
         } = this.props;
+
+        console.log(isMobile);
 
         const {
             checkbox_text = __('I agree to terms and conditions')
@@ -133,7 +138,7 @@ export class CheckoutBilling extends PureComponent {
                       } }
                       mix={ { block: 'CheckoutBilling', elem: 'TermsAndConditions-Checkbox' } }
                     />
-                    { `${checkbox_text } - ` }
+                    { `${checkbox_text } ${!isMobile ? '-' : ''}` }
                 </label>
                 <button
                   block="CheckoutBilling"

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -22,6 +22,7 @@ import { showNotification } from 'Store/Notification/Notification.action';
 import { showPopup } from 'Store/Popup/Popup.action';
 import { Addresstype, CustomerType } from 'Type/Account.type';
 import { PaymentMethodsType } from 'Type/Checkout.type';
+import { DeviceType } from 'Type/Device.type';
 import { TotalsType } from 'Type/MiniCart.type';
 import {
     getFormFields,
@@ -41,7 +42,8 @@ export const mapStateToProps = (state) => ({
     termsAreEnabled: state.ConfigReducer.terms_are_enabled,
     termsAndConditions: state.ConfigReducer.checkoutAgreements,
     addressLinesQty: state.ConfigReducer.address_lines_quantity,
-    cartTotalSubPrice: getCartTotalSubPrice(state)
+    cartTotalSubPrice: getCartTotalSubPrice(state),
+    device: state.ConfigReducer.device
 });
 
 /** @namespace Component/CheckoutBilling/Container/mapDispatchToProps */
@@ -70,7 +72,8 @@ export class CheckoutBillingContainer extends PureComponent {
         cartTotalSubPrice: PropTypes.number,
         setDetailsStep: PropTypes.func.isRequired,
         setLoading: PropTypes.func.isRequired,
-        termsAreEnabled: PropTypes.bool
+        termsAreEnabled: PropTypes.bool,
+        device: DeviceType.isRequired
     };
 
     static defaultProps = {
@@ -128,7 +131,8 @@ export class CheckoutBillingContainer extends PureComponent {
             shippingAddress,
             termsAndConditions,
             termsAreEnabled,
-            totals
+            totals,
+            device
         } = this.props;
         const { isSameAsShipping } = this.state;
 
@@ -142,7 +146,8 @@ export class CheckoutBillingContainer extends PureComponent {
             shippingAddress,
             termsAndConditions,
             termsAreEnabled,
-            totals
+            totals,
+            device
         };
     }
 

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
@@ -52,6 +52,10 @@
         display: flex;
         align-items: center;
 
+        @include mobile {
+            margin-inline-end: 1rem;
+        }
+
         &:hover {
             cursor: pointer;
             
@@ -60,15 +64,22 @@
             }
         }
     }
+    
+
 
     &-TACLink {
         font-size: 14px;
         font-weight: 700;
         color: var(--link-color);
-        margin-inline-start: 0.5em;
+        margin-inline-start: 0.25em;
         display: flex;
         cursor: pointer;
+        white-space: nowrap;
 
+        @include mobile {
+            margin-inline-start: auto;
+        }
+        
         &:hover {
             text-decoration: underline;
         }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4261

**Problem:**
* The problem was that when going on small devices, terms and conditions text were stretching on two lines and so did the '-' symbol.

**In this PR:**
* on mobile devices, removed '-' and added margin left to the read more button so it's moved right now. Because I can't define breakpoints and the way html is set up, I can't position '-' on the tablet and mobile devices correctly, I need one more breakpoints, otherwise it's not possible.
