### PR TITLE
[3455] - Disabled options for the customizable out-of-stock products

### DIFF
--- a/packages/scandipwa/src/component/DatePicker/DatePicker.component.js
+++ b/packages/scandipwa/src/component/DatePicker/DatePicker.component.js
@@ -33,7 +33,8 @@ export class DatePickerComponent extends PureComponent {
         dateFormat: PropTypes.string.isRequired,
         timeFormat: PropTypes.string.isRequired,
         uid: PropTypes.string.isRequired,
-        isClearable: PropTypes.bool.isRequired
+        isClearable: PropTypes.bool.isRequired,
+        isDisabled: PropTypes.bool.isRequired
     };
 
     placeholderMap = {
@@ -49,7 +50,7 @@ export class DatePickerComponent extends PureComponent {
     }
 
     renderCustomInput({ value, onClick }, ref) {
-        const { selectedDate, uid } = this.props;
+        const { selectedDate, uid, isDisabled } = this.props;
 
         return (
             <input
@@ -63,6 +64,7 @@ export class DatePickerComponent extends PureComponent {
               placeholder={ this.getPlaceholder() }
               inputMode="none"
               readOnly
+              disabled={ isDisabled }
             />
         );
     }

--- a/packages/scandipwa/src/component/DatePicker/DatePicker.container.js
+++ b/packages/scandipwa/src/component/DatePicker/DatePicker.container.js
@@ -40,7 +40,8 @@ export class DatePickerContainer extends PureComponent {
         yearRange: PropTypes.string.isRequired,
         uid: PropTypes.string.isRequired,
         isRequired: PropTypes.bool,
-        updateSelectedValues: PropTypes.bool.isRequired
+        updateSelectedValues: PropTypes.bool.isRequired,
+        isDisabled: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -70,7 +71,8 @@ export class DatePickerContainer extends PureComponent {
             timeFormat: magentoTimeFormat,
             dateFieldsOrder,
             uid,
-            isRequired
+            isRequired,
+            isDisabled
         } = this.props;
 
         const showTimeSelect = type === FIELD_DATE_TYPE.dateTime || type === FIELD_DATE_TYPE.time;
@@ -86,7 +88,8 @@ export class DatePickerContainer extends PureComponent {
             dateFormat,
             timeFormat,
             uid,
-            isClearable: !isRequired
+            isClearable: !isRequired,
+            isDisabled
         };
     }
 

--- a/packages/scandipwa/src/component/DateSelect/DateSelect.component.js
+++ b/packages/scandipwa/src/component/DateSelect/DateSelect.component.js
@@ -55,7 +55,8 @@ export class DateSelectComponent extends PureComponent {
         showDateSelect: PropTypes.bool.isRequired,
         showTimeSelect: PropTypes.bool.isRequired,
         dateFieldsOrder: PropTypes.string.isRequired,
-        timeFormat: PropTypes.string.isRequired
+        timeFormat: PropTypes.string.isRequired,
+        isDisabled: PropTypes.bool.isRequired
     };
 
     dateMap = {
@@ -119,7 +120,8 @@ export class DateSelectComponent extends PureComponent {
             isRequired,
             type,
             selectedYear,
-            onSetYear
+            onSetYear,
+            isDisabled
         } = this.props;
 
         return (
@@ -132,7 +134,8 @@ export class DateSelectComponent extends PureComponent {
                   selectPlaceholder: __('Year'),
                   value: selectedYear,
                   [FIELD_TYPE_ATTR]: type,
-                  [FIELD_NAME_ATTR]: 'year'
+                  [FIELD_NAME_ATTR]: 'year',
+                  disabled: isDisabled
               } }
               key={ `${type}-year-${ uid }` }
               options={ this.getYearOptions() }
@@ -144,6 +147,7 @@ export class DateSelectComponent extends PureComponent {
                   isRequired
               } }
               validateOn={ ['onChange'] }
+              isDisabled={ isDisabled }
             />
         );
     }
