### PR TITLE
[4637] - Currency Switcher displays currencies for which rates were not set - fixed

### DIFF
--- a/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.component.js
+++ b/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.component.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable react/prop-types */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *
@@ -30,6 +28,15 @@ export class CurrencySwitcher extends PureComponent {
                 )
             ),
             current_currency_code: PropTypes.string
+        }).isRequired,
+        currencyRates: PropTypes.shape({
+            base_currency_code: PropTypes.string,
+            exchange_rates: PropTypes.arrayOf(
+                PropTypes.objectOf(
+                    PropTypes.string,
+                    PropTypes.number
+                )
+            )
         }).isRequired,
         handleCurrencySelect: PropTypes.func.isRequired
     };

--- a/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.component.js
+++ b/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.component.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/prop-types */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *
@@ -47,6 +49,31 @@ export class CurrencySwitcher extends PureComponent {
         return availableCurrencies.some((e) => e.id === currency) ? currency : currentCurrencyCode;
     }
 
+    currencyHasRate(currency_code) {
+        const {
+            currencyRates: {
+                base_currency_code: base,
+                exchange_rates: rates
+            }
+        } = this.props;
+
+        if (currency_code === base) {
+            return true;
+        }
+
+        if (rates.find(({ currency_to }) => currency_to === currency_code).rate !== 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+    returnFilteredCurrencies() {
+        const { currencyData: { available_currencies_data: availableCurrencies } } = this.props;
+        const currenciesToFilter = Array.from(availableCurrencies);
+        return currenciesToFilter.filter(({ value }) => this.currencyHasRate(value));
+    }
+
     render() {
         const {
             handleCurrencySelect,
@@ -69,7 +96,7 @@ export class CurrencySwitcher extends PureComponent {
                       events={ {
                           onChange: handleCurrencySelect
                       } }
-                      options={ availableCurrencies }
+                      options={ this.returnFilteredCurrencies() }
                     />
                 </div>
             );

--- a/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.component.js
+++ b/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.component.js
@@ -29,7 +29,7 @@ export class CurrencySwitcher extends PureComponent {
             ),
             current_currency_code: PropTypes.string
         }).isRequired,
-        currencyRates: PropTypes.shape({
+        currency: PropTypes.shape({
             base_currency_code: PropTypes.string,
             exchange_rates: PropTypes.arrayOf(
                 PropTypes.objectOf(
@@ -58,7 +58,7 @@ export class CurrencySwitcher extends PureComponent {
 
     currencyHasRate(currency_code) {
         const {
-            currencyRates: {
+            currency: {
                 base_currency_code: base,
                 exchange_rates: rates
             }
@@ -68,7 +68,7 @@ export class CurrencySwitcher extends PureComponent {
             return true;
         }
 
-        if (rates.find(({ currency_to }) => currency_to === currency_code).rate !== 0) {
+        if (rates?.find(({ currency_to }) => currency_to === currency_code).rate !== 0) {
             return true;
         }
 
@@ -77,8 +77,7 @@ export class CurrencySwitcher extends PureComponent {
 
     returnFilteredCurrencies() {
         const { currencyData: { available_currencies_data: availableCurrencies } } = this.props;
-        const currenciesToFilter = Array.from(availableCurrencies);
-        return currenciesToFilter.filter(({ value }) => this.currencyHasRate(value));
+        return availableCurrencies.filter(({ value }) => this.currencyHasRate(value));
     }
 
     render() {

--- a/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.component.js
+++ b/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.component.js
@@ -29,15 +29,6 @@ export class CurrencySwitcher extends PureComponent {
             ),
             current_currency_code: PropTypes.string
         }).isRequired,
-        currency: PropTypes.shape({
-            base_currency_code: PropTypes.string,
-            exchange_rates: PropTypes.arrayOf(
-                PropTypes.objectOf(
-                    PropTypes.string,
-                    PropTypes.number
-                )
-            )
-        }).isRequired,
         handleCurrencySelect: PropTypes.func.isRequired
     };
 
@@ -54,30 +45,6 @@ export class CurrencySwitcher extends PureComponent {
         const currency = getCurrency();
 
         return availableCurrencies.some((e) => e.id === currency) ? currency : currentCurrencyCode;
-    }
-
-    currencyHasRate(currency_code) {
-        const {
-            currency: {
-                base_currency_code: base,
-                exchange_rates: rates
-            }
-        } = this.props;
-
-        if (currency_code === base) {
-            return true;
-        }
-
-        if (rates?.find(({ currency_to }) => currency_to === currency_code).rate !== 0) {
-            return true;
-        }
-
-        return false;
-    }
-
-    returnFilteredCurrencies() {
-        const { currencyData: { available_currencies_data: availableCurrencies } } = this.props;
-        return availableCurrencies.filter(({ value }) => this.currencyHasRate(value));
     }
 
     render() {
@@ -102,7 +69,7 @@ export class CurrencySwitcher extends PureComponent {
                       events={ {
                           onChange: handleCurrencySelect
                       } }
-                      options={ this.returnFilteredCurrencies() }
+                      options={ availableCurrencies }
                     />
                 </div>
             );

--- a/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.container.js
+++ b/packages/scandipwa/src/component/CurrencySwitcher/CurrencySwitcher.container.js
@@ -19,8 +19,7 @@ import CurrencySwitcher from './CurrencySwitcher.component';
 
 /** @namespace Component/CurrencySwitcher/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
-    currencyData: state.ConfigReducer.currencyData,
-    currency: state.ConfigReducer.currency
+    currencyData: state.ConfigReducer.currencyData
 });
 
 /** @namespace Component/CurrencySwitcher/Container/mapDispatchToProps */
@@ -38,15 +37,6 @@ export class CurrencySwitcherContainer extends DataContainer {
                 )
             ),
             current_currency_code: PropTypes.string
-        }).isRequired,
-        currency: PropTypes.shape({
-            base_currency_code: PropTypes.string,
-            exchange_rates: PropTypes.arrayOf(
-                PropTypes.objectOf(
-                    PropTypes.string,
-                    PropTypes.number
-                )
-            )
         }).isRequired
     };
 
@@ -68,8 +58,8 @@ export class CurrencySwitcherContainer extends DataContainer {
     }
 
     containerProps() {
-        const { currencyData, currency } = this.props;
-        return { currencyData, currency };
+        const { currencyData } = this.props;
+        return { currencyData };
     }
 
     render() {

--- a/packages/scandipwa/src/query/Config.query.js
+++ b/packages/scandipwa/src/query/Config.query.js
@@ -28,7 +28,8 @@ export class ConfigQuery {
             .addFieldList([
                 'id',
                 'label',
-                'value'
+                'value',
+                new Field('exchange_rates').addFieldList(['currency_to', 'rate'])
             ]);
     }
 
@@ -38,6 +39,13 @@ export class ConfigQuery {
                 this.getCurrencyField(),
                 'current_currency_code'
             ]);
+    }
+
+    getCurrencyRates() {
+        return new Field('currency')
+            .addField('base_currency_code')
+            .addField(new Field('exchange_rates')
+                .addFieldList(['currency_to', 'rate']));
     }
 
     getPriceDisplayTypeField() {

--- a/packages/scandipwa/src/query/Config.query.js
+++ b/packages/scandipwa/src/query/Config.query.js
@@ -45,14 +45,13 @@ export class ConfigQuery {
     }
 
     getCurrencyRates() {
-        return new Field('currency').addFieldList(this.getCurrencyRatesField())
-            .addFieldList(this._getCurrencyRatesField());
+        return new Field('currency').addFieldList(this.getCurrencyRatesField());
     }
 
     getCurrencyRatesField() {
         return [
             'base_currency_code',
-            'exchange_rates'
+            new Field('exchange_rates').addFieldList(this._getExchangeRatesField())
         ];
     }
 

--- a/packages/scandipwa/src/query/Config.query.js
+++ b/packages/scandipwa/src/query/Config.query.js
@@ -26,17 +26,17 @@ export class ConfigQuery {
     getCurrencyData() {
         return new Field('currencyData')
             .addFieldList([
-                this.getCurrencyField(),
+                this.getCurrencyFields(),
                 'current_currency_code'
             ]);
     }
 
-    getCurrencyField() {
+    getCurrencyFields() {
         return new Field('available_currencies_data')
-            .addFieldList(this._getCurrencyField());
+            .addFieldList(this._getAvailableCurrenciesFields());
     }
 
-    _getCurrencyField() {
+    _getAvailableCurrenciesFields() {
         return [
             'id',
             'label',
@@ -45,17 +45,17 @@ export class ConfigQuery {
     }
 
     getCurrencyRates() {
-        return new Field('currency').addFieldList(this.getCurrencyRatesField());
+        return new Field('currency').addFieldList(this.getCurrencyRatesFields());
     }
 
-    getCurrencyRatesField() {
+    getCurrencyRatesFields() {
         return [
             'base_currency_code',
-            new Field('exchange_rates').addFieldList(this._getExchangeRatesField())
+            new Field('exchange_rates').addFieldList(this._getExchangeRatesFields())
         ];
     }
 
-    _getExchangeRatesField() {
+    _getExchangeRatesFields() {
         return [
             'currency_to',
             'rate'

--- a/packages/scandipwa/src/query/Config.query.js
+++ b/packages/scandipwa/src/query/Config.query.js
@@ -23,16 +23,6 @@ export class ConfigQuery {
             .addFieldList(this._getCheckoutAgreementFields());
     }
 
-    getCurrencyField() {
-        return new Field('available_currencies_data')
-            .addFieldList([
-                'id',
-                'label',
-                'value',
-                new Field('exchange_rates').addFieldList(['currency_to', 'rate'])
-            ]);
-    }
-
     getCurrencyData() {
         return new Field('currencyData')
             .addFieldList([
@@ -41,11 +31,36 @@ export class ConfigQuery {
             ]);
     }
 
+    getCurrencyField() {
+        return new Field('available_currencies_data')
+            .addFieldList(this._getCurrencyField());
+    }
+
+    _getCurrencyField() {
+        return [
+            'id',
+            'label',
+            'value'
+        ];
+    }
+
     getCurrencyRates() {
-        return new Field('currency')
-            .addField('base_currency_code')
-            .addField(new Field('exchange_rates')
-                .addFieldList(['currency_to', 'rate']));
+        return new Field('currency').addFieldList(this.getCurrencyRatesField())
+            .addFieldList(this._getCurrencyRatesField());
+    }
+
+    getCurrencyRatesField() {
+        return [
+            'base_currency_code',
+            'exchange_rates'
+        ];
+    }
+
+    _getExchangeRatesField() {
+        return [
+            'currency_to',
+            'rate'
+        ];
     }
 
     getPriceDisplayTypeField() {

--- a/packages/scandipwa/src/store/Config/Config.dispatcher.js
+++ b/packages/scandipwa/src/store/Config/Config.dispatcher.js
@@ -16,7 +16,7 @@ import ReviewQuery from 'Query/Review.query';
 import { updateConfig } from 'Store/Config/Config.action';
 import { showNotification } from 'Store/Notification/Notification.action';
 import BrowserDatabase from 'Util/BrowserDatabase';
-import { setCurrency } from 'Util/Currency';
+import { returnFilteredCurrencies, setCurrency } from 'Util/Currency';
 import { fetchMutation, QueryDispatcher } from 'Util/Request';
 import { ONE_MONTH_IN_SECONDS } from 'Util/Request/QueryDispatcher';
 
@@ -39,8 +39,10 @@ export class ConfigDispatcher extends QueryDispatcher {
 
     onSuccess(data, dispatch) {
         if (data) {
-            BrowserDatabase.setItem(data, 'config', ONE_MONTH_IN_SECONDS);
-            dispatch(updateConfig(data));
+            const { currencyData, currency } = data;
+            const filteredData = { ...data, ...returnFilteredCurrencies(currencyData, currency) };
+            BrowserDatabase.setItem(filteredData, 'config', ONE_MONTH_IN_SECONDS);
+            dispatch(updateConfig(filteredData));
         }
     }
 

--- a/packages/scandipwa/src/store/Config/Config.dispatcher.js
+++ b/packages/scandipwa/src/store/Config/Config.dispatcher.js
@@ -55,6 +55,7 @@ export class ConfigDispatcher extends QueryDispatcher {
             ConfigQuery.getQuery(),
             ConfigQuery.getCheckoutAgreements(),
             ConfigQuery.getCurrencyData(),
+            ConfigQuery.getCurrencyRates(),
             CartQuery.getCartDisplayConfig()
         ];
     }

--- a/packages/scandipwa/src/store/Config/Config.reducer.js
+++ b/packages/scandipwa/src/store/Config/Config.reducer.js
@@ -25,7 +25,7 @@ export const filterStoreConfig = (config) => Object.entries(config).reduce(
 
 /** @namespace Store/Config/Reducer/filterAvailableCurrencies */
 export const filterAvailableCurrencies = (currencyData, currencyRates) => {
-    if (currencyData.available_currencies_data.length < 1 || currencyRates.exchange_rates.length < 1) {
+    if (currencyData?.available_currencies_data?.length < 1 || currencyRates?.exchange_rates?.length < 1) {
         return ({ currencyData, currencyRates });
     }
     const { available_currencies_data: availableCurrencies = [] } = currencyData;
@@ -109,7 +109,6 @@ export const ConfigReducer = (
             reviewRatings,
             checkoutAgreements,
             currencyData,
-            currency,
             storeConfig = {},
             cartDisplayConfig = {}
         } = {},
@@ -119,10 +118,6 @@ export const ConfigReducer = (
     switch (type) {
     case UPDATE_CONFIG:
         const filteredStoreConfig = filterStoreConfig(storeConfig);
-        // const filteredCurrencyData = {
-        //     ...currencyData,
-        //     ...filterAvailableCurrencies(currencyData, currency)
-        // };
         const { secure_base_media_url } = filteredStoreConfig;
         window.secure_base_media_url = secure_base_media_url;
 
@@ -131,12 +126,7 @@ export const ConfigReducer = (
             countries: getCountryData(countries, state),
             reviewRatings: getIndexedRatings(reviewRatings),
             checkoutAgreements: getCheckoutAgreementData(checkoutAgreements, state),
-            ...filterAvailableCurrencies(
-                getCurrencyData(currencyData, state),
-                getCurrencyRates(currency, state)
-            ),
-            // currency: getCurrencyRates(currency, state),
-            // ...filteredCurrencyData,
+            ...filterAvailableCurrencies(currencyData, currency),
             ...filteredStoreConfig,
             // Should be updated manually as filteredStoreConfig does not contain header_logo_src when it is null
             // and header_logo_src takes old value
@@ -157,5 +147,4 @@ export const ConfigReducer = (
         return state;
     }
 };
-
 export default ConfigReducer;

--- a/packages/scandipwa/src/store/Config/Config.reducer.js
+++ b/packages/scandipwa/src/store/Config/Config.reducer.js
@@ -52,8 +52,11 @@ export const {
 /** @namespace Store/Config/Reducer/getIndexedRatings */
 export const getIndexedRatings = (reviewRatings) => ((reviewRatings) ? reviewRatings.items || [] : []);
 
-/** @namespace Store/Config/Reducer/getCurrency */
-export const getCurrency = (base, state) => (base || state.currency || {});
+/** @namespace Store/Config/Reducer/getCurrencyRates */
+export const getCurrencyRates = (base, state) => (base || state.currency || {});
+
+/** @namespace Store/Config/Reducer/getCurrencyData */
+export const getCurrencyData = (base, state) => (base || state.currencyData || {});
 
 /** @namespace Store/Config/Reducer/getCountryData */
 export const getCountryData = (base, state) => (base || state.countries || {});
@@ -121,7 +124,7 @@ export const ConfigReducer = (
             countries: getCountryData(countries, state),
             reviewRatings: getIndexedRatings(reviewRatings),
             checkoutAgreements: getCheckoutAgreementData(checkoutAgreements, state),
-            currency: getCurrency(currency, state),
+            currency: getCurrencyRates(currency, state),
             ...filteredCurrencyData,
             ...filteredStoreConfig,
             // Should be updated manually as filteredStoreConfig does not contain header_logo_src when it is null

--- a/packages/scandipwa/src/store/Config/Config.reducer.js
+++ b/packages/scandipwa/src/store/Config/Config.reducer.js
@@ -23,28 +23,6 @@ export const filterStoreConfig = (config) => Object.entries(config).reduce(
     {}
 );
 
-/** @namespace Store/Config/Reducer/filterAvailableCurrencies */
-export const filterAvailableCurrencies = (currencyData, currencyRates) => {
-    if (
-        currencyData?.available_currencies_data?.length < 1 || currencyRates?.exchange_rates?.length < 1) {
-        return ({ currencyData, currencyRates });
-    }
-
-    const { available_currencies_data: availableCurrencies = [] } = currencyData;
-    const { base_curreny_code: base, exchange_rates: rates = [] } = currencyRates;
-
-    return ({
-        currencyData: {
-            ...currencyData,
-            available_currencies_data:
-                availableCurrencies.filter(({ value }) => (
-                    value === base || rates?.find(({ currency_to }) => currency_to === value).rate > 0
-                ))
-        },
-        currencyRates
-    });
-};
-
 export const {
     countries, reviewRatings, storeConfig, currencyData, currency, cartDisplayConfig
 } = BrowserDatabase.getItem('config') || {
@@ -81,7 +59,8 @@ export const getCheckoutAgreementData = (base, state) => (base || state.checkout
 /** @namespace Store/Config/Reducer/getInitialState */
 export const getInitialState = () => ({
     ...filterStoreConfig(storeConfig),
-    ...filterAvailableCurrencies(currencyData, currency),
+    currencyData,
+    currency,
     countries,
     reviewRatings,
     checkoutAgreements: [],
@@ -129,7 +108,8 @@ export const ConfigReducer = (
             countries: getCountryData(countries, state),
             reviewRatings: getIndexedRatings(reviewRatings),
             checkoutAgreements: getCheckoutAgreementData(checkoutAgreements, state),
-            ...filterAvailableCurrencies(currencyData, currency),
+            currency: getCurrencyRates(currency, state),
+            currencyData: getCurrencyData(currencyData, state),
             ...filteredStoreConfig,
             // Should be updated manually as filteredStoreConfig does not contain header_logo_src when it is null
             // and header_logo_src takes old value

--- a/packages/scandipwa/src/store/Config/Config.reducer.js
+++ b/packages/scandipwa/src/store/Config/Config.reducer.js
@@ -25,18 +25,21 @@ export const filterStoreConfig = (config) => Object.entries(config).reduce(
 
 /** @namespace Store/Config/Reducer/filterAvailableCurrencies */
 export const filterAvailableCurrencies = (currencyData, currencyRates) => {
-    if (currencyData?.available_currencies_data?.length < 1 || currencyRates?.exchange_rates?.length < 1) {
+    if (
+        currencyData?.available_currencies_data?.length < 1 || currencyRates?.exchange_rates?.length < 1) {
         return ({ currencyData, currencyRates });
     }
+
     const { available_currencies_data: availableCurrencies = [] } = currencyData;
     const { base_curreny_code: base, exchange_rates: rates = [] } = currencyRates;
+
     return ({
         currencyData: {
             ...currencyData,
             available_currencies_data:
-     availableCurrencies.filter(({ value }) => (
-         value === base || rates?.find(({ currency_to }) => currency_to === value).rate > 0
-     ))
+                availableCurrencies.filter(({ value }) => (
+                    value === base || rates?.find(({ currency_to }) => currency_to === value).rate > 0
+                ))
         },
         currencyRates
     });

--- a/packages/scandipwa/src/store/Config/Config.reducer.js
+++ b/packages/scandipwa/src/store/Config/Config.reducer.js
@@ -24,12 +24,13 @@ export const filterStoreConfig = (config) => Object.entries(config).reduce(
 );
 
 export const {
-    countries, reviewRatings, storeConfig, currencyData, cartDisplayConfig
+    countries, reviewRatings, storeConfig, currencyData, currency, cartDisplayConfig
 } = BrowserDatabase.getItem('config') || {
     countries: [],
     reviewRatings: [],
     storeConfig: {},
     currencyData: {},
+    currency: {},
     cartDisplayConfig: {
         display_tax_in_price: '',
         display_tax_in_subtotal: '',
@@ -46,6 +47,9 @@ export const getIndexedRatings = (reviewRatings) => ((reviewRatings) ? reviewRat
 /** @namespace Store/Config/Reducer/getCurrencyData */
 export const getCurrencyData = (base, state) => (base || state.currencyData || {});
 
+/** @namespace Store/Config/Reducer/getCurrency */
+export const getCurrency = (base, state) => (base || state.currency || {});
+
 /** @namespace Store/Config/Reducer/getCountryData */
 export const getCountryData = (base, state) => (base || state.countries || {});
 
@@ -59,6 +63,7 @@ export const getInitialState = () => ({
     reviewRatings,
     checkoutAgreements: [],
     currencyData,
+    currency,
     isLoading: true,
     cartDisplayConfig,
     priceTaxDisplay: {},
@@ -86,6 +91,7 @@ export const ConfigReducer = (
             reviewRatings,
             checkoutAgreements,
             currencyData,
+            currency,
             storeConfig = {},
             cartDisplayConfig = {}
         } = {},
@@ -104,6 +110,7 @@ export const ConfigReducer = (
             reviewRatings: getIndexedRatings(reviewRatings),
             checkoutAgreements: getCheckoutAgreementData(checkoutAgreements, state),
             currencyData: getCurrencyData(currencyData, state),
+            currency: getCurrency(currency, state),
             ...filteredStoreConfig,
             // Should be updated manually as filteredStoreConfig does not contain header_logo_src when it is null
             // and header_logo_src takes old value

--- a/packages/scandipwa/src/util/Currency/Currency.js
+++ b/packages/scandipwa/src/util/Currency/Currency.js
@@ -43,3 +43,31 @@ export const getCurrency = () => {
 
     return (typeof currency === 'string') ? currency : '';
 };
+
+/**
+ *
+ * @param {object} currencyData
+ * @param {object} currencyRates
+ * @returns {object} filtered currencyData object and currency (rates) object
+ * @namespace Util/Currency/returnFilteredCurrencies
+ */
+export const returnFilteredCurrencies = (currencyData, currencyRates) => {
+    if (
+        currencyData?.available_currencies_data?.length < 1 || currencyRates?.exchange_rates?.length < 1) {
+        return ({ currencyData, currencyRates });
+    }
+
+    const { available_currencies_data: availableCurrencies = [] } = currencyData;
+    const { base_curreny_code: base, exchange_rates: rates = [] } = currencyRates;
+
+    return ({
+        currencyData: {
+            ...currencyData,
+            available_currencies_data:
+                availableCurrencies.filter(({ value }) => (
+                    value === base || rates?.find(({ currency_to }) => currency_to === value)?.rate > 0
+                ))
+        },
+        currency: currencyRates
+    });
+};


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4637

**Problem:**
* The Currency switched displayed currencies for which the exchange rate wasn't specified in the admin panel

**In this PR:**
* Created a new query that fetches the exchange rates
* Used this new data to filter out the currencies for which no rate was specified
* Wired the currency switcher to the new filtered list so that only the proper values are displayed
