### PR TITLE
#4627 - Adding/deleting/editing addresses now includes a success message

### DIFF
--- a/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.container.js
+++ b/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.container.js
@@ -50,6 +50,7 @@ export const mapDispatchToProps = (dispatch) => ({
 export class MyAccountAddressPopupContainer extends PureComponent {
     static propTypes = {
         showErrorNotification: PropTypes.func.isRequired,
+        showSuccessNotification: PropTypes.func.isRequired,
         updateCustomerDetails: PropTypes.func.isRequired,
         hideActiveOverlay: PropTypes.func.isRequired,
         goToPreviousHeaderState: PropTypes.func.isRequired,
@@ -112,6 +113,21 @@ export class MyAccountAddressPopupContainer extends PureComponent {
         return this.handleCreateAddress(address);
     }
 
+    showNotification(status, operation) {
+        const { showSuccessNotification, showErrorNotification } = this.props;
+        const message = `Your ${operation} the address`;
+        switch (status) {
+        case 'success':
+            showSuccessNotification(message);
+            break;
+        case 'error':
+            showErrorNotification(message);
+            break;
+        default:
+            break;
+        }
+    }
+
     async handleEditAddress(address) {
         const { payload: { address: { id } } } = this.props;
         const query = MyAccountQuery.getUpdateAddressMutation(id, address);
@@ -123,6 +139,7 @@ export class MyAccountAddressPopupContainer extends PureComponent {
         try {
             await fetchMutation(query);
             this.handleAfterAction();
+            this.showNotification('success', 'edited');
         } catch (e) {
             this.handleError(e);
         }
@@ -141,6 +158,7 @@ export class MyAccountAddressPopupContainer extends PureComponent {
         try {
             await fetchMutation(query);
             this.handleAfterAction();
+            this.showNotification('success', 'deleted');
         } catch (e) {
             this.handleError(e);
         }
@@ -156,6 +174,7 @@ export class MyAccountAddressPopupContainer extends PureComponent {
         try {
             await fetchMutation(query);
             this.handleAfterAction();
+            this.showNotification('success', 'saved');
         } catch (e) {
             this.handleError(e);
         }

--- a/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.container.js
+++ b/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.container.js
@@ -113,9 +113,9 @@ export class MyAccountAddressPopupContainer extends PureComponent {
         return this.handleCreateAddress(address);
     }
 
-    showNotification(status, operation) {
+    showAddressNotification(status, operation) {
         const { showSuccessNotification, showErrorNotification } = this.props;
-        const message = `Your ${operation} the address`;
+        const message = __('You %s the address', operation);
         switch (status) {
         case 'success':
             showSuccessNotification(message);
@@ -139,7 +139,7 @@ export class MyAccountAddressPopupContainer extends PureComponent {
         try {
             await fetchMutation(query);
             this.handleAfterAction();
-            this.showNotification('success', 'edited');
+            this.showAddressNotification('success', 'edited');
         } catch (e) {
             this.handleError(e);
         }
@@ -158,7 +158,7 @@ export class MyAccountAddressPopupContainer extends PureComponent {
         try {
             await fetchMutation(query);
             this.handleAfterAction();
-            this.showNotification('success', 'deleted');
+            this.showAddressNotification('success', 'deleted');
         } catch (e) {
             this.handleError(e);
         }
@@ -174,7 +174,7 @@ export class MyAccountAddressPopupContainer extends PureComponent {
         try {
             await fetchMutation(query);
             this.handleAfterAction();
-            this.showNotification('success', 'saved');
+            this.showAddressNotification('success', 'saved');
         } catch (e) {
             this.handleError(e);
         }


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4627

**Problem:**
* Changing/deleting/editing addresses in MyAccount didn't trigger a success notification

**In this PR:**
* Added the appropriate logic into methods responsible for processing the aforementioned operations
