### PR TITLE
Fixed product name not aligned with cross on IOS

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -143,6 +143,7 @@
             @include mobile {
                 white-space: normal;
                 max-width: calc(100% - 24px);
+                line-height: var(--paragraph-line-height-mobile);
             }
         }
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4069 

**Problem:**
* Product name or stars is not aligned with the cross in Wishlist on mobile

**In this PR:**
* Fixed alignment
