### PR TITLE
 [4273] - Fixed the footer's jumping when clicking on (Links and ProductCards) on CMS

### DIFF
--- a/packages/scandipwa/src/component/Html/Html.component.js
+++ b/packages/scandipwa/src/component/Html/Html.component.js
@@ -17,12 +17,7 @@ import parser from 'html-react-parser';
 import attributesToProps from 'html-react-parser/lib/attributes-to-props';
 import domToReact from 'html-react-parser/lib/dom-to-react';
 import PropTypes from 'prop-types';
-import {
-    Fragment,
-    lazy,
-    PureComponent,
-    Suspense
-} from 'react';
+import { lazy, PureComponent, Suspense } from 'react';
 
 import Image from 'Component/Image';
 import Link from 'Component/Link';
@@ -146,46 +141,6 @@ export class Html extends PureComponent {
 
     /**
      * Replace links to native React Router links
-     * @param  {{ children: Array }}
-     * @return {JSX} Return JSX if link is allowed to be replaced
-     * @memberof Html
-     */
-    domToReactFunction(children) {
-        if (children[1]?.attribs.class?.includes('HomepageCategories-Button')) {
-            return [
-                <Fragment key="HomepageCategories-Button1">
-                    { domToReact(children[0], this.parserOptions) }
-                </Fragment>,
-                <button
-                  { ...attributesToProps({
-                      ...children[1].attribs,
-                      onClick: this.scrollToTopFunction,
-                      key: 'HomepageCategories-Button2'
-                  }) }
-                >
-                    { domToReact(children[1].children, this.parserOptions) }
-                </button>,
-                <Fragment key="HomepageCategories-Button3">
-                    { domToReact(children[2], this.parserOptions) }
-                </Fragment>
-            ];
-        }
-
-        if (children[0]?.attribs?.class?.includes('HomepageCategories-Button')) {
-            return (
-                <button
-                  { ...attributesToProps({ ...children[0].attribs, onClick: this.scrollToTopFunction }) }
-                >
-                    { domToReact(children[0].children, this.parserOptions) }
-                </button>
-            );
-        }
-
-        return domToReact(children, this.parserOptions);
-    }
-
-    /**
-     * Replace links to native React Router links
      * @param  {{ attribs: Object, children: Array }}
      * @return {void|JSX} Return JSX if link is allowed to be replaced
      * @memberof Html
@@ -199,8 +154,11 @@ export class Html extends PureComponent {
 
             if (!isAbsoluteUrl(href) && !isSpecialLink(href)) {
                 return (
-                    <Link { ...attributesToProps({ ...attrs, to: href }) }>
-                        { this.domToReactFunction(children) }
+                    <Link
+                      onClick={ this.scrollToTopFunction }
+                      { ...attributesToProps({ ...attrs, to: href }) }
+                    >
+                        { domToReact(children, this.parserOptions) }
                     </Link>
                 );
             }

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -84,6 +84,7 @@ export class ProductCard extends Product {
 
     registerSharedElement() {
         const { registerSharedElement } = this.props;
+        document.documentElement.scrollIntoView();
         registerSharedElement(this.imageRef);
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4273

**Problem:**
* The original merged 
PR https://github.com/scandipwa/scandipwa/pull/4431 (commit 24cf3b0950a34420ecea4986d8e4c199537ca76f) 
focused on the buttons (scrollToTop on clicking HomepageCategoriesButtons not all redirects)

**In this PR:**
Reverted commit 24cf3b0950a34420ecea4986d8e4c199537ca76f (undid parsing buttons and domToReactFunction)
But kept the same idea of scrolling to top on changing pages
Only expanded it to all links (not just buttons)
Also added scrollToTop to the onClick function of Products' cards since the issue was reproduced on clicking on Products cards

(Also merged master)
*ScrollToTopFunction is on line 138 in the new commit*