### PR TITLE
#4543 - correct error message spacing on pdp

### DIFF
--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
@@ -47,7 +47,7 @@
     }
 
     &-Select.Field_hasError {
-        margin-block-end: 20px;
+        margin-block-end: 16px;
     }
 
     &-PriceLabel {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4543

**Problem:**
* Big margin was displayed between dropdown and error message for bundle product on PDP

**In this PR:**
* Changed padding
