### PR TITLE
Fixed shipping method to stay on same line

### DIFF
--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
@@ -82,7 +82,7 @@
 
     &-Row {
         strong {
-            display: inline-block;
+            display: inline;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4541 

**Problem:**
* Shipping method title and rate wrap to second line if they are long

**In this PR:**
* Fixed so it stay on the same line
