### PR TITLE
[3146] - Aligned Compare's close-buttons with their product's title

### DIFF
--- a/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.style.scss
+++ b/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.style.scss
@@ -78,5 +78,6 @@
     &-CloseBtn {
         inset-inline-end: 0;
         position: absolute;
+        margin-block-start: -5px;
     }
 }

--- a/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.style.scss
+++ b/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.style.scss
@@ -78,6 +78,6 @@
     &-CloseBtn {
         inset-inline-end: 0;
         position: absolute;
-        margin-block-start: -5px;
+        margin-block-start: -4px;
     }
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3146

**Problem:**
* Cross sign shifted down in compare list around 2-3 pixels.

**In this PR:**
* Aligned Compare's close-buttons with their product's title
