### PR TITLE
Fixed product description not shown if only image

### DIFF
--- a/packages/scandipwa/src/component/ProductInformation/ProductInformation.component.js
+++ b/packages/scandipwa/src/component/ProductInformation/ProductInformation.component.js
@@ -77,7 +77,7 @@ export class ProductInformation extends PureComponent {
 
         // check if at least one HTML element has content
         const elementsWithContent = Array.from(document.body.children).filter(
-            (element) => element.innerText !== '' || element.nodeName === 'IMG'
+            (element) => element.innerHTML !== '' || element.nodeName === 'IMG'
         );
 
         return elementsWithContent.length === 0;

--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -281,7 +281,7 @@ export class ProductPageContainer extends PureComponent {
         const { description: { html = '' } = {} } = this.getDataSource();
         // handling cases when empty html tag is received
         const htmlElement = new DOMParser().parseFromString(html, 'text/html');
-        return !htmlElement?.body?.innerText;
+        return !htmlElement?.body?.innerHTML;
     }
 
     isProductAttributesTabEmpty() {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4480 

**Problem:**
* Description (About tab) was not shown if the description contains only an image
* state isInformationTabEmpty is true in this case

**In this PR:**
* Fixed the function isProductInformationTabEmpty to return false if HTML contain only image
* now about tab show even if it is only an image
