### PR TITLE
#4632 Error message 'Minimal value is N!' overlaps to control quantity buttons

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -72,7 +72,7 @@
     &-Error {
         &Messages {
             margin-block-end: -.1em;
-            padding-block-start: 6px;
+            padding-block-start: 12px;
         }
 
         &Message {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4632

**Problem:**
* Error message 'Minimal value is N!' overlaps to control quantity buttons for grouped product on PDP

**In this PR:**
* Added extra space 
