### PR TITLE
#4513 - corrected loading of the product page

### DIFF
--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -497,14 +497,9 @@ export class ProductPageContainer extends PureComponent {
             return;
         }
 
-        /**
-         * Skip loading the same product SKU the second time
-         */
-        if (currentProductSKU === productSKU) {
-            return;
+        if (currentProductSKU !== productSKU) {
+            this.setState({ currentProductSKU: productSKU });
         }
-
-        this.setState({ currentProductSKU: productSKU });
 
         const options = {
             isSingleProduct: true,


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4513

**Problem:**
* PDP was stuck after the second page load

**In this PR:**
* Changed how componentDidUpdate is handled. instead of not requested product, the product is always being requested, however state, won't be updated if currentProductSKU === productSKU
