### PR TITLE
#4035 Minus and plus button disabled if product only 1 in stock

### DIFF
--- a/packages/scandipwa/src/component/FieldNumber/FieldNumber.component.js
+++ b/packages/scandipwa/src/component/FieldNumber/FieldNumber.component.js
@@ -58,7 +58,7 @@ export class FieldNumber extends PureComponent {
                   disabled={ isDisabled }
                 />
                 <button
-                  disabled={ +value === max || isDisabled }
+                  disabled={ max === 1 || +value === max || isDisabled }
                   // eslint-disable-next-line react/jsx-no-bind
                   onClick={ () => handleValueChange(+value + 1) }
                   aria-label={ __('Add') }
@@ -67,7 +67,7 @@ export class FieldNumber extends PureComponent {
                     <AddIcon block="SubtractButton" isPrimary />
                 </button>
                 <button
-                  disabled={ +value === min || isDisabled }
+                  disabled={ min === 1 + +value || +value === min || isDisabled }
                   // eslint-disable-next-line react/jsx-no-bind
                   onClick={ () => handleValueChange(+value - 1) }
                   aria-label={ __('Subtract') }

--- a/packages/scandipwa/src/component/FieldNumber/FieldNumber.component.js
+++ b/packages/scandipwa/src/component/FieldNumber/FieldNumber.component.js
@@ -43,6 +43,8 @@ export class FieldNumber extends PureComponent {
             isDisabled
         } = this.props;
 
+        const numberValue = +value;
+
         return (
             <>
                 <input
@@ -58,18 +60,18 @@ export class FieldNumber extends PureComponent {
                   disabled={ isDisabled }
                 />
                 <button
-                  disabled={ max === 1 || +value === max || isDisabled }
+                  disabled={ max === 1 || numberValue === max || isDisabled }
                   // eslint-disable-next-line react/jsx-no-bind
-                  onClick={ () => handleValueChange(+value + 1) }
+                  onClick={ () => handleValueChange(numberValue + 1) }
                   aria-label={ __('Add') }
                   type={ FIELD_TYPE.button }
                 >
                     <AddIcon block="SubtractButton" isPrimary />
                 </button>
                 <button
-                  disabled={ min === 1 + +value || +value === min || isDisabled }
+                  disabled={ numberValue + 1 === min || numberValue === min || isDisabled }
                   // eslint-disable-next-line react/jsx-no-bind
-                  onClick={ () => handleValueChange(+value - 1) }
+                  onClick={ () => handleValueChange(numberValue - 1) }
                   aria-label={ __('Subtract') }
                   type={ FIELD_TYPE.button }
                 >


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4035

**Problem:**
* Minus button activated if product only 1 in stock available, and it is less than minimum salable quantity (= 2 items)

**In this PR:**
* Added checks to the minus and plus buttons
