### PR TITLE
Fixed Colon after qty moved down on IOS

### DIFF
--- a/packages/scandipwa/src/component/MyAccountOrderItemsTableRow/MyAccountOrderItemsTableRow.style.scss
+++ b/packages/scandipwa/src/component/MyAccountOrderItemsTableRow/MyAccountOrderItemsTableRow.style.scss
@@ -94,6 +94,7 @@
                         &::after {
                             content: ":";
                             display: inline-block;
+                            vertical-align: top;
                         }
                     }
                 }


### PR DESCRIPTION
**Related issue(s):**
* #4548 

**Problem:**
* Colon after qty of ordered item drop down on IOS if there is multiple lines

**In this PR:**
* Fix so it is stay top