### PR TITLE
removed dispatcher for stoppping the loader for the first dispatch 

### DIFF
--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
@@ -62,7 +62,6 @@ export class CartDispatcher {
             } = await fetchMutation(CartQuery.getCreateEmptyCartMutation());
 
             setGuestQuoteId(quoteId);
-            dispatch(updateIsLoadingCart(false));
 
             return quoteId;
         } catch (error) {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4660 

**Problem:**
* Cart dispatchers (createGuestEmptyCart and updateInitialCartData) are dispatched so there is a time gap between them the loader is stopped

**In this PR:**
* Removed the stopping the loader for the first dispatch that is triggered