### PR TITLE
Fixed product name not aligned with cross on IOS

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
@@ -182,12 +182,14 @@ export class WishlistItem extends PureComponent {
     }
 
     renderRemove() {
-        const { removeItem } = this.props;
+        const { removeItem, product: { review_count } } = this.props;
+        const withReview = review_count >= 1;
 
         return (
             <button
               block="WishlistItem"
               elem="Remove"
+              mods={ { withReview } }
               onClick={ removeItem }
               aria-label={ __('Remove') }
             >

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -143,6 +143,7 @@
             @include mobile {
                 white-space: normal;
                 max-width: calc(100% - 24px);
+                line-height: var(--paragraph-line-height-mobile);
             }
         }
     }

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -143,7 +143,7 @@
             @include mobile {
                 white-space: normal;
                 max-width: calc(100% - 24px);
-                line-height: var(--paragraph-line-height-mobile);
+                line-height: 1;
             }
         }
     }
@@ -172,6 +172,14 @@
 
             .CloseIcon {
                 width: 24px;
+            }
+        }
+    }
+
+    &-Remove {
+        @include mobile {
+            &_withReview[aria-label='Remove'] {
+                inset-block-start: -2px;
             }
         }
     }

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -155,7 +155,7 @@
         }
     }
 
-    &-Remove[aria-label='Remove'] {
+    &-Remove {
         position: absolute;
         inset-inline-end: 4px;
         inset-block-start: 4px;
@@ -173,12 +173,8 @@
             .CloseIcon {
                 width: 24px;
             }
-        }
-    }
 
-    &-Remove {
-        @include mobile {
-            &_withReview[aria-label='Remove'] {
+            &_withReview {
                 inset-block-start: -2px;
             }
         }


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4069 

**Problem:**
* Product name or stars is not aligned with the cross in Wishlist on mobile

**In this PR:**
* Fixed alignment
