### PR TITLE
issue-4618 - Set high priority for checking composer deps in root packages.json in CSA

### DIFF
--- a/build-packages/scandipwa-dev-utils/composer.js
+++ b/build-packages/scandipwa-dev-utils/composer.js
@@ -16,7 +16,7 @@ let rootDeps = {};
  * @param {string} modulePath
  * @return {array} an array of object entries.
  */
-const getComposerDeps = (modulePath, context = modulePath, root = false) => {
+const getComposerDeps = (modulePath, context = modulePath, isRoot = false) => {
     if (visitedDeps.indexOf(modulePath) !== -1) {
         return [];
     }
@@ -30,7 +30,7 @@ const getComposerDeps = (modulePath, context = modulePath, root = false) => {
         } = {}
     } = getPackageJson(modulePath, context);
 
-    if (root) {
+    if (isRoot) {
         rootDeps = composer;
     }
 
@@ -61,7 +61,6 @@ const isValidComposer = (pathname = process.cwd()) => {
 
         if (rootDeps[module] && acc[module].indexOf(rootDeps[module]) === -1) {
             acc[module].push(rootDeps[module]);
-
             return acc;
         }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4618 

**Problem:**
* Can't change version of BE module in composer.json if source files package.json requires strict version of module.

**In this PR:**
* At the moment CSA goes through all package.json files to find scandipwa: { composer: {} } deps and it means that root dependencies that we defined in root folder are with lowest priority. So we can just save them for later use.
In case if we need to update module, we need to set correct version in composer.json same as in package.json for scandipwa: composer section! In this case Developer will have full control on what versions should be installed.

Test cases:
1. 

- Downgrade version of pwa to 5.2.0 (Requires scandipwa/cache to be 1.1.4)
- Set version of cache module in composer.json to 1.1.5
- Set version of cache module in root package.json to 1.1.5

Result:
It will validate version only for 1.1.5 and pass validation.

2. 

- Downgrade version of pwa to 5.2.0 (Requires scandipwa/cache to be 1.1.4)
- Set version of cache module in composer.json to 1.1.5

Result:
Will fail validation and throw error that requires 1.1.4 version

3. 

- Downgrade version of pwa to 5.2.0 (Requires scandipwa/cache to be 1.1.4)
- Set custom extension with cache module version 1.1.3
- Set version of cache module in composer.json to 1.1.5
- Set version of cache module in root package.json to 1.1.5

Result: 
It will validate version only for 1.1.5 and pass validation.

4. 

- Downgrade version of pwa to 5.2.0 (Requires scandipwa/cache to be 1.1.4)
- Set custom extension with cache module version 1.1.3
- Set version of cache module in composer.json to 1.1.5

Result: 
Will fail validation and throw error that requires version 1.1.3 1.1.4. (Tho impossible in this case to install, because both are strict versions).