### PR TITLE
Fixes Never-Ending loader if user canceled second file input

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -485,6 +485,6 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://demo100-ors-1588667385-csa-hcx.scandipwa.cloud/",
+    "proxy": "https://scandipwapmrev.indvp.com/",
     "gitHead": "187276597fcf17521bcccdac1238b4e0061e5418"
 }

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -485,6 +485,6 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://scandipwapmrev.indvp.com/",
+    "proxy": "https://demo100-ors-1588667385-csa-hcx.scandipwa.cloud/",
     "gitHead": "187276597fcf17521bcccdac1238b4e0061e5418"
 }

--- a/packages/scandipwa/src/component/FieldFile/FieldFile.container.js
+++ b/packages/scandipwa/src/component/FieldFile/FieldFile.container.js
@@ -55,11 +55,11 @@ export class FieldFileContainer extends PureComponent {
         if (this.fieldRef) {
             const { files } = this.fieldRef;
             this.setState({ isLoading: true });
-            const { name } = files[0] ? files[0] : '';
+            const { name } = files[0] || {};
 
             if (!name) {
                 this.setState({
-                    fileName: name,
+                    fileName: '',
                     isLoading: false
                 });
 

--- a/packages/scandipwa/src/component/FieldFile/FieldFile.container.js
+++ b/packages/scandipwa/src/component/FieldFile/FieldFile.container.js
@@ -55,8 +55,17 @@ export class FieldFileContainer extends PureComponent {
         if (this.fieldRef) {
             const { files } = this.fieldRef;
             this.setState({ isLoading: true });
+            const { name } = files[0] ? files[0] : '';
 
-            const { name } = files[0];
+            if (!name) {
+                this.setState({
+                    fileName: name,
+                    isLoading: false
+                });
+
+                return;
+            }
+
             const reader = new FileReader();
             reader.onload = () => {
                 this.setState({


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3511 

**Problem:**
* File input display an infinite loader (+ and error in console) if user canceled the input on the second time

**In this PR:**
* Fixes the error but checking if there is a file input or not
