### PR TITLE
[4478] - Mac: vertically cropped dropdowns - Fixed

### DIFF
--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -46,8 +46,7 @@ $select-arrow-width: 14px !default;
         width: 100%;
         margin-block-start: -2px;
         padding-inline-end: 40px;
-        min-height: max-content;
-        height: 48px;
+        height: max-content;
 
         @include desktop {
             pointer-events: none;

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -16,10 +16,6 @@ $select-arrow-height: 14px !default;
 $select-arrow-width: 14px !default;
 
 .FieldSelect {
-    select {
-        min-height: max-content;
-    }
-
     &-Clickable {
         cursor: pointer;
         display: flex;
@@ -50,7 +46,7 @@ $select-arrow-width: 14px !default;
         width: 100%;
         margin-block-start: -2px;
         padding-inline-end: 40px;
-        min-height: 30px;
+        min-height: max-content;
         height: 48px;
 
         @include desktop {

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -16,6 +16,10 @@ $select-arrow-height: 14px !default;
 $select-arrow-width: 14px !default;
 
 .FieldSelect {
+    select {
+        min-height: max-content;
+    }
+
     &-Clickable {
         cursor: pointer;
         display: flex;

--- a/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
+++ b/packages/scandipwa/src/component/FieldSelect/FieldSelect.style.scss
@@ -46,6 +46,7 @@ $select-arrow-width: 14px !default;
         width: 100%;
         margin-block-start: -2px;
         padding-inline-end: 40px;
+        min-height: 30px;
         height: max-content;
 
         @include desktop {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4478

**Problem:**
* Mac: vertically cropped dropdowns

**In this PR:**
* Added `min-height: max-content` to select tags
