### PR TITLE
#4261 - fixed text overflowing on second line on small devices

### DIFF
--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
@@ -22,9 +22,11 @@ import { STORE_IN_PICK_UP_METHOD_CODE } from 'Component/StoreInPickUp/StoreInPic
 import { BILLING_STEP } from 'Route/Checkout/Checkout.config';
 import { Addresstype } from 'Type/Account.type';
 import { PaymentMethodsType } from 'Type/Checkout.type';
-import { DeviceType } from 'Type/Device.type';
+import { RefType } from 'Type/Common.type';
 import { TotalsType } from 'Type/MiniCart.type';
 import { formatPrice } from 'Util/Price';
+
+import { SPAN_WIDTH_THRESHOLD } from './CheckoutBilling.config';
 
 import './CheckoutBilling.style';
 
@@ -54,7 +56,8 @@ export class CheckoutBilling extends PureComponent {
             checkbox_text: PropTypes.string
         })).isRequired,
         selectedShippingMethod: PropTypes.string.isRequired,
-        device: DeviceType.isRequired
+        spanRef: RefType.isRequired,
+        spanWidth: PropTypes.number.isRequired
     };
 
     static defaultProps = {
@@ -99,10 +102,9 @@ export class CheckoutBilling extends PureComponent {
         const {
             termsAreEnabled,
             termsAndConditions,
-            device: { isMobile }
+            spanRef,
+            spanWidth
         } = this.props;
-
-        console.log(isMobile);
 
         const {
             checkbox_text = __('I agree to terms and conditions')
@@ -138,7 +140,18 @@ export class CheckoutBilling extends PureComponent {
                       } }
                       mix={ { block: 'CheckoutBilling', elem: 'TermsAndConditions-Checkbox' } }
                     />
-                    { `${checkbox_text } ${!isMobile ? '-' : ''}` }
+                   <div>
+                    <span ref={ spanRef }>
+                      { `${checkbox_text } ` }
+                      <small
+                        block="CheckoutBilling"
+                        elem="Divider-Symbol"
+                        mods={ { isTextDivided: !!(spanWidth < SPAN_WIDTH_THRESHOLD) } }
+                      >
+                        -
+                      </small>
+                    </span>
+                   </div>
                 </label>
                 <button
                   block="CheckoutBilling"

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
@@ -22,6 +22,7 @@ import { STORE_IN_PICK_UP_METHOD_CODE } from 'Component/StoreInPickUp/StoreInPic
 import { BILLING_STEP } from 'Route/Checkout/Checkout.config';
 import { Addresstype } from 'Type/Account.type';
 import { PaymentMethodsType } from 'Type/Checkout.type';
+import { DeviceType } from 'Type/Device.type';
 import { TotalsType } from 'Type/MiniCart.type';
 import { formatPrice } from 'Util/Price';
 
@@ -52,7 +53,8 @@ export class CheckoutBilling extends PureComponent {
         termsAndConditions: PropTypes.arrayOf(PropTypes.shape({
             checkbox_text: PropTypes.string
         })).isRequired,
-        selectedShippingMethod: PropTypes.string.isRequired
+        selectedShippingMethod: PropTypes.string.isRequired,
+        device: DeviceType.isRequired
     };
 
     static defaultProps = {
@@ -96,8 +98,11 @@ export class CheckoutBilling extends PureComponent {
     renderTermsAndConditions() {
         const {
             termsAreEnabled,
-            termsAndConditions
+            termsAndConditions,
+            device: { isMobile }
         } = this.props;
+
+        console.log(isMobile);
 
         const {
             checkbox_text = __('I agree to terms and conditions')
@@ -133,7 +138,7 @@ export class CheckoutBilling extends PureComponent {
                       } }
                       mix={ { block: 'CheckoutBilling', elem: 'TermsAndConditions-Checkbox' } }
                     />
-                    { `${checkbox_text } - ` }
+                    { `${checkbox_text } ${!isMobile ? '-' : ''}` }
                 </label>
                 <button
                   block="CheckoutBilling"

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
@@ -141,7 +141,11 @@ export class CheckoutBilling extends PureComponent {
                       mix={ { block: 'CheckoutBilling', elem: 'TermsAndConditions-Checkbox' } }
                     />
                    <div>
-                    <span ref={ spanRef }>
+                    <span
+                      block="CheckoutBilling"
+                      elem="TACText"
+                      ref={ spanRef }
+                    >
                       { `${checkbox_text } ` }
                       <small
                         block="CheckoutBilling"
@@ -158,6 +162,7 @@ export class CheckoutBilling extends PureComponent {
                   elem="TACLink"
                   onClick={ this.handleShowPopup }
                   type="button"
+                  mods={ { isTransformed: !!(spanWidth < SPAN_WIDTH_THRESHOLD) } }
                 >
                         { __('read more') }
                 </button>

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.config.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.config.js
@@ -1,0 +1,14 @@
+/* eslint-disable import/prefer-default-export */
+
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export const SPAN_WIDTH_THRESHOLD = 150;

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -123,6 +123,9 @@ export class CheckoutBillingContainer extends PureComponent {
 
     componentDidMount() {
         const spanWidth = this.spanRef.current.getBoundingClientRect().width;
+
+        console.log(this.spanRef.current.getBoundingClientRect());
+
         this.setState({ spanWidth });
     }
 

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -10,7 +10,7 @@
  */
 
 import PropTypes from 'prop-types';
-import { PureComponent } from 'react';
+import { createRef, PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import { KLARNA, PURCHASE_ORDER } from 'Component/CheckoutPayments/CheckoutPayments.config';
@@ -22,7 +22,6 @@ import { showNotification } from 'Store/Notification/Notification.action';
 import { showPopup } from 'Store/Popup/Popup.action';
 import { Addresstype, CustomerType } from 'Type/Account.type';
 import { PaymentMethodsType } from 'Type/Checkout.type';
-import { DeviceType } from 'Type/Device.type';
 import { TotalsType } from 'Type/MiniCart.type';
 import {
     getFormFields,
@@ -42,8 +41,7 @@ export const mapStateToProps = (state) => ({
     termsAreEnabled: state.ConfigReducer.terms_are_enabled,
     termsAndConditions: state.ConfigReducer.checkoutAgreements,
     addressLinesQty: state.ConfigReducer.address_lines_quantity,
-    cartTotalSubPrice: getCartTotalSubPrice(state),
-    device: state.ConfigReducer.device
+    cartTotalSubPrice: getCartTotalSubPrice(state)
 });
 
 /** @namespace Component/CheckoutBilling/Container/mapDispatchToProps */
@@ -72,14 +70,15 @@ export class CheckoutBillingContainer extends PureComponent {
         cartTotalSubPrice: PropTypes.number,
         setDetailsStep: PropTypes.func.isRequired,
         setLoading: PropTypes.func.isRequired,
-        termsAreEnabled: PropTypes.bool,
-        device: DeviceType.isRequired
+        termsAreEnabled: PropTypes.bool
     };
 
     static defaultProps = {
         termsAreEnabled: false,
         cartTotalSubPrice: null
     };
+
+    spanRef = createRef();
 
     static getDerivedStateFromProps(props, state) {
         const { paymentMethod, prevPaymentMethods } = state;
@@ -117,8 +116,14 @@ export class CheckoutBillingContainer extends PureComponent {
             isSameAsShipping: this.isSameShippingAddress(customer),
             selectedCustomerAddressId: 0,
             prevPaymentMethods: paymentMethods,
-            paymentMethod
+            paymentMethod,
+            spanWidth: 0
         };
+    }
+
+    componentDidMount() {
+        const spanWidth = this.spanRef.current.getBoundingClientRect().width;
+        this.setState({ spanWidth });
     }
 
     containerProps() {
@@ -131,10 +136,9 @@ export class CheckoutBillingContainer extends PureComponent {
             shippingAddress,
             termsAndConditions,
             termsAreEnabled,
-            totals,
-            device
+            totals
         } = this.props;
-        const { isSameAsShipping } = this.state;
+        const { isSameAsShipping, spanWidth } = this.state;
 
         return {
             cartTotalSubPrice,
@@ -144,10 +148,11 @@ export class CheckoutBillingContainer extends PureComponent {
             setDetailsStep,
             setLoading,
             shippingAddress,
+            spanRef: this.spanRef,
             termsAndConditions,
             termsAreEnabled,
             totals,
-            device
+            spanWidth
         };
     }
 

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -22,6 +22,7 @@ import { showNotification } from 'Store/Notification/Notification.action';
 import { showPopup } from 'Store/Popup/Popup.action';
 import { Addresstype, CustomerType } from 'Type/Account.type';
 import { PaymentMethodsType } from 'Type/Checkout.type';
+import { DeviceType } from 'Type/Device.type';
 import { TotalsType } from 'Type/MiniCart.type';
 import {
     getFormFields,
@@ -41,7 +42,8 @@ export const mapStateToProps = (state) => ({
     termsAreEnabled: state.ConfigReducer.terms_are_enabled,
     termsAndConditions: state.ConfigReducer.checkoutAgreements,
     addressLinesQty: state.ConfigReducer.address_lines_quantity,
-    cartTotalSubPrice: getCartTotalSubPrice(state)
+    cartTotalSubPrice: getCartTotalSubPrice(state),
+    device: state.ConfigReducer.device
 });
 
 /** @namespace Component/CheckoutBilling/Container/mapDispatchToProps */
@@ -70,7 +72,8 @@ export class CheckoutBillingContainer extends PureComponent {
         cartTotalSubPrice: PropTypes.number,
         setDetailsStep: PropTypes.func.isRequired,
         setLoading: PropTypes.func.isRequired,
-        termsAreEnabled: PropTypes.bool
+        termsAreEnabled: PropTypes.bool,
+        device: DeviceType.isRequired
     };
 
     static defaultProps = {
@@ -128,7 +131,8 @@ export class CheckoutBillingContainer extends PureComponent {
             shippingAddress,
             termsAndConditions,
             termsAreEnabled,
-            totals
+            totals,
+            device
         } = this.props;
         const { isSameAsShipping } = this.state;
 
@@ -142,7 +146,8 @@ export class CheckoutBillingContainer extends PureComponent {
             shippingAddress,
             termsAndConditions,
             termsAreEnabled,
-            totals
+            totals,
+            device
         };
     }
 

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
@@ -52,6 +52,10 @@
         display: flex;
         align-items: center;
 
+        @include mobile {
+            margin-inline-end: 1rem;
+        }
+
         &:hover {
             cursor: pointer;
             
@@ -60,15 +64,22 @@
             }
         }
     }
+    
+
 
     &-TACLink {
         font-size: 14px;
         font-weight: 700;
         color: var(--link-color);
-        margin-inline-start: 0.5em;
+        margin-inline-start: 0.25em;
         display: flex;
         cursor: pointer;
+        white-space: nowrap;
 
+        @include mobile {
+            margin-inline-start: auto;
+        }
+        
         &:hover {
             text-decoration: underline;
         }

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
@@ -53,18 +53,18 @@
         align-items: center;
         padding-inline-end: 1em;
 
-        span {
-            @include mobile {
-                position: unset;
-            }
-        }
-
         &:hover {
             cursor: pointer;
             
             @include desktop {
                 color: var(--primary-base-color);
             }
+        }
+    }
+    
+    &-TACText {
+        @include mobile {
+            position: unset;
         }
     }
 
@@ -75,7 +75,7 @@
         transform: translate(-50%, -50%);
 
         &_isTextDivided {
-            inset-inline-start: 95%;
+            inset-inline-start: calc(140px + 1.5em);
         }
     }
 
@@ -86,6 +86,11 @@
         color: var(--link-color);
         display: flex;
         cursor: pointer;
+        white-space: nowrap;
+
+        &_isTransformed {
+            inset-inline-start: calc(-80% + 205px);
+        }
 
         &:hover {
             text-decoration: underline;
@@ -93,6 +98,17 @@
 
         &:focus {
             text-decoration: underline;
+        }
+    }
+
+    &-TACPlaceholder {
+        display: none;
+        width: 68px;
+        width: 1px;
+        background-color: transparent;
+
+        &_isPlaceHolderDisplayed {
+            display: block;
         }
     }
 

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.style.scss
@@ -51,9 +51,12 @@
     &-TACLabel {
         display: flex;
         align-items: center;
+        padding-inline-end: 1em;
 
-        @include mobile {
-            margin-inline-end: 1rem;
+        span {
+            @include mobile {
+                position: unset;
+            }
         }
 
         &:hover {
@@ -64,22 +67,26 @@
             }
         }
     }
-    
 
+    &-Divider-Symbol {
+        position: absolute;
+        inset-inline-start: calc(100% + 1em);
+        inset-block-start: 50%;
+        transform: translate(-50%, -50%);
+
+        &_isTextDivided {
+            inset-inline-start: 95%;
+        }
+    }
 
     &-TACLink {
         font-size: 14px;
         font-weight: 700;
+        margin-inline-start: 0.5em;
         color: var(--link-color);
-        margin-inline-start: 0.25em;
         display: flex;
         cursor: pointer;
-        white-space: nowrap;
 
-        @include mobile {
-            margin-inline-start: auto;
-        }
-        
         &:hover {
             text-decoration: underline;
         }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4261

**Problem:**
* The problem was that when going on small devices, terms and conditions text were stretching on two lines and so did the '-' symbol.
* 
**In this PR:**
* on mobile devices, removed '-' and added margin left to the read more button so it's moved right now. Because I can't define breakpoints and the way html is set up, I can't position '-' on the tablet and mobile devices correctly, I need one more breakpoints, otherwise it's not possible.