@@ -154,7 +158,8 @@ export class DateSelectComponent extends PureComponent {
             isRequired,
             type,
             selectedMonth,
-            onSetMonth
+            onSetMonth,
+            isDisabled
         } = this.props;
 
         return (
@@ -167,7 +172,8 @@ export class DateSelectComponent extends PureComponent {
                   selectPlaceholder: __('Month'),
                   value: selectedMonth,
                   [FIELD_TYPE_ATTR]: type,
-                  [FIELD_NAME_ATTR]: 'month'
+                  [FIELD_NAME_ATTR]: 'month',
+                  disabled: isDisabled
               } }
               key={ `${type}-month-${ uid }` }
               options={ this.getMonthOptions() }
@@ -179,6 +185,7 @@ export class DateSelectComponent extends PureComponent {
                   isRequired
               } }
               validateOn={ ['onChange'] }
+              isDisabled={ isDisabled }
             />
         );
     }
@@ -189,7 +196,8 @@ export class DateSelectComponent extends PureComponent {
             uid,
             isRequired,
             type,
-            selectedDay
+            selectedDay,
+            isDisabled
         } = this.props;
 
         return (
@@ -202,7 +210,8 @@ export class DateSelectComponent extends PureComponent {
                   selectPlaceholder: __('Day'),
                   value: selectedDay,
                   [FIELD_TYPE_ATTR]: type,
-                  [FIELD_NAME_ATTR]: 'day'
+                  [FIELD_NAME_ATTR]: 'day',
+                  disabled: isDisabled
               } }
               key={ `${type}-day-${ uid }` }
               options={ this.getDayOptions() }
@@ -214,6 +223,7 @@ export class DateSelectComponent extends PureComponent {
                   isRequired
               } }
               validateOn={ ['onChange'] }
+              isDisabled={ isDisabled }
             />
         );
     }
@@ -224,7 +234,8 @@ export class DateSelectComponent extends PureComponent {
             uid,
             isRequired,
             type,
-            selectedHours
+            selectedHours,
+            isDisabled
         } = this.props;
 
         return (
@@ -249,6 +260,7 @@ export class DateSelectComponent extends PureComponent {
                   isRequired
               } }
               validateOn={ ['onChange'] }
+              isDisabled={ isDisabled }
             />
         );
     }
@@ -259,7 +271,8 @@ export class DateSelectComponent extends PureComponent {
             uid,
             isRequired,
             type,
-            selectedMinutes
+            selectedMinutes,
+            isDisabled
         } = this.props;
 
         return (
@@ -272,7 +285,8 @@ export class DateSelectComponent extends PureComponent {
                   selectPlaceholder: __('Minutes'),
                   value: selectedMinutes,
                   [FIELD_TYPE_ATTR]: type,
-                  [FIELD_NAME_ATTR]: 'minutes'
+                  [FIELD_NAME_ATTR]: 'minutes',
+                  disabled: isDisabled
               } }
               key={ `${type}-minutes-${ uid }` }
               options={ this.getMinutesOptions() }
@@ -284,6 +298,7 @@ export class DateSelectComponent extends PureComponent {
                   isRequired
               } }
               validateOn={ ['onChange'] }
+              isDisabled={ isDisabled }
             />
         );
     }
@@ -295,7 +310,8 @@ export class DateSelectComponent extends PureComponent {
             isRequired,
             type,
             selectedAMPM,
-            timeFormat
+            timeFormat,
+            isDisabled
         } = this.props;
 
         if (timeFormat !== TIME_FORMAT.H12) {
@@ -312,7 +328,8 @@ export class DateSelectComponent extends PureComponent {
                   value: selectedAMPM,
                   noPlaceholder: true,
                   [FIELD_TYPE_ATTR]: type,
-                  [FIELD_NAME_ATTR]: 'ampm'
+                  [FIELD_NAME_ATTR]: 'ampm',
+                  disabled: isDisabled
               } }
               options={ this.getAMPMOptions() }
               mix={ { block: 'DateSelect', elem: 'AMPM' } }
@@ -323,6 +340,7 @@ export class DateSelectComponent extends PureComponent {
                   isRequired
               } }
               validateOn={ ['onChange'] }
+              isDisabled={ isDisabled }
             />
         );
     }

