### PR TITLE
removed border for cms block cuz parent block has border-bottom

### DIFF
--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
@@ -194,7 +194,6 @@
 
     &-CmsBlock {
         padding: 10px 0;
-        border-block-end: $divider-border;
     }
 
     .ProductPrice {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4228 

**Problem:**
* In mobile checkout page summary block had a double border, one is from ExpandableContent's and one CmsBlock's

**In this PR:**
* Removed the border bottom for CmsBlock because its parent, ExpandableContent has
