### PR TITLE
#4521  - added padding top swatchlist

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
@@ -134,6 +134,7 @@
 
                 &-PriceWrapper {
                     flex-grow: unset;
+                    margin-block-end: 16px;
                 }
 
                 &-WishListButton {

--- a/packages/scandipwa/src/component/ProductConfigurableAttributes/ProductConfigurableAttributes.style.scss
+++ b/packages/scandipwa/src/component/ProductConfigurableAttributes/ProductConfigurableAttributes.style.scss
@@ -42,7 +42,6 @@
         align-items: center;
         padding-inline-start: 3px;
         padding-block-start: 3px;
-        margin-block-start: 16px;
 
         &_isUnselected {
             animation: var(--shake-animation);


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4521

**Problem:**
* Padding between price and options was missing in product card on PLP if layout is set to list view

**In this PR:**
* Added margin-top 16px
