### PR TITLE
Add default value for promo block rendering in case of null

### DIFF
--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -381,7 +381,7 @@ export class Checkout extends PureComponent {
             onCouponCodeUpdate
         } = this.props;
         const { areTotalsVisible } = this.stepMap[checkoutStep];
-        const { renderPromo } = this.renderPromo(true);
+        const { renderPromo } = this.renderPromo(true) || {};
 
         if (!areTotalsVisible || (showOnMobile && !isMobile) || (!showOnMobile && isMobile)) {
             return null;


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4604 

**Problem:**
* Tries to destruct value from null

**In this PR:**
* If null, we set empty object
