### PR TITLE
added check for attributes if they have attribute_values

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -247,9 +247,8 @@ export class ProductCard extends Product {
         const configureConfig = (type === PRODUCT_TYPE.configurable
             // eslint-disable-next-line max-len
             && Object.keys(super.getConfigurableAttributes()).length !== Object.keys(this.getConfigurableAttributes()).length)
-            || (type === PRODUCT_TYPE.configurable
-                && Object.values(this.getConfigurableAttributes())
-                    .some((value) => value.attribute_values.length === 0));
+            // eslint-disable-next-line max-len
+            || (type === PRODUCT_TYPE.configurable && Object.values(this.getConfigurableAttributes()).some((value) => value.attribute_values.length === 0));
         const configureCustomize = options.some(({ required = false }) => required);
         const configureDownloadableLinks = PRODUCT_TYPE.downloadable && links_purchased_separately === 1;
 

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -246,7 +246,10 @@ export class ProductCard extends Product {
         const configureBundleAndGrouped = type === PRODUCT_TYPE.bundle || type === PRODUCT_TYPE.grouped;
         const configureConfig = (type === PRODUCT_TYPE.configurable
             // eslint-disable-next-line max-len
-            && Object.keys(super.getConfigurableAttributes()).length !== Object.keys(this.getConfigurableAttributes()).length) || (type === PRODUCT_TYPE.configurable && Object.values(this.getConfigurableAttributes()).some((value) => value.attribute_values.length === 0));
+            && Object.keys(super.getConfigurableAttributes()).length !== Object.keys(this.getConfigurableAttributes()).length)
+            || (type === PRODUCT_TYPE.configurable
+                && Object.values(this.getConfigurableAttributes())
+                    .some((value) => value.attribute_values.length === 0));
         const configureCustomize = options.some(({ required = false }) => required);
         const configureDownloadableLinks = PRODUCT_TYPE.downloadable && links_purchased_separately === 1;
 

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -244,9 +244,9 @@ export class ProductCard extends Product {
         } = this.props;
 
         const configureBundleAndGrouped = type === PRODUCT_TYPE.bundle || type === PRODUCT_TYPE.grouped;
-        const configureConfig = type === PRODUCT_TYPE.configurable
+        const configureConfig = (type === PRODUCT_TYPE.configurable
             // eslint-disable-next-line max-len
-            && Object.keys(super.getConfigurableAttributes()).length !== Object.keys(this.getConfigurableAttributes()).length;
+            && Object.keys(super.getConfigurableAttributes()).length !== Object.keys(this.getConfigurableAttributes()).length) || (type === PRODUCT_TYPE.configurable && Object.values(this.getConfigurableAttributes()).some((value) => value.attribute_values.length === 0));
         const configureCustomize = options.some(({ required = false }) => required);
         const configureDownloadableLinks = PRODUCT_TYPE.downloadable && links_purchased_separately === 1;
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4506 

**Problem:**
* User didn't redirect from PLP if the visual_swatch or text attribute was inside PDP 

**In this PR:**
* Added check condition if there is value for attribute in PLP 
