### PR TITLE
made color for text transparent TEST

### DIFF
--- a/packages/scandipwa/src/component/Image/Image.style.scss
+++ b/packages/scandipwa/src/component/Image/Image.style.scss
@@ -103,6 +103,7 @@
         height: 100%;
         object-position: 50% 50%;
         object-fit: contain;
+        color: transparent;
 
         &::after {
             content: '';


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4661 

**Problem:**
* The alt text of the images was visible in Firefox

**In this PR:**
* Made color transparent
