### PR TITLE
checking if the attribute is available and returning the function and correction styles

### DIFF
--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -104,10 +104,15 @@ export class ProductAttributeValue extends PureComponent {
     }
 
     clickHandler(e) {
-        const { onClick, attribute } = this.props;
+        const { onClick, attribute, isAvailable } = this.props;
 
         e.preventDefault();
         e.stopPropagation();
+
+        if (!isAvailable) {
+            return;
+        }
+
         onClick(attribute);
     }
 

--- a/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/packages/scandipwa/src/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -207,7 +207,7 @@
         }
     }
 
-    &:hover {
+    &:hover:not(&_isNotAvailable) {
         @include desktop {
             --option-border-color: var(--primary-base-color);
             --option-text-color: var(--primary-base-color);
@@ -219,13 +219,26 @@
     &_isNotAvailable {
         opacity: .5;
         cursor: default;
-        pointer-events: none;
 
-        .ProductAttributeValue-Color {
-            &::before {
-                @include not-available;
+        .ProductAttributeValue {
+            &-Color {
+                &::before {
+                    @include not-available;
 
-                background-color: var(--option-check-mark-background);
+                    background-color: var(--option-check-mark-background);
+                }
+            }
+
+            &-Color,
+            &-Image-Overlay {
+                &:hover {
+                    @include desktop {
+                        &::before,
+                        &::after {
+                            --option-is-selected: 0;
+                        }
+                    }
+                }
             }
         }
     }

--- a/packages/scandipwa/src/component/ProductConfigurableAttributes/ProductConfigurableAttributes.style.scss
+++ b/packages/scandipwa/src/component/ProductConfigurableAttributes/ProductConfigurableAttributes.style.scss
@@ -63,7 +63,7 @@
         margin-block-start: var(--option-margin-block);
         margin-inline-end: var(--option-margin-inline);
         margin-inline-start: var(--option-margin-inline);
-    } 
+    }
 
     &-Expandable:first-of-type {
         border-block-start: none;


### PR DESCRIPTION

**Related issue(s):**
* Fixes #4665 

**Problem:**
* The user redirected to PDP if clicked on the disabled option

**In this PR:**
* Removed the pointer-events property from styles and handle clicks for disabled options but just return the function and corrected the styles for hover effects.
