### PR TITLE
Only one error message appears while updating password on reset passw…

### DIFF
--- a/packages/scandipwa/src/component/PasswordChangeForm/PasswordChangeForm.component.js
+++ b/packages/scandipwa/src/component/PasswordChangeForm/PasswordChangeForm.component.js
@@ -26,13 +26,18 @@ export class PasswordChangeForm extends FieldForm {
         minimunPasswordCharacter: PropTypes.string.isRequired
     };
 
+    __construct(props) {
+        super.__construct(props);
+        this.passwordRef = React.createRef('');
+    }
+
     get fieldMap() {
         const {
             range,
             minimunPasswordCharacter
         } = this.props;
 
-        return customerEmailAndPasswordFields(range, minimunPasswordCharacter);
+        return customerEmailAndPasswordFields(range, minimunPasswordCharacter, this.passwordRef);
     }
 
     getFormProps() {

--- a/packages/scandipwa/src/component/PasswordChangeForm/PasswordChangeForm.form.js
+++ b/packages/scandipwa/src/component/PasswordChangeForm/PasswordChangeForm.form.js
@@ -51,7 +51,8 @@ export const customerEmailAndPasswordFields = (range, minimunPasswordCharacter) 
             inputType: VALIDATION_INPUT_TYPE.password,
             match: (value) => {
                 const password = document.getElementById('password');
-                return password.value === value;
+                const password_confirmation = document.getElementById('password_confirmation');
+                return password.value === value || password_confirmation.value === '';
             },
             customErrorMessages: {
                 onMatchFail: __('Passwords do not match!')

--- a/packages/scandipwa/src/component/PasswordChangeForm/PasswordChangeForm.form.js
+++ b/packages/scandipwa/src/component/PasswordChangeForm/PasswordChangeForm.form.js
@@ -51,8 +51,7 @@ export const customerEmailAndPasswordFields = (range, minimunPasswordCharacter) 
             inputType: VALIDATION_INPUT_TYPE.password,
             match: (value) => {
                 const password = document.getElementById('password');
-                const password_confirmation = document.getElementById('password_confirmation');
-                return password.value === value || password_confirmation.value === '';
+                return value && password.value === value;
             },
             customErrorMessages: {
                 onMatchFail: __('Passwords do not match!')

--- a/packages/scandipwa/src/component/PasswordChangeForm/PasswordChangeForm.form.js
+++ b/packages/scandipwa/src/component/PasswordChangeForm/PasswordChangeForm.form.js
@@ -18,10 +18,11 @@ import { VALIDATION_INPUT_TYPE } from 'Util/Validator/Config';
  * @param props
  * @returns {[{addRequiredTag: boolean, validateOn: string[], validationRule: {isRequired: boolean}, label: *, type: string, attr: {defaultValue, name: string, placeholder: *}}, {addRequiredTag: boolean, validateOn: string[], validationRule: {isRequired: boolean}, label: *, type: string, attr: {defaultValue, name: string, placeholder: *}}, ...[{addRequiredTag: boolean, validateOn: string[], validationRule: {isRequired: boolean}, label: *, type: string, attr: {defaultValue, name: string, placeholder: *}}]|*[]]}
  * @namespace Component/PasswordChangeForm/Form/customerEmailAndPasswordFields */
-export const customerEmailAndPasswordFields = (range, minimunPasswordCharacter) => [
+export const customerEmailAndPasswordFields = (range, minimunPasswordCharacter, passwordRef) => [
     {
         type: FIELD_TYPE.password,
         label: __('New password'),
+        elemRef: passwordRef,
         attr: {
             id: 'password',
             name: 'password',
@@ -50,7 +51,7 @@ export const customerEmailAndPasswordFields = (range, minimunPasswordCharacter) 
             isRequired: true,
             inputType: VALIDATION_INPUT_TYPE.password,
             match: (value) => {
-                const password = document.getElementById('password');
+                const password = passwordRef.current;
                 return value && password.value === value;
             },
             customErrorMessages: {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4497

**Problem:**
* Two error messages appear below Confirm password field on reset password page if user submitted form without confirm new password

**In this PR:**
* When confirm password field is empty only one error ('field is required') appears instead of both errors.
