### PR TITLE
[3199] - Removed default shipping method auto-selection on Shipping step

### DIFF
--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.component.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.component.js
@@ -103,6 +103,7 @@ export class CheckoutShipping extends PureComponent {
 
     renderActions() {
         const { selectedShippingMethod } = this.props;
+        const isDisabled = !selectedShippingMethod.amount;
 
         return (
             <div block="Checkout" elem="StickyButtonWrapper">
@@ -110,7 +111,7 @@ export class CheckoutShipping extends PureComponent {
                 <button
                   type="submit"
                   block="Button"
-                  disabled={ !selectedShippingMethod }
+                  disabled={ isDisabled }
                   mix={ { block: 'CheckoutShipping', elem: 'Button' } }
                 >
                     <LockIcon />

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
@@ -25,6 +25,7 @@ import {
     trimCheckoutAddress,
     trimCheckoutCustomerAddress
 } from 'Util/Address';
+import { scrollToTop } from 'Util/Browser';
 import { getCartTotalSubPrice } from 'Util/Cart';
 import scrollToError from 'Util/Form/Form';
 import transformToNameValuePair from 'Util/Form/Transform';
@@ -106,24 +107,20 @@ export class CheckoutShippingContainer extends PureComponent {
     }
 
     componentDidUpdate(prevProps) {
-        const { shippingMethods: prevShippingMethods } = prevProps;
-        const { shippingMethods } = this.props;
+        const { isPickInStoreMethodSelected: prevIsInPickStoreMethodSelected } = prevProps;
+        const { isPickInStoreMethodSelected } = this.props;
 
-        if (prevShippingMethods !== shippingMethods) {
+        if (isPickInStoreMethodSelected) {
+            scrollToTop();
+        }
+
+        if (isPickInStoreMethodSelected !== prevIsInPickStoreMethodSelected) {
             this.resetShippingMethod();
         }
     }
 
     resetShippingMethod() {
-        const { selectedShippingMethod: { method_code: selectedMethodCode = '' } } = this.state;
-        const { shippingMethods } = this.props;
-
-        if (shippingMethods.find(({ method_code }) => method_code === selectedMethodCode)) {
-            return;
-        }
-        const [defaultShippingMethod] = shippingMethods.filter((method) => method.available);
-        const selectedShippingMethod = defaultShippingMethod || {};
-        this.setState({ selectedShippingMethod });
+        this.setState({ selectedShippingMethod: {} });
     }
 
     containerProps() {

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
@@ -106,21 +106,13 @@ export class CheckoutShippingContainer extends PureComponent {
         };
     }
 
-    componentDidUpdate(prevProps) {
-        const { isPickInStoreMethodSelected: prevIsInPickStoreMethodSelected } = prevProps;
+    componentDidUpdate() {
+        // const { isPickInStoreMethodSelected: prevIsInPickStoreMethodSelected } = prevProps;
         const { isPickInStoreMethodSelected } = this.props;
 
         if (isPickInStoreMethodSelected) {
             scrollToTop();
         }
-
-        if (isPickInStoreMethodSelected !== prevIsInPickStoreMethodSelected) {
-            this.resetShippingMethod();
-        }
-    }
-
-    resetShippingMethod() {
-        this.setState({ selectedShippingMethod: {} });
     }
 
     containerProps() {

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
@@ -107,11 +107,15 @@ export class CheckoutShippingContainer extends PureComponent {
     }
 
     componentDidUpdate() {
-        // const { isPickInStoreMethodSelected: prevIsInPickStoreMethodSelected } = prevProps;
-        const { isPickInStoreMethodSelected } = this.props;
+        const { isPickInStoreMethodSelected, shippingMethods } = this.props;
+        const pickupMethod = shippingMethods.find((el) => el.carrier_code === 'instore');
 
         if (isPickInStoreMethodSelected) {
             scrollToTop();
+
+            if (pickupMethod) {
+                this.onShippingMethodSelect(pickupMethod);
+            }
         }
     }
 
@@ -145,6 +149,10 @@ export class CheckoutShippingContainer extends PureComponent {
             onStoreSelect,
             onShippingEstimationFieldsChange
         };
+    }
+
+    handlePickupMethodSelect(selectedShippingMethod) {
+        this.setState({ selectedShippingMethod });
     }
 
     getStoreAddress(shippingAddress, isBillingAddress = false) {

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
@@ -105,29 +105,6 @@ export class CheckoutShippingContainer extends PureComponent {
         };
     }
 
-    componentDidUpdate(prevProps) {
-        const { shippingMethods: prevShippingMethods } = prevProps;
-        const { shippingMethods } = this.props;
-
-        if (prevShippingMethods !== shippingMethods) {
-            this.resetShippingMethod();
-        }
-    }
-
-    resetShippingMethod() {
-        const { selectedShippingMethod: { method_code: selectedMethodCode = '' } } = this.state;
-        const { shippingMethods } = this.props;
-
-        if (shippingMethods.find(({ method_code }) => method_code === selectedMethodCode)) {
-            return;
-        }
-
-        const [defaultShippingMethod] = shippingMethods.filter((method) => method.available);
-        const selectedShippingMethod = defaultShippingMethod || {};
-
-        this.setState({ selectedShippingMethod });
-    }
-
     containerProps() {
         const {
             cartTotalSubPrice,

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.js
@@ -105,6 +105,27 @@ export class CheckoutShippingContainer extends PureComponent {
         };
     }
 
+    componentDidUpdate(prevProps) {
+        const { shippingMethods: prevShippingMethods } = prevProps;
+        const { shippingMethods } = this.props;
+
+        if (prevShippingMethods !== shippingMethods) {
+            this.resetShippingMethod();
+        }
+    }
+
+    resetShippingMethod() {
+        const { selectedShippingMethod: { method_code: selectedMethodCode = '' } } = this.state;
+        const { shippingMethods } = this.props;
+
+        if (shippingMethods.find(({ method_code }) => method_code === selectedMethodCode)) {
+            return;
+        }
+        const [defaultShippingMethod] = shippingMethods.filter((method) => method.available);
+        const selectedShippingMethod = defaultShippingMethod || {};
+        this.setState({ selectedShippingMethod });
+    }
+
     containerProps() {
         const {
             cartTotalSubPrice,

--- a/packages/scandipwa/src/component/Field/Field.component.js
+++ b/packages/scandipwa/src/component/Field/Field.component.js
@@ -207,7 +207,7 @@ export class Field extends PureComponent {
         };
         // if button value is "none" do not disable
         const isButtonDisabled = (!value.match('none') && isDisabled);
-        const isChecked = isButtonDisabled || defaultChecked ? !isDisabled : null;
+        const isChecked = isButtonDisabled || defaultChecked ? !isDisabled : false;
 
         return (
             <label htmlFor={ id } block="Field" elem={ `${elem}Label` } mods={ { isDisabled } }>


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/3199

**Problem:**
* On the Shipping step, a delivery option was auto-selected by default
* In-store pickup delivery option has special logic that's supposed to render when a user selects it, but autoselecting was causing bugs for the method. Can't test for that yet because the client won't fetch that particular option.

**In this PR:**
* Removed the auto-selection of a delivery option on mount
* Modified the "Proceed to billing" button to be disabled if a user hadn't picked any delivery options
