### PR TITLE
[4364] - Background is no longer visible in dropdown lists

### DIFF
--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.component.js
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.component.js
@@ -157,7 +157,7 @@ export class FieldSelect extends PureComponent {
                   isNotScrollable: !isScrollable
               } }
             >
-                { options.map(this.renderOption.bind(this)) }
+                <div>{ options.map(this.renderOption.bind(this)) }</div>
             </ul>
         );
     }

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -66,7 +66,7 @@ $select-arrow-width: 14px !default;
         inset-block-start: 100%;
         inset-inline-start: 0;
         z-index: 40;
-        overflow-y: scroll;
+        overflow-y: auto;
         border-style: solid;
         border-width: 0 1px 1px;
         border-color: transparent;
@@ -77,6 +77,11 @@ $select-arrow-width: 14px !default;
         min-width: 100%;
 
         &_isExpanded {
+            > div {
+                max-height: 50vh;
+                overflow-y: auto;
+            }
+
             @include desktop {
                 z-index: 15;
                 max-height: fit-content;

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -78,13 +78,13 @@ $select-arrow-width: 14px !default;
 
         &_isExpanded {
             > div {
-                max-height: 50vh;
+                max-height: calc(#{$select-option-height} * 5);
                 overflow-y: auto;
             }
 
             @include desktop {
                 z-index: 15;
-                max-height: calc(#{$select-option-height} * 5);
+                max-height: fit-content;
                 border-color: var(--input-border-color);
                 background-color: #{$white};
             }
@@ -98,10 +98,6 @@ $select-arrow-width: 14px !default;
 
         &_isNotScrollable {
             overflow-y: hidden;
-
-            &[class*="isExpanded"] {
-                max-height: fit-content;
-            }
 
             // Firefox support
             /* stylelint-disable-next-line declaration-no-important */


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4364

**Problem:**
* Background is visible in dropdown lists
Issue couldn't be produced directly. It's shown in this [comment](https://github.com/scandipwa/scandipwa/issues/4364#issuecomment-1075339302) with pics 

**In this PR:**
* Wrapped the list items with a div to which I specified max-height and auto overflow
* Changed the parent's overflow to auto
By this, I made dropdown lists support any number of options + no visible background.
