### PR TITLE
removed propery which replaced loader to the bottom of a card in mywishlist mobile

### DIFF
--- a/packages/scandipwa/src/route/MyAccount/MyAccount.style.scss
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.style.scss
@@ -66,17 +66,6 @@
                     }
                 }
             }
-
-            &_my-wishlist,
-            &_my-orders {
-                .Loader {
-                    &-Scale { 
-                        @include mobile {
-                            inset-block-start: 35vh;
-                        }
-                    }
-                }
-            }
         }
 
         @include mobile {


### PR DESCRIPTION

**Related issue(s):**
* Fixes #4558 

**Problem:**
* Loader in MyWish item and in MyOrders table was shifted to the bottom of components

**In this PR:**
* Removed property that replaced the loader to the bottom
