### PR TITLE
Made notifications for mobile position fixed so they won't take height

### DIFF
--- a/packages/scandipwa/src/component/Notification/Notification.style.scss
+++ b/packages/scandipwa/src/component/Notification/Notification.style.scss
@@ -44,6 +44,8 @@
     }
 
     @include mobile {
+        position: fixed;
+        inset-block-start: var(--header-height);
         padding: 12px 14px;
         width: 100%;
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4579 

**Problem:**
* The page content jumped when a notification appeared

**In this PR:**
* Added position fixed for mobile so the will not change content height when it appears 
