### PR TITLE
Fixes 'Maximum N characters'jumps when user enter more than N

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -71,7 +71,7 @@
     &-Error {
         &Messages {
             margin-block-end: -.1em;
-            padding-block-start: 10px;
+            padding-block-start: 6px;
         }
 
         &Message {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4586 

**Problem:**
* 'Maximum N characters' jumps if user enter more than N characters in text area / field
* Field error message have different margin than field label

**In this PR:**
* Fixes error message to have the same margin
* 'Maximum N characters' don't jump
