### PR TITLE
[3230] - IOS-RTL: Fixed the icon in Add to home screen banner

### DIFF
--- a/packages/scandipwa/src/style/abstract/_icons.scss
+++ b/packages/scandipwa/src/style/abstract/_icons.scss
@@ -65,6 +65,10 @@
         inset-block-start: -9px;
         transform: rotate(45deg);
         width: 6px;
+
+        [dir="rtl"] & {
+            transform: rotate(315deg);
+        }
     }
 
     &::after {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3230

**Problem:**
* iOS: RTL: Icon is broken in Add to home screen banner

**In this PR:**
* Rotate 315deg
