### PR TITLE
#4530 List/Grid icons and Sort by dropdown is shifted left on PLP

### DIFF
--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -42,7 +42,7 @@ $select-arrow-width: 14px !default;
 
     &-Select {
         width: 100%;
-        margin-block-start: -3px;
+        margin-block-start: -2px;
         padding-inline-end: 40px;
         min-height: 30px;
         height: 48px;

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -42,9 +42,9 @@ $select-arrow-width: 14px !default;
 
     &-Select {
         width: 100%;
+        margin-block-start: -3px;
         padding-inline-end: 40px;
         min-height: 30px;
-        margin-block: calc(var(--input-padding) + 3px);
         height: 48px;
 
         @include desktop {

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
@@ -412,20 +412,26 @@ export class CategoryPage extends PureComponent {
         return (
             <aside block="CategoryPage" elem="Miscellaneous">
                 { this.renderItemsCount() }
+
                 <div
                   block="CategoryPage"
-                  elem="LayoutWrapper"
-                  mods={ { isPrerendered: isSSR() || isCrawler() } }
+                  elem="MiscellaneousLayoutWrapper"
                 >
-                    { this.renderLayoutButtons() }
-                    { this.renderCategorySort() }
-                </div>
-                <div
-                  block="CategoryPage"
-                  elem="LayoutWrapper"
-                  mods={ { isPrerendered: isSSR() || isCrawler() } }
-                >
-                    { this.renderFilterButton() }
+                  <div
+                    block="CategoryPage"
+                    elem="LayoutWrapper"
+                    mods={ { isPrerendered: isSSR() || isCrawler() } }
+                  >
+                      { this.renderLayoutButtons() }
+                      { this.renderCategorySort() }
+                  </div>
+                  <div
+                    block="CategoryPage"
+                    elem="LayoutWrapper"
+                    mods={ { isPrerendered: isSSR() || isCrawler() } }
+                  >
+                      { this.renderFilterButton() }
+                  </div>
                 </div>
             </aside>
         );

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
@@ -412,7 +412,6 @@ export class CategoryPage extends PureComponent {
         return (
             <aside block="CategoryPage" elem="Miscellaneous">
                 { this.renderItemsCount() }
-
                 <div
                   block="CategoryPage"
                   elem="MiscellaneousLayoutWrapper"

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.style.scss
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.style.scss
@@ -59,6 +59,7 @@
 
     &-ItemsCount {
         padding: 0;
+        margin-block-start: -2px;
 
         @include mobile {
             order: 1;

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.style.scss
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.style.scss
@@ -107,6 +107,14 @@
         white-space: pre;
     }
 
+    &-MiscellaneousLayoutWrapper {
+        @include mobile {
+            display: flex;
+            justify-content: space-between;
+            width: 100%;
+        }
+    }
+
     &-Miscellaneous {
         z-index: 1;
         display: flex;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4530

**Problem:**
* List/Grid icons and Sort by dropdown is shifted left on PLP

**In this PR:**
* Aligned all items and fixed mobile version 
