### PR TITLE
List item text doesn't overlap bullet and number

### DIFF
--- a/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
@@ -115,7 +115,7 @@
             &::before {
                 position: relative;
                 margin-inline-start: 10px;
-                margin-inline-end: -25px;
+                margin-inline-end: 5px;
                 inset-block-start: -1px;
             }
         }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4573

**Problem:**
* Text hovers on bullets and numeration

**In this PR:**
* Bullets, numbers and list items are separated now
