### PR TITLE
reduced margin top down to 5px from 24px

### DIFF
--- a/packages/scandipwa/i18n/da_DK.json
+++ b/packages/scandipwa/i18n/da_DK.json
@@ -589,11 +589,13 @@
     "Sort by": null,
     "If there is an account associated with %s you will receive an email with a link to reset your password": null,
     " discount each": null,
-    "Sort by": null,
     "The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later.": null,
     "Unable to reset password": null,
     "Please enter no more than %s characters.": null,
     "You saved the account information.": null,
     "Minimum of different classes of characters in password is %s. ": null,
-    "Classes of characters: Lower Case, Upper Case, Digits, Special Characters.": null
+    "Classes of characters: Lower Case, Upper Case, Digits, Special Characters.": null,
+    "Maximum %s characters (%s remaining)": null,
+    "Maximum %s characters": null,
+    "Maximum %s characters (%s too many)": null
 }

--- a/packages/scandipwa/src/component/ProductConfigurableAttributes/ProductConfigurableAttributes.style.scss
+++ b/packages/scandipwa/src/component/ProductConfigurableAttributes/ProductConfigurableAttributes.style.scss
@@ -14,7 +14,7 @@
     line-height: 20px;
 
     @include desktop {
-        margin-block-start: 24px;
+        margin-block-start: 5px;
     }
 
     &-DropDownList {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4610 

**Problem:**
* Unnecessary margin-top for ProductConfigurableAttributes block

**In this PR:**
* Reduced the margin down to 5px because on hover to the attribute, the border should be visible 
