### PR TITLE
added check if it is loading for compare btn

### DIFF
--- a/packages/scandipwa/src/component/ProductCompareButton/ProductCompareButton.container.js
+++ b/packages/scandipwa/src/component/ProductCompareButton/ProductCompareButton.container.js
@@ -84,6 +84,12 @@ export class ProductCompareButtonContainer extends PureComponent {
             removeComparedProduct
         } = this.props;
 
+        const { isLoading } = this.state;
+
+        if (isLoading) {
+            return;
+        }
+
         e.preventDefault();
 
         this.setState({ isLoading: true });


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4651 

**Problem:**
* Request sent every time when the user clicked on compare button even if it Is loading and loader is shown.

**In this PR:**
* Added check if loading then return