--- a/packages/scandipwa/src/component/DateSelect/DateSelect.container.js
+++ b/packages/scandipwa/src/component/DateSelect/DateSelect.container.js
@@ -37,7 +37,8 @@ export class DateSelectContainer extends PureComponent {
         yearRange: PropTypes.string.isRequired,
         uid: PropTypes.string.isRequired,
         isRequired: PropTypes.bool,
-        updateSelectedValues: PropTypes.func.isRequired
+        updateSelectedValues: PropTypes.func.isRequired,
+        isDisabled: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -97,7 +98,8 @@ export class DateSelectContainer extends PureComponent {
             timeFormat,
             dateFieldsOrder,
             uid,
-            isRequired
+            isRequired,
+            isDisabled
         } = this.props;
 
         const showTimeSelect = type === FIELD_DATE_TYPE.dateTime || type === FIELD_DATE_TYPE.time;
@@ -118,7 +120,8 @@ export class DateSelectContainer extends PureComponent {
             timeFormat,
             uid,
             isRequired,
-            type
+            type,
+            isDisabled
         };
     }
 

--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -269,6 +269,12 @@
                     }
                 }
 
+                &_isDisabled {
+                    label, input {
+                        pointer-events: none;
+                    }
+                }
+
                 &_hasError {
                     input {
                         & + label {

--- a/packages/scandipwa/src/component/FieldDate/FieldDate.container.js
+++ b/packages/scandipwa/src/component/FieldDate/FieldDate.container.js
@@ -33,7 +33,8 @@ export class FieldDateContainer extends PureComponent {
         uid: PropTypes.string.isRequired,
         isRequired: PropTypes.bool,
         updateSelectedValues: PropTypes.func.isRequired,
-        useCalendar: PropTypes.bool.isRequired
+        useCalendar: PropTypes.bool.isRequired,
+        isDisabled: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -45,14 +46,16 @@ export class FieldDateContainer extends PureComponent {
             type,
             uid,
             isRequired,
-            updateSelectedValues
+            updateSelectedValues,
+            isDisabled
         } = this.props;
 
         return {
             type,
             uid,
             isRequired,
-            updateSelectedValues
+            updateSelectedValues,
+            isDisabled
         };
     }
 

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.component.js
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.component.js
@@ -100,7 +100,8 @@ export class FieldSelect extends PureComponent {
 
         const {
             isExpanded,
-            handleSelectListOptionClick
+            handleSelectListOptionClick,
+            isDisabled
         } = this.props;
 
         return (
@@ -108,7 +109,7 @@ export class FieldSelect extends PureComponent {
               block="FieldSelect"
               elem="Option"
               mods={ {
-                  isDisabled: !isAvailable,
+                  isDisabled: !isAvailable || isDisabled,
                   isExpanded,
                   isPlaceholder,
                   isHovered

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.container.js
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.container.js
@@ -88,10 +88,11 @@ export class FieldSelectContainer extends PureComponent {
     }
 
     isSelectedOptionAvailable() {
+        const { isDisabled } = this.props;
         const options = this.getOptions();
         const selectedOptionIndex = this.fieldRef.options.selectedIndex;
         const selectedOption = options[selectedOptionIndex];
-        const isAvailable = selectedOption.isAvailable !== false;
+        const isAvailable = !!selectedOption?.isAvailable && !isDisabled;
 
         this.setState({
             selectedOptionIndex,

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
@@ -39,7 +39,8 @@ export class ProductCustomizableOption extends PureComponent {
         getDropdownOptions: PropTypes.func.isRequired,
         isRequired: PropTypes.bool.isRequired,
         currencyCode: PropTypes.string.isRequired,
-        options: CustomizableOptionsType
+        options: CustomizableOptionsType,
+        isProductInStock: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -97,7 +98,7 @@ export class ProductCustomizableOption extends PureComponent {
 
     renderDefaultValue(option) {
         const {
-            title, fieldType, isRequired, uid
+            title, fieldType, isRequired, uid, isProductInStock
         } = this.props;
         const { value } = this.state;
         const { max_characters } = option;
@@ -116,7 +117,8 @@ export class ProductCustomizableOption extends PureComponent {
                   attr={ {
                       id: uid,
                       name: uid,
-                      placeholder: ''
+                      placeholder: '',
+                      disabled: !isProductInStock
                   } }
                   subLabel={ subLabel }
                   events={ {
@@ -133,7 +135,8 @@ export class ProductCustomizableOption extends PureComponent {
             title,
             uid,
             isRequired,
-            updateSelectedValues
+            updateSelectedValues,
+            isProductInStock
         } = this.props;
 
         const label = this.getLabel(option, title);
@@ -145,6 +148,7 @@ export class ProductCustomizableOption extends PureComponent {
                   type={ type }
                   uid={ uid }
                   isRequired={ isRequired }
+                  isDisabled={ !isProductInStock }
                   updateSelectedValues={ updateSelectedValues }
                 />
             </>
@@ -153,7 +157,7 @@ export class ProductCustomizableOption extends PureComponent {
 
     renderFileValue(option) {
         const {
-            title, uid, isRequired, updateSelectedValues
+            title, uid, isRequired, updateSelectedValues, isProductInStock
         } = this.props;
         const { file_extension: fileExtensions = '' } = option;
         const label = this.getLabel(option, title);
@@ -172,11 +176,13 @@ export class ProductCustomizableOption extends PureComponent {
                   attr={ {
                       id: uid,
                       name: uid,
-                      accept: fileExtensions
+                      accept: fileExtensions,
+                      disabled: !isProductInStock
                   } }
                   events={ {
                       onChange: updateSelectedValues
                   } }
+                  mix={ { block: 'Field', mods: { isDisabled: !isProductInStock } } }
                   validateOn={ ['onChange'] }
                 />
             </>
@@ -188,7 +194,7 @@ export class ProductCustomizableOption extends PureComponent {
             uid,
             is_default: isDefault = false
         } = option;
-        const { updateSelectedValues } = this.props;
+        const { updateSelectedValues, isProductInStock } = this.props;
         const label = this.getLabel(option);
 
         return (
@@ -200,7 +206,8 @@ export class ProductCustomizableOption extends PureComponent {
                       id: `option-${ uid }`,
                       value: uid,
                       name: `option-${ uid }`,
-                      defaultChecked: isDefault
+                      defaultChecked: isDefault,
+                      disabled: !isProductInStock
                   } }
                   events={ {
                       onChange: updateSelectedValues
@@ -230,7 +237,7 @@ export class ProductCustomizableOption extends PureComponent {
             uid,
             is_default
         } = option;
-        const { updateSelectedValues } = this.props;
+        const { updateSelectedValues, isProductInStock } = this.props;
         const label = this.getLabel(option);
 
         return (
@@ -242,7 +249,8 @@ export class ProductCustomizableOption extends PureComponent {
                       id: `option-${ uid }`,
                       value: uid,
                       name: `option-${ name }`,
-                      defaultChecked: is_default
+                      defaultChecked: is_default,
+                      disabled: !isProductInStock
                   } }
                   events={ {
                       onChange: updateSelectedValues
@@ -272,7 +280,8 @@ export class ProductCustomizableOption extends PureComponent {
             getDropdownOptions,
             updateSelectedValues,
             isRequired,
-            uid
+            uid,
+            isProductInStock
         } = this.props;
 
         return (
@@ -282,7 +291,8 @@ export class ProductCustomizableOption extends PureComponent {
                   attr={ {
                       id: `customizable-options-dropdown-${ uid }`,
                       name: `customizable-options-dropdown-${ uid }`,
-                      selectPlaceholder: __('Select option...')
+                      selectPlaceholder: __('Select option...'),
+                      disabled: !isProductInStock
                   } }
                   mix={ { block: 'ProductCustomizableItem', elem: 'Select' } }
                   options={ getDropdownOptions() }
@@ -293,6 +303,7 @@ export class ProductCustomizableOption extends PureComponent {
                       isRequired
                   } }
                   validateOn={ ['onChange'] }
+                  isDisabled={ !isProductInStock }
                 />
             </div>
         );

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.container.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.container.js
@@ -42,7 +42,8 @@ export class ProductCustomizableOptionContainer extends PureComponent {
         type: PropTypes.string.isRequired,
         options: CustomizableOptionsType,
         updateSelectedValues: PropTypes.func.isRequired,
-        currencyCode: PropTypes.string.isRequired
+        currencyCode: PropTypes.string.isRequired,
+        isProductInStock: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -87,7 +88,8 @@ export class ProductCustomizableOptionContainer extends PureComponent {
             isRequired,
             type,
             updateSelectedValues,
-            currencyCode
+            currencyCode,
+            isProductInStock
         } = this.props;
 
         return {
@@ -98,7 +100,8 @@ export class ProductCustomizableOptionContainer extends PureComponent {
             options: nonRequiredRadioOptions(this.getSortedOptions(), isRequired, type),
             updateSelectedValues,
             currencyCode,
-            fieldType: this.getFieldType()
+            fieldType: this.getFieldType(),
+            isProductInStock
         };
     }
 

--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.component.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.component.js
@@ -25,7 +25,8 @@ import './ProductCustomizableOptions.style';
 export class ProductCustomizableOptions extends PureComponent {
     static propTypes = {
         options: OptionsListType,
-        updateSelectedValues: PropTypes.func.isRequired
+        updateSelectedValues: PropTypes.func.isRequired,
+        isProductInStock: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -33,6 +34,7 @@ export class ProductCustomizableOptions extends PureComponent {
     };
 
     renderOptionGroup(group) {
+        const { isProductInStock } = this.props;
         const {
             title,
             value,
@@ -52,6 +54,7 @@ export class ProductCustomizableOptions extends PureComponent {
               isRequired={ required }
               type={ type }
               updateSelectedValues={ updateSelectedValues }
+              isProductInStock={ isProductInStock }
             />
         );
     }

--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.container.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.container.js
@@ -11,10 +11,20 @@
 
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
+import { connect } from 'react-redux';
 
-import { OptionsListType } from 'Type/ProductList.type';
+import { OptionsListType, ProductType } from 'Type/ProductList.type';
+import { getProductInStock } from 'Util/Product/Extract';
 
 import ProductCustomizableOptions from './ProductCustomizableOptions.component';
+
+/** @namespace Component/ProductCustomizableOptions/Container/mapStateToProps */
+export const mapStateToProps = (state) => ({
+    activeProduct: state.ProductReducer.product
+});
+
+/** @namespace Component/ProductCustomizableOptions/Container/mapDispatchToProps */
+export const mapDispatchToProps = () => ({});
 
 /**
  * Product Customizable Options
@@ -24,7 +34,8 @@ import ProductCustomizableOptions from './ProductCustomizableOptions.component';
 export class ProductCustomizableOptionsContainer extends PureComponent {
     static propTypes = {
         options: OptionsListType,
-        updateSelectedValues: PropTypes.func.isRequired
+        updateSelectedValues: PropTypes.func.isRequired,
+        activeProduct: ProductType.isRequired
     };
 
     static defaultProps = {
@@ -32,11 +43,12 @@ export class ProductCustomizableOptionsContainer extends PureComponent {
     };
 
     containerProps() {
-        const { options, updateSelectedValues } = this.props;
+        const { options, updateSelectedValues, activeProduct } = this.props;
 
         return {
             options,
-            updateSelectedValues
+            updateSelectedValues,
+            isProductInStock: getProductInStock(activeProduct)
         };
     }
 
@@ -49,4 +61,4 @@ export class ProductCustomizableOptionsContainer extends PureComponent {
     }
 }
 
-export default ProductCustomizableOptionsContainer;
+export default connect(mapStateToProps, mapDispatchToProps)(ProductCustomizableOptionsContainer);


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3455

**Problem:**
* Options are not disabled if customizable product is 'Out of stock'

**In this PR:**
1- In the last File ([ProductCustomizableOptions.container](https://github.com/scandipwa/scandipwa/compare/master...EriSilver:3455-DisableOptionsOutOfStock?expand=1#diff-8bbe52c0609f691da013384805af61984c0e483169bf9a74cacd24322ffcf2de)): got the activeProduct from reduc store and checked for its availability by getProductInStock(activeProduct) 
*Tested in ProductCustomizableOption**s**.container not ProductCustomizableOption to use the function once since it's fixed and not keep activating it with every option*

2- Passed `isProductInStock` to [ProductCustomizableOption.container.js](https://github.com/scandipwa/scandipwa/compare/master...EriSilver:3455-DisableOptionsOutOfStock?expand=1#diff-b8dffcf1de3fc0564da94fb2c7e7d03b7f0025b5e341296d22dda81f7578e957) then component, 
which adds `isDisabled` to Fields and `disabled` to attrs when needed

3- Modified the Fields' files that needed modification
4- Added extra BEM --> isDisabled mods to Field of type 'file', to set cursor as default instead of pointer when disabled