### PR TITLE
#4594 Long word in table on CMS page is not moved to second line

### DIFF
--- a/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
@@ -33,6 +33,7 @@
         margin-block-start: calc(var(--header-total-height) + 12px);
         margin-block-end: var(--header-nav-height);
         margin-inline: auto;
+        word-wrap: break-word;
 
         @include mobile {
             padding-inline: 14px;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4594

**Problem:**
* Long word in table on CMS page is not moved to second line

**In this PR:**
* Added styles to long words
