### PR TITLE
[3742] - [2973]  - Go back from billing to shipping

### DIFF
--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.component.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.component.js
@@ -32,27 +32,36 @@ export class CheckoutAddressBook extends PureComponent {
         onShippingEstimationFieldsChange: PropTypes.func.isRequired,
         selectedAddressId: PropTypes.number.isRequired,
         isBilling: PropTypes.bool.isRequired,
-        isSubmitted: PropTypes.bool.isRequired,
-        is_virtual: PropTypes.bool.isRequired
-    };
-
-    state = {
-        isCustomAddressExpanded: false
+        isSubmitted: PropTypes.bool.isRequired
     };
 
     renderAddress = this.renderAddress.bind(this);
 
     expandCustomAddress = this.expandCustomAddress.bind(this);
 
+    __construct(props) {
+        super.__construct(props);
+        const {
+            isBilling = false,
+            selectedAddressId = 0,
+            shippingFields = {}
+        } = props;
+
+        this.state = {
+            isCustomAddressExpanded: false,
+            customAddress: (
+                !isBilling && !selectedAddressId
+                    ? shippingFields
+                    : {}
+            )
+        };
+    }
+
     static getDerivedStateFromProps(props) {
-        const { is_virtual, selectedAddressId, customer: { addresses = [] } } = props;
+        const { selectedAddressId, customer: { addresses = [] } } = props;
 
-        if (addresses.length === 0) {
+        if (!addresses.length || !selectedAddressId) {
             return { isCustomAddressExpanded: true };
-        }
-
-        if (selectedAddressId === 0) {
-            return is_virtual ? { isCustomAddressExpanded: true } : null;
         }
 
         return { isCustomAddressExpanded: false };
@@ -130,12 +139,13 @@ export class CheckoutAddressBook extends PureComponent {
 
     renderCustomAddress() {
         const { isBilling, onShippingEstimationFieldsChange, isSubmitted } = this.props;
+        const { customAddress = {} } = this.state;
         const formPortalId = isBilling ? BILLING_STEP : SHIPPING_STEP;
 
         return (
             <CheckoutAddressForm
               onShippingEstimationFieldsChange={ onShippingEstimationFieldsChange }
-              address={ {} }
+              address={ customAddress }
               id={ formPortalId }
               isSubmitted={ isSubmitted }
             />

--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.component.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.component.js
@@ -51,7 +51,7 @@ export class CheckoutAddressBook extends PureComponent {
             isCustomAddressExpanded: false,
             customAddress: (
                 !isBilling && !selectedAddressId
-                    ? this.prepareAddressFormat(shippingFields)
+                    ? shippingFields
                     : {}
             )
         };
@@ -65,32 +65,6 @@ export class CheckoutAddressBook extends PureComponent {
         }
 
         return { isCustomAddressExpanded: false };
-    }
-
-    prepareAddressFormat(address) {
-        const {
-            country_id: countryId,
-            region: {
-                region,
-                region_id: regionId
-            } = {},
-            region_id,
-            region: address_region,
-            region_string,
-            ...data
-        } = address;
-
-        return {
-            ...data,
-            countryId,
-            region: (
-                region_string
-                || region
-                || JSON.stringify(address_region) === '{}' ? '' : address_region
-                || ''
-            ),
-            regionId: region_id || regionId
-        };
     }
 
     expandCustomAddress() {

--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.component.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.component.js
@@ -51,7 +51,7 @@ export class CheckoutAddressBook extends PureComponent {
             isCustomAddressExpanded: false,
             customAddress: (
                 !isBilling && !selectedAddressId
-                    ? shippingFields
+                    ? this.prepareAddressFormat(shippingFields)
                     : {}
             )
         };
@@ -65,6 +65,32 @@ export class CheckoutAddressBook extends PureComponent {
         }
 
         return { isCustomAddressExpanded: false };
+    }
+
+    prepareAddressFormat(address) {
+        const {
+            country_id: countryId,
+            region: {
+                region,
+                region_id: regionId
+            } = {},
+            region_id,
+            region: address_region,
+            region_string,
+            ...data
+        } = address;
+
+        return {
+            ...data,
+            countryId,
+            region: (
+                region_string
+                || region
+                || JSON.stringify(address_region) === '{}' ? '' : address_region
+                || ''
+            ),
+            regionId: region_id || regionId
+        };
     }
 
     expandCustomAddress() {

--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
-import { CustomerType } from 'Type/Account.type';
+import { Addresstype, CustomerType } from 'Type/Account.type';
 import { isSignedIn } from 'Util/Auth';
 import { noopFn } from 'Util/Common';
 
@@ -26,7 +26,8 @@ export const MyAccountDispatcher = import(
 
 /** @namespace Component/CheckoutAddressBook/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
-    customer: state.MyAccountReducer.customer
+    customer: state.MyAccountReducer.customer,
+    shippingFields: state.CheckoutReducer.shippingFields
 });
 
 /** @namespace Component/CheckoutAddressBook/Container/mapDispatchToProps */
@@ -45,7 +46,8 @@ export class CheckoutAddressBookContainer extends PureComponent {
         customer: CustomerType.isRequired,
         isBilling: PropTypes.bool,
         isSubmitted: PropTypes.bool,
-        is_virtual: PropTypes.bool
+        is_virtual: PropTypes.bool,
+        shippingFields: Addresstype
     };
 
     static defaultProps = {
@@ -53,7 +55,8 @@ export class CheckoutAddressBookContainer extends PureComponent {
         onAddressSelect: noopFn,
         onShippingEstimationFieldsChange: noopFn,
         isSubmitted: false,
-        is_virtual: false
+        is_virtual: false,
+        shippingFields: {}
     };
 
     static _getDefaultAddressId(props) {
@@ -91,14 +94,14 @@ export class CheckoutAddressBookContainer extends PureComponent {
 
         const defaultAddressId = CheckoutAddressBookContainer._getDefaultAddressId(props);
 
-        if (defaultAddressId) {
-            onAddressSelect(defaultAddressId);
-            this.estimateShipping(defaultAddressId);
-        }
+        const selectedAddressId = this.getSelectedAddressId(defaultAddressId);
+
+        onAddressSelect(selectedAddressId);
+        this.estimateShipping(selectedAddressId);
 
         this.state = {
             prevDefaultAddressId: defaultAddressId,
-            selectedAddressId: defaultAddressId
+            selectedAddressId
         };
     }
 
@@ -141,7 +144,7 @@ export class CheckoutAddressBookContainer extends PureComponent {
             onShippingEstimationFieldsChange,
             isBilling,
             isSubmitted,
-            is_virtual
+            shippingFields
         } = this.props;
         const { selectedAddressId } = this.state;
 
@@ -151,8 +154,32 @@ export class CheckoutAddressBookContainer extends PureComponent {
             isBilling,
             selectedAddressId,
             isSubmitted,
-            is_virtual
+            shippingFields
         };
+    }
+
+    getSelectedAddressId(defaultAddressId) {
+        const {
+            shippingFields: {
+                id: shippingFieldsId = 0,
+                street: shippingFieldsStreet = []
+            },
+            isBilling
+        } = this.props;
+
+        if (isBilling) {
+            return defaultAddressId;
+        }
+
+        if (shippingFieldsId) {
+            return shippingFieldsId;
+        }
+
+        if (!shippingFieldsStreet.length) {
+            return defaultAddressId;
+        }
+
+        return 0;
     }
 
     onAddressSelect(address) {

--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
@@ -160,6 +160,43 @@ export class CheckoutAddressBookContainer extends PureComponent {
         };
     }
 
+    getAddressIdFromAddressBook() {
+        const {
+            shippingFields,
+            customer: {
+                addresses = []
+            } = {}
+        } = this.props;
+
+        // the main keys distinguishing addresses
+        const keys = [
+            'city',
+            'country_id',
+            'firstname',
+            'lastname',
+            'postcode',
+            'telephone',
+            'vat_id'
+        ];
+
+        const filteredAddresses = (
+            addresses.filter((address) => (
+                keys.every((key) => {
+                    if (shippingFields[key] !== address[key]) {
+                        return false;
+                    }
+
+                    return true;
+                })
+                && (
+                    JSON.stringify(shippingFields.street) === JSON.stringify(address.street)
+                )
+            ))
+        );
+
+        return filteredAddresses.length ? filteredAddresses[0].id : 0;
+    }
+
     getSelectedAddressId(defaultAddressId) {
         const {
             shippingFields: {
@@ -181,7 +218,10 @@ export class CheckoutAddressBookContainer extends PureComponent {
             return defaultAddressId;
         }
 
-        return 0;
+        // comparing address values to check if the fetched address is in the address book
+        const addressId = this.getAddressIdFromAddressBook();
+
+        return addressId;
     }
 
     onAddressSelect(address) {

--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
@@ -224,7 +224,7 @@ export class CheckoutAddressBookContainer extends PureComponent {
             return defaultAddressId;
         }
 
-        return this.getAddressId();
+        return !this?.state ? 0 : this.getAddressId();
     }
 
     onAddressSelect(address) {

--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
@@ -96,8 +96,10 @@ export class CheckoutAddressBookContainer extends PureComponent {
 
         const selectedAddressId = this.getSelectedAddressId(defaultAddressId);
 
-        onAddressSelect(selectedAddressId);
-        this.estimateShipping(selectedAddressId);
+        if (selectedAddressId) {
+            onAddressSelect(selectedAddressId);
+            this.estimateShipping(selectedAddressId);
+        }
 
         this.state = {
             prevDefaultAddressId: defaultAddressId,
@@ -190,12 +192,21 @@ export class CheckoutAddressBookContainer extends PureComponent {
     estimateShipping(addressId) {
         const {
             onShippingEstimationFieldsChange,
-            customer: { addresses = [] }
+            customer: { addresses = [] },
+            shippingFields,
+            shippingFields: {
+                street: shippingFieldsStreet = []
+            },
+            isBilling
         } = this.props;
 
-        const address = addresses.find(({ id }) => id === addressId);
+        const address = (
+            !addressId && !isBilling
+                ? shippingFields
+                : addresses.find(({ id }) => id === addressId)
+        );
 
-        if (!address) {
+        if (!address || (!addressId && !shippingFieldsStreet.length)) {
             return;
         }
 
@@ -206,7 +217,10 @@ export class CheckoutAddressBookContainer extends PureComponent {
             region: {
                 region_id,
                 region
-            } = {}
+            } = {},
+            region_string,
+            region: address_region,
+            region_id: regionId
         } = address;
 
         if (!country_id) {
@@ -216,8 +230,8 @@ export class CheckoutAddressBookContainer extends PureComponent {
         onShippingEstimationFieldsChange({
             city,
             country_id,
-            region_id,
-            region,
+            region_id: region_id || regionId,
+            region: region_string || region || address_region,
             postcode
         });
     }

--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
@@ -113,7 +113,7 @@ export class CheckoutAddressBookContainer extends PureComponent {
 
         if (defaultAddressId !== prevDefaultAddressId) {
             return {
-                selectedAddressId: defaultAddressId,
+                selectedAddressId: this?.getSelectedAddressId(defaultAddressId) || defaultAddressId,
                 prevDefaultAddressId: defaultAddressId
             };
         }
@@ -121,17 +121,30 @@ export class CheckoutAddressBookContainer extends PureComponent {
         return null;
     }
 
-    componentDidUpdate(_, prevState) {
+    componentDidUpdate(prevProps, prevState) {
         const {
             onAddressSelect,
             requestCustomerData,
-            customer
+            customer,
+            shippingFields: {
+                street: shippingFieldsStreet = []
+            }
         } = this.props;
+        const {
+            shippingFields: {
+                street: prevShippingFieldsStreet = []
+            }
+        } = prevProps;
         const { selectedAddressId: prevSelectedAddressId } = prevState;
-        const { selectedAddressId } = this.state;
+        const { selectedAddressId, prevDefaultAddressId } = this.state;
 
         if (isSignedIn() && !Object.keys(customer).length) {
             requestCustomerData();
+        }
+
+        if (shippingFieldsStreet.length && !prevShippingFieldsStreet.length) {
+            // eslint-disable-next-line react/no-did-update-set-state
+            this.setState({ selectedAddressId: this.getSelectedAddressId(prevDefaultAddressId) });
         }
 
         if (selectedAddressId !== prevSelectedAddressId) {

--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
@@ -113,7 +113,7 @@ export class CheckoutAddressBookContainer extends PureComponent {
 
         if (defaultAddressId !== prevDefaultAddressId) {
             return {
-                selectedAddressId: defaultAddressId,
+                selectedAddressId: this?.getSelectedAddressId(defaultAddressId) || defaultAddressId,
                 prevDefaultAddressId: defaultAddressId
             };
         }
@@ -121,17 +121,26 @@ export class CheckoutAddressBookContainer extends PureComponent {
         return null;
     }
 
-    componentDidUpdate(_, prevState) {
+    componentDidUpdate(prevProps, prevState) {
         const {
             onAddressSelect,
             requestCustomerData,
-            customer
+            customer,
+            customer: {
+                addresses
+            } = {}
         } = this.props;
+        const { customer: { addresses: prevAddresses } = {} } = prevProps;
         const { selectedAddressId: prevSelectedAddressId } = prevState;
-        const { selectedAddressId } = this.state;
+        const { selectedAddressId, prevDefaultAddressId } = this.state;
 
         if (isSignedIn() && !Object.keys(customer).length) {
             requestCustomerData();
+        }
+
+        if (!prevAddresses && addresses) {
+            // eslint-disable-next-line react/no-did-update-set-state
+            this.setState({ selectedAddressId: this.getSelectedAddressId(prevDefaultAddressId) });
         }
 
         if (selectedAddressId !== prevSelectedAddressId) {

--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
@@ -206,7 +206,7 @@ export class CheckoutAddressBookContainer extends PureComponent {
                 : addresses.find(({ id }) => id === addressId)
         );
 
-        if (!address || (!addressId && !shippingFieldsStreet.length)) {
+        if (!address || (!isBilling && !addressId && !shippingFieldsStreet.length)) {
             return;
         }
 

--- a/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
+++ b/packages/scandipwa/src/component/CheckoutAddressBook/CheckoutAddressBook.container.js
@@ -113,7 +113,7 @@ export class CheckoutAddressBookContainer extends PureComponent {
 
         if (defaultAddressId !== prevDefaultAddressId) {
             return {
-                selectedAddressId: this?.getSelectedAddressId(defaultAddressId) || defaultAddressId,
+                selectedAddressId: defaultAddressId,
                 prevDefaultAddressId: defaultAddressId
             };
         }
@@ -121,30 +121,17 @@ export class CheckoutAddressBookContainer extends PureComponent {
         return null;
     }
 
-    componentDidUpdate(prevProps, prevState) {
+    componentDidUpdate(_, prevState) {
         const {
             onAddressSelect,
             requestCustomerData,
-            customer,
-            shippingFields: {
-                street: shippingFieldsStreet = []
-            }
+            customer
         } = this.props;
-        const {
-            shippingFields: {
-                street: prevShippingFieldsStreet = []
-            }
-        } = prevProps;
         const { selectedAddressId: prevSelectedAddressId } = prevState;
-        const { selectedAddressId, prevDefaultAddressId } = this.state;
+        const { selectedAddressId } = this.state;
 
         if (isSignedIn() && !Object.keys(customer).length) {
             requestCustomerData();
-        }
-
-        if (shippingFieldsStreet.length && !prevShippingFieldsStreet.length) {
-            // eslint-disable-next-line react/no-did-update-set-state
-            this.setState({ selectedAddressId: this.getSelectedAddressId(prevDefaultAddressId) });
         }
 
         if (selectedAddressId !== prevSelectedAddressId) {

--- a/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
+++ b/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
@@ -38,19 +38,16 @@ export class CheckoutAddressForm extends MyAccountAddressForm {
                 regionId,
                 region,
                 city,
-                postcode,
-                country_id,
-                region_string,
-                region_id
+                postcode
             },
             defaultCountry,
             onShippingEstimationFieldsChange
         } = this.props;
 
         onShippingEstimationFieldsChange({
-            country_id: country_id || countryId || defaultCountry,
-            region_id: region_id || regionId,
-            region: region_string || region,
+            country_id: countryId || defaultCountry,
+            region_id: regionId,
+            region,
             city,
             postcode
         });

--- a/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
+++ b/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
@@ -38,16 +38,19 @@ export class CheckoutAddressForm extends MyAccountAddressForm {
                 regionId,
                 region,
                 city,
-                postcode
+                postcode,
+                country_id,
+                region_string,
+                region_id
             },
             defaultCountry,
             onShippingEstimationFieldsChange
         } = this.props;
 
         onShippingEstimationFieldsChange({
-            country_id: countryId || defaultCountry,
-            region_id: regionId !== '' ? regionId : null,
-            region,
+            country_id: country_id || countryId || defaultCountry,
+            region_id: region_id || regionId,
+            region: region_string || region,
             city,
             postcode
         });

--- a/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
+++ b/packages/scandipwa/src/component/CheckoutAddressForm/CheckoutAddressForm.component.js
@@ -38,16 +38,19 @@ export class CheckoutAddressForm extends MyAccountAddressForm {
                 regionId,
                 region,
                 city,
-                postcode
+                postcode,
+                country_id,
+                region_string,
+                region_id
             },
             defaultCountry,
             onShippingEstimationFieldsChange
         } = this.props;
 
         onShippingEstimationFieldsChange({
-            country_id: countryId || defaultCountry,
-            region_id: regionId,
-            region,
+            country_id: country_id || countryId || defaultCountry,
+            region_id: region_id || regionId,
+            region: region_string || region,
             city,
             postcode
         });

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
@@ -57,6 +57,11 @@ export class MyAccountAddressForm extends FieldForm {
     get fieldMap() {
         const {
             address,
+            address: {
+                region_id: address_regionId,
+                region: address_region,
+                region_string: address_regionString
+            },
             countries,
             addressLinesQty,
             regionDisplayAll,
@@ -86,9 +91,9 @@ export class MyAccountAddressForm extends FieldForm {
             availableRegions,
             isStateRequired,
             countryId,
-            currentRegion,
+            currentRegion: address_regionString || address_region || currentRegion,
             currentCity,
-            currentRegionId,
+            currentRegionId: parseInt(address_regionId, 10) || currentRegionId,
             currentZipcode,
             ...address
         }, {

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
@@ -43,6 +43,7 @@ export class MyAccountAddressForm extends FieldForm {
         currentRegion: PropTypes.string,
         currentZipcode: PropTypes.string,
         currentRegionId: PropTypes.number
+        // setPreviouslySelectedAddressData: PropTypes.func.isRequired
     };
 
     static defaultProps = {
@@ -53,14 +54,27 @@ export class MyAccountAddressForm extends FieldForm {
         isStateRequired: false
     };
 
+    /* componentDidMount() {
+        const {
+            address: {
+                regionId,
+                region,
+                countryId
+            },
+            setPreviouslySelectedAddressData
+        } = this.props;
+
+        setPreviouslySelectedAddressData(countryId, region, regionId);
+    } */
+
     //#region GETTERS
     get fieldMap() {
         const {
             address,
             address: {
-                region_id: address_regionId,
-                region: address_region,
-                region_string: address_regionString
+                regionId,
+                countryId: country_id,
+                region
             },
             countries,
             addressLinesQty,
@@ -81,6 +95,9 @@ export class MyAccountAddressForm extends FieldForm {
             onRegionIdChange
         } = this.props;
 
+        console.log('>>>>>>>>AA', address, country_id, countryId, parseInt(regionId, 10), 'llll', region);
+        console.log('>>>>>>>>>>AQQ', currentRegion, currentRegionId);
+
         return myAccountAddressForm({
             address,
             countries,
@@ -90,10 +107,10 @@ export class MyAccountAddressForm extends FieldForm {
             defaultCountry,
             availableRegions,
             isStateRequired,
-            countryId,
-            currentRegion: address_regionString || address_region || currentRegion,
+            countryId: country_id || countryId,
+            currentRegion: region || currentRegion,
             currentCity,
-            currentRegionId: parseInt(address_regionId, 10) || currentRegionId,
+            currentRegionId: parseInt(regionId, 10) || currentRegionId,
             currentZipcode,
             ...address
         }, {

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.component.js
@@ -43,7 +43,6 @@ export class MyAccountAddressForm extends FieldForm {
         currentRegion: PropTypes.string,
         currentZipcode: PropTypes.string,
         currentRegionId: PropTypes.number
-        // setPreviouslySelectedAddressData: PropTypes.func.isRequired
     };
 
     static defaultProps = {
@@ -54,27 +53,14 @@ export class MyAccountAddressForm extends FieldForm {
         isStateRequired: false
     };
 
-    /* componentDidMount() {
-        const {
-            address: {
-                regionId,
-                region,
-                countryId
-            },
-            setPreviouslySelectedAddressData
-        } = this.props;
-
-        setPreviouslySelectedAddressData(countryId, region, regionId);
-    } */
-
     //#region GETTERS
     get fieldMap() {
         const {
             address,
             address: {
-                regionId,
-                countryId: country_id,
-                region
+                region_id: address_regionId,
+                region: address_region,
+                region_string: address_regionString
             },
             countries,
             addressLinesQty,
@@ -95,9 +81,6 @@ export class MyAccountAddressForm extends FieldForm {
             onRegionIdChange
         } = this.props;
 
-        console.log('>>>>>>>>AA', address, country_id, countryId, parseInt(regionId, 10), 'llll', region);
-        console.log('>>>>>>>>>>AQQ', currentRegion, currentRegionId);
-
         return myAccountAddressForm({
             address,
             countries,
@@ -107,10 +90,10 @@ export class MyAccountAddressForm extends FieldForm {
             defaultCountry,
             availableRegions,
             isStateRequired,
-            countryId: country_id || countryId,
-            currentRegion: region || currentRegion,
+            countryId,
+            currentRegion: address_regionString || address_region || currentRegion,
             currentCity,
-            currentRegionId: parseInt(regionId, 10) || currentRegionId,
+            currentRegionId: parseInt(address_regionId, 10) || currentRegionId,
             currentZipcode,
             ...address
         }, {

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
@@ -69,7 +69,6 @@ export class MyAccountAddressFormContainer extends PureComponent {
         onCityChange: this.onCityChange.bind(this),
         onRegionChange: this.onRegionChange.bind(this),
         onRegionIdChange: this.onRegionIdChange.bind(this)
-        // setPreviouslySelectedAddressData: this.setPreviouslySelectedAddressData.bind(this)
     };
 
     containerProps() {
@@ -109,16 +108,6 @@ export class MyAccountAddressFormContainer extends PureComponent {
             currentRegionId
         };
     }
-
-    /* async setPreviouslySelectedAddressData(countryId, currentRegion, currentRegionId) {
-        await this.setState({
-            countryId,
-            currentRegion,
-            currentRegionId
-        });
-
-        console.log('>>>>>>>>>>>>>', this.state);
-    } */
 
     // #region GETTERS
     getCountry(countryId = null) {

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.container.js
@@ -69,6 +69,7 @@ export class MyAccountAddressFormContainer extends PureComponent {
         onCityChange: this.onCityChange.bind(this),
         onRegionChange: this.onRegionChange.bind(this),
         onRegionIdChange: this.onRegionIdChange.bind(this)
+        // setPreviouslySelectedAddressData: this.setPreviouslySelectedAddressData.bind(this)
     };
 
     containerProps() {
@@ -108,6 +109,16 @@ export class MyAccountAddressFormContainer extends PureComponent {
             currentRegionId
         };
     }
+
+    /* async setPreviouslySelectedAddressData(countryId, currentRegion, currentRegionId) {
+        await this.setState({
+            countryId,
+            currentRegion,
+            currentRegionId
+        });
+
+        console.log('>>>>>>>>>>>>>', this.state);
+    } */
 
     // #region GETTERS
     getCountry(countryId = null) {

--- a/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.form.js
+++ b/packages/scandipwa/src/component/MyAccountAddressForm/MyAccountAddressForm.form.js
@@ -93,7 +93,7 @@ export const getRegionFields = (props, events) => {
                 attr: {
                     id: 'address-region-id',
                     name: 'region_string',
-                    value: currentRegion,
+                    defaultValue: currentRegion,
                     placeholder: __('Your state / province')
                 },
                 events: {
@@ -114,7 +114,7 @@ export const getRegionFields = (props, events) => {
             label: __('State / Province'),
             attr: {
                 name: 'region_id',
-                value: currentRegionId,
+                defaultValue: currentRegionId,
                 selectPlaceholder: __('Select region...')
             },
             events: {

--- a/packages/scandipwa/src/store/Checkout/Checkout.action.js
+++ b/packages/scandipwa/src/store/Checkout/Checkout.action.js
@@ -10,6 +10,13 @@
 export const UPDATE_SHIPPING_FIELDS = 'UPDATE_SHIPPING_FIELDS';
 export const UPDATE_EMAIL = 'UPDATE_EMAIL';
 export const UPDATE_EMAIL_AVAILABLE = 'UPDATE_EMAIL_AVAILABLE';
+export const UPDATE_SHIPPING_FIELDS_ID = 'UPDATE_SHIPPING_FIELDS_ID';
+
+/** @namespace Store/Checkout/Action/updateShippingFieldsId */
+export const updateShippingFieldsId = (id) => ({
+    type: UPDATE_SHIPPING_FIELDS_ID,
+    id
+});
 
 /** @namespace Store/Checkout/Action/updateShippingFields */
 export const updateShippingFields = (shippingFields) => ({

--- a/packages/scandipwa/src/store/Checkout/Checkout.reducer.js
+++ b/packages/scandipwa/src/store/Checkout/Checkout.reducer.js
@@ -11,7 +11,8 @@
 import {
     UPDATE_EMAIL,
     UPDATE_EMAIL_AVAILABLE,
-    UPDATE_SHIPPING_FIELDS
+    UPDATE_SHIPPING_FIELDS,
+    UPDATE_SHIPPING_FIELDS_ID
 } from './Checkout.action';
 
 /** @namespace Store/Checkout/Reducer/getInitialState */
@@ -46,6 +47,18 @@ export const CheckoutReducer = (state = getInitialState(), action) => {
         return {
             ...state,
             isEmailAvailable
+        };
+
+    case UPDATE_SHIPPING_FIELDS_ID:
+        const { shippingFields: stateShippingFields } = state;
+        const { id } = action;
+
+        return {
+            ...state,
+            shippingFields: {
+                ...stateShippingFields,
+                id
+            }
         };
 
     default:

--- a/packages/scandipwa/src/util/Address/index.js
+++ b/packages/scandipwa/src/util/Address/index.js
@@ -275,3 +275,38 @@ export const checkIfStoreIncluded = (stores, selectedStore) => {
 
     return stores.find((store) => JSON.stringify(store) === selectedStoreInString);
 };
+
+/**
+ * Checks if an address is in the provided list of addresses
+ * and if found, it returns its id
+ */
+/** @namespace Util/Address/Index/getAddressIdFromAddressBook */
+export const getAddressIdFromAddressBook = (shippingFields, addresses) => {
+    // the main keys distinguishing addresses
+    const keys = [
+        'city',
+        'country_id',
+        'firstname',
+        'lastname',
+        'postcode',
+        'telephone',
+        'vat_id'
+    ];
+
+    const filteredAddresses = (
+        addresses.filter((address) => (
+            keys.every((key) => {
+                if (shippingFields[key] !== address[key]) {
+                    return false;
+                }
+
+                return true;
+            })
+            && (
+                JSON.stringify(shippingFields.street) === JSON.stringify(address.street)
+            )
+        ))
+    );
+
+    return filteredAddresses.length ? filteredAddresses[0].id : 0;
+};


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3742
* Fixes https://github.com/scandipwa/scandipwa/issues/2973

**Problem:**
* The checkout shipping addresses weren't connected to checkout changes 
The component uses the default address on construction which also caused wrong address estimation request on going back 

**In this PR:**
It checks if there is a shipping address saved and gets it from the checkoutReducer.shipping_fields
Then, updates the selectedAddressId and pass the info to fill the form for customAddress (if !id).
The previously selected shipping address is selected automatically. 
If there is a custom address, the form will be open and filled automatically.

*This is also built to automatically fill the shipping form on reloading /shipping - this feature will work after I finish this PR https://github.com/scandipwa/scandipwa/pull/4621 - Also, this PR will handle going back from /details_step*

* [CheckoutAddressBook.container.js](https://github.com/scandipwa/scandipwa/compare/master...EriSilver:3742-2973-GoBackCheckout?expand=1#diff-76e4d1eb1844013a9517b58171d4dcaf184720bc2b1c7e0629c7804d32a02e99),
---- line 99, if id? -> it will send an estimation request, else the request will be sent in [CheckoutAddressForm.component.js](https://github.com/scandipwa/scandipwa/compare/master...EriSilver:3742-2973-GoBackCheckout?expand=1#diff-6922d8de54f93aa84d77d8b7521b2102661d5792dfdded4b8f0d90a8b617c44d)
---- created function getSelectedAddressId: 
if billing -> return defaultAddress, 
else if there is a previously saved address return id, 
else return defaultShippingAddress (`default || zero`) if no shippingFields' address
else: since the fetched shipping address on reloading `/checkout` returns a null id --> therefore, compared the returned shipping_address main fields to the addresses in the customer address book in `getAddressIdFromAddressBook()` and got the id if found matching data, else zero 
*When zero, the custom address form opens*

updated the selectedAddressId in componentDidUpdate depending on `customer.addresses` ==> since customerData is fetched after cartData

---- it passes shipping_fields to the component which passes it to CheckoutAddressForm to be set as defautValues

* [MyAccountAddressForm.form.js](https://github.com/scandipwa/scandipwa/compare/master...EriSilver:3742-2973-GoBackCheckout?expand=1#diff-af8582fe285182fe03f24dae1549908d8edeeb404254c9af473fcc52c822f6ea), changed value in select fields to defaultValue to allow selecting different options on going back.
