### PR TITLE
[3125] - /cart coupon's input turns red on entering an invalid coupon Code

### DIFF
--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.component.js
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.component.js
@@ -29,8 +29,8 @@ export class CartCoupon extends PureComponent {
         handleRemoveCouponFromCart: PropTypes.func.isRequired,
         mix: MixType.isRequired,
         title: PropTypes.string.isRequired,
-        isBadCoupon: PropTypes.bool.isRequired,
-        resetIsBadCoupon: PropTypes.func.isRequired
+        isIncorrectCoupon: PropTypes.bool.isRequired,
+        resetIsIncorrectCoupon: PropTypes.func.isRequired
     };
 
     static defaultProps = {
@@ -49,19 +49,21 @@ export class CartCoupon extends PureComponent {
 
     handleFormSubmit = this.handleFormSubmit.bind(this);
 
-    getSnapshotBeforeUpdate(prevProps) {
-        const { isBadCoupon: prevIsBadCoupon = false } = prevProps;
-        const { isBadCoupon = false, resetIsBadCoupon } = this.props;
+    componentDidUpdate(prevProps) {
+        const { isIncorrectCoupon: prevIsIncorrectCoupon = false } = prevProps;
+        const { isIncorrectCoupon = false, resetIsIncorrectCoupon } = this.props;
 
-        if (isBadCoupon && prevIsBadCoupon !== isBadCoupon) {
-            this.setState({
-                isFieldWithError: isBadCoupon
-            });
-            resetIsBadCoupon();
+        if (isIncorrectCoupon && prevIsIncorrectCoupon !== isIncorrectCoupon) {
+            this.toggleIsFieldWithError(isIncorrectCoupon);
+            resetIsIncorrectCoupon();
         }
     }
 
-    componentDidUpdate() {}
+    toggleIsFieldWithError(value) {
+        this.setState({
+            isFieldWithError: value
+        });
+    }
 
     handleCouponCodeChange(event, field) {
         const { value = '' } = field;

--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.component.js
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.component.js
@@ -28,7 +28,9 @@ export class CartCoupon extends PureComponent {
         handleApplyCouponToCart: PropTypes.func.isRequired,
         handleRemoveCouponFromCart: PropTypes.func.isRequired,
         mix: MixType.isRequired,
-        title: PropTypes.string.isRequired
+        title: PropTypes.string.isRequired,
+        isBadCoupon: PropTypes.bool.isRequired,
+        resetIsBadCoupon: PropTypes.func.isRequired
     };
 
     static defaultProps = {
@@ -47,11 +49,26 @@ export class CartCoupon extends PureComponent {
 
     handleFormSubmit = this.handleFormSubmit.bind(this);
 
+    getSnapshotBeforeUpdate(prevProps) {
+        const { isBadCoupon: prevIsBadCoupon = false } = prevProps;
+        const { isBadCoupon = false, resetIsBadCoupon } = this.props;
+
+        if (isBadCoupon && prevIsBadCoupon !== isBadCoupon) {
+            this.setState({
+                isFieldWithError: isBadCoupon
+            });
+            resetIsBadCoupon();
+        }
+    }
+
+    componentDidUpdate() {}
+
     handleCouponCodeChange(event, field) {
         const { value = '' } = field;
 
         this.setState({
-            enteredCouponCode: value
+            enteredCouponCode: value,
+            isFieldWithError: false
         });
     }
 
@@ -87,7 +104,7 @@ export class CartCoupon extends PureComponent {
     }
 
     renderApplyCoupon() {
-        const { enteredCouponCode } = this.state;
+        const { enteredCouponCode, isFieldWithError } = this.state;
 
         return (
             <>
@@ -108,6 +125,7 @@ export class CartCoupon extends PureComponent {
                           isRequired: true
                       } }
                       validateOn={ ['onChange'] }
+                      mix={ { mods: { hasError: isFieldWithError }, block: 'Field' } }
                     />
                 </div>
                 <button

--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.container.js
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.container.js
@@ -56,30 +56,30 @@ export class CartCouponContainer extends PureComponent {
 
     state = {
         isLoading: false,
-        isBadCoupon: false
+        isIncorrectCoupon: false
     };
 
     containerFunctions = {
         handleApplyCouponToCart: this.handleApplyCouponToCart.bind(this),
         handleRemoveCouponFromCart: this.handleRemoveCouponFromCart.bind(this),
-        resetIsBadCoupon: this.resetIsBadCoupon.bind(this)
+        resetIsIncorrectCoupon: this.resetIsIncorrectCoupon.bind(this)
     };
 
     containerProps() {
-        const { isLoading, isBadCoupon } = this.state;
+        const { isLoading, isIncorrectCoupon } = this.state;
         const { couponCode, mix, title } = this.props;
 
         return {
             isLoading,
-            isBadCoupon,
+            isIncorrectCoupon,
             couponCode,
             mix,
             title
         };
     }
 
-    resetIsBadCoupon() {
-        this.setState({ isBadCoupon: false });
+    resetIsIncorrectCoupon() {
+        this.setState({ isIncorrectCoupon: false });
     }
 
     handleApplyCouponToCart(couponCode) {
@@ -91,13 +91,11 @@ export class CartCouponContainer extends PureComponent {
             /** @namespace Component/CartCoupon/Container/CartCouponContainer/handleApplyCouponToCart/then/finally/applyCouponToCart/then */
             (success) => {
                 onCouponCodeUpdate();
-                this.setState({ isBadCoupon: !success });
+                this.setState({ isIncorrectCoupon: !success });
             }
         ).finally(
         /** @namespace Component/CartCoupon/Container/CartCouponContainer/handleApplyCouponToCart/then/finally */
-            () => {
-                this.setState({ isLoading: false });
-            }
+            () => this.setState({ isLoading: false })
         );
     }
 

--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.container.js
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.container.js
@@ -54,23 +54,32 @@ export class CartCouponContainer extends PureComponent {
         title: ''
     };
 
-    state = { isLoading: false };
+    state = {
+        isLoading: false,
+        isBadCoupon: false
+    };
 
     containerFunctions = {
         handleApplyCouponToCart: this.handleApplyCouponToCart.bind(this),
-        handleRemoveCouponFromCart: this.handleRemoveCouponFromCart.bind(this)
+        handleRemoveCouponFromCart: this.handleRemoveCouponFromCart.bind(this),
+        resetIsBadCoupon: this.resetIsBadCoupon.bind(this)
     };
 
     containerProps() {
-        const { isLoading } = this.state;
+        const { isLoading, isBadCoupon } = this.state;
         const { couponCode, mix, title } = this.props;
 
         return {
             isLoading,
+            isBadCoupon,
             couponCode,
             mix,
             title
         };
+    }
+
+    resetIsBadCoupon() {
+        this.setState({ isBadCoupon: false });
     }
 
     handleApplyCouponToCart(couponCode) {
@@ -79,11 +88,16 @@ export class CartCouponContainer extends PureComponent {
         this.setState({ isLoading: true });
 
         applyCouponToCart(couponCode).then(
-            /** @namespace Component/CartCoupon/Container/CartCouponContainer/handleApplyCouponToCart/then/finally/applyCouponToCart/then/onCouponCodeUpdate */
-            () => onCouponCodeUpdate()
+            /** @namespace Component/CartCoupon/Container/CartCouponContainer/handleApplyCouponToCart/then/finally/applyCouponToCart/then */
+            (success) => {
+                onCouponCodeUpdate();
+                this.setState({ isBadCoupon: !success });
+            }
         ).finally(
-            /** @namespace Component/CartCoupon/Container/CartCouponContainer/handleApplyCouponToCart/then/finally */
-            () => this.setState({ isLoading: false })
+        /** @namespace Component/CartCoupon/Container/CartCouponContainer/handleApplyCouponToCart/then/finally */
+            () => {
+                this.setState({ isLoading: false });
+            }
         );
     }
 

--- a/packages/scandipwa/src/component/Field/Field.component.js
+++ b/packages/scandipwa/src/component/Field/Field.component.js
@@ -328,6 +328,7 @@ export class Field extends PureComponent {
             type, validationResponse, mix
         } = this.props;
         const inputRenderer = this.renderMap[type];
+        const { mods: { hasError = false } = {} } = mix;
 
         return (
             <div block="Field" elem="Wrapper" mods={ { type } }>
@@ -335,7 +336,7 @@ export class Field extends PureComponent {
                   block="Field"
                   mods={ {
                       type,
-                      isValid: validationResponse === true,
+                      isValid: !hasError && validationResponse === true,
                       hasError: validationResponse !== true && Object.keys(validationResponse || {}).length !== 0
                   } }
                   mix={ mix }

--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
@@ -190,7 +190,7 @@ export class CartDispatcher {
             const guestQuoteId = !isCustomerSignedIn && getGuestQuoteId();
 
             if (!isCustomerSignedIn && !guestQuoteId) {
-                return;
+                return null;
             }
 
             const { applyCoupon: { cartData = {} } = {} } = await fetchMutation(
@@ -199,8 +199,12 @@ export class CartDispatcher {
 
             this._updateCartData(cartData, dispatch);
             dispatch(showNotification('success', __('Coupon was applied!')));
+
+            return true;
         } catch (error) {
             dispatch(showNotification('error', getErrorMessage(error)));
+
+            return null;
         }
     }
 

--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
@@ -190,7 +190,7 @@ export class CartDispatcher {
             const guestQuoteId = !isCustomerSignedIn && getGuestQuoteId();
 
             if (!isCustomerSignedIn && !guestQuoteId) {
-                return null;
+                return false;
             }
 
             const { applyCoupon: { cartData = {} } = {} } = await fetchMutation(
@@ -204,7 +204,7 @@ export class CartDispatcher {
         } catch (error) {
             dispatch(showNotification('error', getErrorMessage(error)));
 
-            return null;
+            return false;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3125

**Problem:**
In/Valid coupons checks were not connected to the input styling

**In this PR:**
1 - In CartDispatched, applyCouponToCart function is set to return true if valid coupon, else null.
2 - In CartCoupon.container, created a state variable isBadCoupon whose update depends on the applyCouponToCart function. And it's passed to the CartCoupon.component
3 - In CartCoupon.component, created a state variable isFieldWithError that changes to
--- true if bad coupon
--- false on input change (input returns to green)
-- isFieldWithError is updated in getSnapshotBeforeUpdate, where is prevProps is compared with the current
and when the component's state is updated, I also update isBadCoupon in the container (passed function resetIsBadCoupon)
4 - Field's mods hasError is created based on state.isFieldWithError 
--- has error is passed in mix ==> which is also destructed and used to render the Field mods inValid to not have styles overridden

