### PR TITLE
Fixed Addres book header not showing

### DIFF
--- a/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
@@ -310,11 +310,10 @@ export class MyAccountContainer extends PureComponent {
     }
 
     getTabName() {
-        const { location: { pathname } } = this.props;
         const { tabName: stateTabName, activeTab } = this.state;
-        const { tabName, url } = MyAccountContainer.tabMap[activeTab];
+        const { tabName } = MyAccountContainer.tabMap[activeTab];
 
-        if (!pathname.includes(url)) {
+        if (!tabName) {
             return stateTabName;
         }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4611 
 
**Problem:**
* Title 'Address book' is missing and button 'Add New Address' is shifted up in Address book in My Account when opening it via Manage Addresses link

**In this PR:**
* Fixed header not showing
