### PR TITLE
[2816] - Fixed the instant redirect with warning message on reloading Checkout page and the brief appearances of an empty cart in /cart and order summary

### DIFF
--- a/packages/scandipwa/src/component/Router/Router.container.js
+++ b/packages/scandipwa/src/component/Router/Router.container.js
@@ -64,11 +64,11 @@ export const mapStateToProps = (state) => ({
 export const mapDispatchToProps = (dispatch) => ({
     updateMeta: (meta) => dispatch(updateMeta(meta)),
     updateConfigDevice: (device) => dispatch(updateConfigDevice(device)),
-    init: () => {
+    init: async () => {
         ConfigDispatcher.then(
             ({ default: dispatcher }) => dispatcher.handleData(dispatch)
         );
-        MyAccountDispatcher.then(
+        await MyAccountDispatcher.then(
             ({ default: dispatcher }) => dispatcher.handleCustomerDataOnInit(dispatch)
         );
         WishlistDispatcher.then(

--- a/packages/scandipwa/src/component/Router/Router.container.js
+++ b/packages/scandipwa/src/component/Router/Router.container.js
@@ -60,27 +60,31 @@ export const mapStateToProps = (state) => ({
     status_code: state.MetaReducer.status_code
 });
 
+/** @namespace Component/Router/Container/initFunction */
+export const initFunction = async (dispatch) => {
+    ConfigDispatcher.then(
+        ({ default: dispatcher }) => dispatcher.handleData(dispatch)
+    );
+
+    const { default: dispatcher } = await MyAccountDispatcher;
+    await dispatcher.handleCustomerDataOnInit(dispatch);
+
+    WishlistDispatcher.then(
+        ({ default: dispatcher }) => dispatcher.updateInitialWishlistData(dispatch)
+    );
+    CartDispatcher.then(
+        ({ default: dispatcher }) => dispatcher.updateInitialCartData(dispatch)
+    );
+    ProductCompareDispatcher.then(
+        ({ default: dispatcher }) => dispatcher.updateInitialProductCompareData(dispatch)
+    );
+};
+
 /** @namespace Component/Router/Container/mapDispatchToProps */
 export const mapDispatchToProps = (dispatch) => ({
     updateMeta: (meta) => dispatch(updateMeta(meta)),
     updateConfigDevice: (device) => dispatch(updateConfigDevice(device)),
-    init: async () => {
-        ConfigDispatcher.then(
-            ({ default: dispatcher }) => dispatcher.handleData(dispatch)
-        );
-        await MyAccountDispatcher.then(
-            ({ default: dispatcher }) => dispatcher.handleCustomerDataOnInit(dispatch)
-        );
-        WishlistDispatcher.then(
-            ({ default: dispatcher }) => dispatcher.updateInitialWishlistData(dispatch)
-        );
-        CartDispatcher.then(
-            ({ default: dispatcher }) => dispatcher.updateInitialCartData(dispatch)
-        );
-        ProductCompareDispatcher.then(
-            ({ default: dispatcher }) => dispatcher.updateInitialProductCompareData(dispatch)
-        );
-    }
+    init: () => initFunction(dispatch)
 });
 
 /** @namespace Component/Router/Container */

--- a/packages/scandipwa/src/route/CartPage/CartPage.component.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.component.js
@@ -36,7 +36,8 @@ export class CartPage extends PureComponent {
         hasOutOfStockProductsInCart: PropTypes.bool,
         onCouponCodeUpdate: PropTypes.func,
         onCartItemLoading: PropTypes.func,
-        device: DeviceType.isRequired
+        device: DeviceType.isRequired,
+        isCartLoading: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -51,10 +52,11 @@ export class CartPage extends PureComponent {
                 items,
                 quote_currency_code
             },
-            onCartItemLoading
+            onCartItemLoading,
+            isCartLoading
         } = this.props;
 
-        if (!items) {
+        if (!items || isCartLoading) {
             return <Loader isLoading />;
         }
 

--- a/packages/scandipwa/src/route/CartPage/CartPage.container.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.container.js
@@ -56,6 +56,7 @@ export const CartDispatcher = import(
 /** @namespace Route/CartPage/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     totals: state.CartReducer.cartTotals,
+    isCartLoading: state.CartReducer.isLoading,
     headerState: state.NavigationReducer[TOP_NAVIGATION_TYPE].navigationState,
     guest_checkout: state.ConfigReducer.guest_checkout,
     device: state.ConfigReducer.device,
@@ -93,7 +94,8 @@ export class CartPageContainer extends PureComponent {
         guest_checkout: PropTypes.bool.isRequired,
         history: HistoryType.isRequired,
         totals: TotalsType.isRequired,
-        device: DeviceType.isRequired
+        device: DeviceType.isRequired,
+        isCartLoading: PropTypes.bool.isRequired
     };
 
     containerFunctions = {
@@ -153,7 +155,8 @@ export class CartPageContainer extends PureComponent {
             totals: {
                 items = []
             } = {},
-            device
+            device,
+            isCartLoading
         } = this.props;
 
         const { isCartItemLoading } = this.state;
@@ -162,7 +165,8 @@ export class CartPageContainer extends PureComponent {
             hasOutOfStockProductsInCart: this.hasOutOfStockProductsInCartItems(items),
             totals,
             isCartItemLoading,
-            device
+            device,
+            isCartLoading
         };
     }
 

--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -113,7 +113,8 @@ export class Checkout extends PureComponent {
         onShippingMethodSelect: PropTypes.func.isRequired,
         onStoreSelect: PropTypes.func.isRequired,
         selectedStoreAddress: StoreType,
-        isSignedIn: PropTypes.bool.isRequired
+        isSignedIn: PropTypes.bool.isRequired,
+        isCartLoading: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -350,6 +351,14 @@ export class Checkout extends PureComponent {
         return <Loader isLoading={ isLoading } />;
     }
 
+    renderFullPageLoader() {
+        return (
+            <main block="Checkout" elem="FullPageLoader">
+                <Loader isLoading />
+            </main>
+        );
+    }
+
     renderSummary(showOnMobile = false) {
         const {
             checkoutTotals,
@@ -454,6 +463,12 @@ export class Checkout extends PureComponent {
     }
 
     render() {
+        const { isCartLoading } = this.props;
+
+        if (isCartLoading) {
+            return this.renderFullPageLoader();
+        }
+
         return (
             <main block="Checkout">
                 <ContentWrapper

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -224,9 +224,9 @@ export class CheckoutContainer extends PureComponent {
             isGuestNotAllowDownloadable
         } = this.props;
 
-        this.handleRedirectIfNoItemsInCart();
-
         const { email } = this.state;
+
+        this.handleRedirectIfNoItemsInCart();
 
         // if guest checkout is disabled and user is not logged in => throw him to homepage
         if (!guest_checkout && !isSignedIn()) {

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -63,6 +63,7 @@ export const CheckoutDispatcher = import(
 /** @namespace Route/Checkout/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     totals: state.CartReducer.cartTotals,
+    isCartLoading: state.CartReducer.isLoading,
     cartTotalSubPrice: getCartTotalSubPrice(state),
     customer: state.MyAccountReducer.customer,
     guest_checkout: state.ConfigReducer.guest_checkout,
@@ -148,7 +149,8 @@ export class CheckoutContainer extends PureComponent {
         cartTotalSubPrice: PropTypes.number,
         isInStoreActivated: PropTypes.bool.isRequired,
         isGuestNotAllowDownloadable: PropTypes.bool.isRequired,
-        isSignedIn: PropTypes.bool.isRequired
+        isSignedIn: PropTypes.bool.isRequired,
+        isCartLoading: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -217,21 +219,14 @@ export class CheckoutContainer extends PureComponent {
     componentDidMount() {
         const {
             history,
-            showInfoNotification,
             guest_checkout,
             updateMeta,
-            isGuestNotAllowDownloadable,
-            totals: {
-                items = []
-            }
+            isGuestNotAllowDownloadable
         } = this.props;
 
-        const { email } = this.state;
+        this.handleRedirectIfNoItemsInCart();
 
-        if (!items.length) {
-            showInfoNotification(__('Please add at least one product to cart!'));
-            history.push(appendWithStoreCode('/cart'));
-        }
+        const { email } = this.state;
 
         // if guest checkout is disabled and user is not logged in => throw him to homepage
         if (!guest_checkout && !isSignedIn()) {
@@ -255,6 +250,8 @@ export class CheckoutContainer extends PureComponent {
         const { match: { params: { step: prevUrlStep } } } = prevProps;
         const { email } = this.state;
         const { email: prevEmail } = prevState;
+
+        this.handleRedirectIfNoItemsInCart();
 
         // Handle going back from billing to shipping
         if (/shipping/.test(urlStep) && /billing/.test(prevUrlStep)) {
@@ -331,6 +328,22 @@ export class CheckoutContainer extends PureComponent {
             },
             this._handleError
         );
+    }
+
+    handleRedirectIfNoItemsInCart() {
+        const {
+            totals: {
+                items = []
+            },
+            isCartLoading,
+            showInfoNotification,
+            history
+        } = this.props;
+
+        if (!isCartLoading && !items.length) {
+            showInfoNotification(__('Please add at least one product to cart!'));
+            history.push(appendWithStoreCode('/cart'));
+        }
     }
 
     handleRedirectIfDownloadableInCart() {
@@ -430,7 +443,8 @@ export class CheckoutContainer extends PureComponent {
             setHeaderState,
             totals,
             isInStoreActivated,
-            isSignedIn
+            isSignedIn,
+            isCartLoading
         } = this.props;
         const {
             billingAddress,
@@ -476,7 +490,8 @@ export class CheckoutContainer extends PureComponent {
             shippingMethods,
             totals,
             selectedStoreAddress,
-            isPickInStoreMethodSelected
+            isPickInStoreMethodSelected,
+            isCartLoading
         };
     }
 

--- a/packages/scandipwa/src/route/Checkout/Checkout.style.scss
+++ b/packages/scandipwa/src/route/Checkout/Checkout.style.scss
@@ -39,10 +39,10 @@
         position: fixed;
         inset-block-start: 0;
         inset-inline-start: 0;
-        // 200 to hide the CookiePopup component whose z-index is 200
+        // Set to 200 to hide the CookiePopup component whose z-index is 200
         z-index: 201;
         width: 100vw;
-        background: white;
+        background: #fff;
     }
 
     &-StickyButtonWrapper {

--- a/packages/scandipwa/src/route/Checkout/Checkout.style.scss
+++ b/packages/scandipwa/src/route/Checkout/Checkout.style.scss
@@ -34,6 +34,17 @@
         }
     }
 
+    &-FullPageLoader {
+        height: 100vh;
+        position: fixed;
+        inset-block-start: 0;
+        inset-inline-start: 0;
+        // 200 to hide the CookiePopup component whose z-index is 200
+        z-index: 201;
+        width: 100vw;
+        background: white;
+    }
+
     &-StickyButtonWrapper {
         @include mobile {
             border-block-start: 1px solid var(--primary-divider-color);

--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
@@ -30,6 +30,8 @@ export class CartDispatcher {
     async updateInitialCartData(dispatch, isForCustomer = false) {
         // Need to get current cart from BE, update cart
         try {
+            dispatch(updateIsLoadingCart(true));
+
             // ! Get quote token first (local or from the backend) just to make sure it exists
             const quoteId = await this._getGuestQuoteId(dispatch);
             const { cartData = {} } = await fetchQuery(
@@ -38,13 +40,12 @@ export class CartDispatcher {
                 )
             );
 
-            dispatch(updateIsLoadingCart(false));
-
             if (isForCustomer && !getAuthorizationToken()) {
                 return null;
             }
 
-            return this._updateCartData(cartData, dispatch);
+            await this._updateCartData(cartData, dispatch);
+            return dispatch(updateIsLoadingCart(false));
         } catch (error) {
             return this.createGuestEmptyCart(dispatch);
         }

--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
@@ -41,11 +41,14 @@ export class CartDispatcher {
             );
 
             if (isForCustomer && !getAuthorizationToken()) {
+                dispatch(updateIsLoadingCart(false));
                 return null;
             }
 
             await this._updateCartData(cartData, dispatch);
-            return dispatch(updateIsLoadingCart(false));
+            dispatch(updateIsLoadingCart(false));
+
+            return null;
         } catch (error) {
             return this.createGuestEmptyCart(dispatch);
         }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/2816

**Problem:**
- On reloading /cart, full cart is briefly shown as empty
- On reloading /checkout/:step, instant redirect to cart with a warning message 'Please add at least one product to cart!' when the cart is full
- On reloading /checkout/:step, the order summary is briefly shown as having 0 items 

**In this PR:**
* Used async/await to force the order of the functions in init function 
first: handleCustomerDataOnInit (which includes resetting cart), 
then: fetching cart data with the user's auth token.
* Set CartReducer.isCartLoading to true before fetching the initial cart data when first loading pages then set to false after.
* Loaders disappear when isCartLoading is false -- therefore no brief appearance of zero items in /cartPage or /checkout's order's summary 
---- In /checkout ->> the initial loader covers the full page, to not allow checkout page's brief appearing then disappearing before redirecting to cart if found zero items in cart after fetching
---- In /cart ->> loader is small

New function in the commits: 
--- initFunction -> extracted init's function from mapDispatchToProps
--- handleRedirectIfNoItemsInCart for /checkout
--- renderFullPageLoader for /checkout
