### PR TITLE
fixed buttons in cart when resizing

### DIFF
--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.style.scss
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.style.scss
@@ -24,7 +24,7 @@
         flex-direction: column;
         justify-content: center;
     }
-    
+
     &-MessageText {
         margin: 0;
         word-break: break-word;
@@ -91,9 +91,7 @@
         }
 
         @include tablet-portrait {
-            width: 100%;
             margin-inline-start: 0;
-            margin-block-start: 10px;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4529 

**Problem:**
* Buttons in cart page shifted down and submit button was filling 100% of available space in 1020 size, but in local PC this behavior was seen in 850px

**In this PR:**
* removed some properties for submit button which caused this bug
