### PR TITLE
Prepended config URL strings with slashes for the sake of convention

### DIFF
--- a/packages/scandipwa/src/component/MyAccountOrder/MyAccountOrder.config.js
+++ b/packages/scandipwa/src/component/MyAccountOrder/MyAccountOrder.config.js
@@ -17,20 +17,20 @@ export const ORDER_REFUNDS = 'Refund';
 export const ORDER_ACTION_LABELS = {
     [ORDER_INVOICES]: {
         print: __('Print Invoice'),
-        printUrl: 'sales/order/printInvoice/invoice_id',
+        printUrl: '/sales/order/printInvoice/invoice_id',
         printAll: __('Print All Invoices'),
-        printAllUrl: 'sales/order/printInvoice/order_id'
+        printAllUrl: '/sales/order/printInvoice/order_id'
     },
     [ORDER_SHIPMENTS]: {
         print: __('Print Shipment'),
-        printUrl: 'sales/order/printShipment/shipment_id',
+        printUrl: '/sales/order/printShipment/shipment_id',
         printAll: __('Print All Shipments'),
-        printAllUrl: 'sales/order/printShipment/order_id'
+        printAllUrl: '/sales/order/printShipment/order_id'
     },
     [ORDER_REFUNDS]: {
         print: __('Print Refund'),
-        printUrl: 'sales/order/printCreditmemo/creditmemo_id',
+        printUrl: '/sales/order/printCreditmemo/creditmemo_id',
         printAll: __('Print All Refunds'),
-        printAllUrl: 'sales/order/printCreditmemo/order_id'
+        printAllUrl: '/sales/order/printCreditmemo/order_id'
     }
 };

--- a/packages/scandipwa/src/route/MyAccount/MyAccount.config.js
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.config.js
@@ -11,13 +11,13 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-export const ACCOUNT_INFORMATION_EDIT_URL = 'customer/account/edit';
-export const ACCOUNT_FORGOT_PASSWORD_URL = 'customer/account/forgotpassword';
+export const ACCOUNT_INFORMATION_EDIT_URL = '/customer/account/edit';
+export const ACCOUNT_FORGOT_PASSWORD_URL = '/customer/account/forgotpassword';
 export const ACCOUNT_REGISTRATION_URL = '/customer/account/create';
 export const ACCOUNT_LOGIN_URL = '/customer/account/login';
 export const ACCOUNT_URL = '/customer/account';
 export const ACCOUNT_ORDER_URL = '/sales/order/view/order_id';
-export const ACCOUNT_ORDER_PRINT_URL = 'sales/order/print/order_id';
-export const ACCOUNT_ORDER_HISTORY = 'sales/order/history';
+export const ACCOUNT_ORDER_PRINT_URL = '/sales/order/print/order_id';
+export const ACCOUNT_ORDER_HISTORY = '/sales/order/history';
 // eslint-disable-next-line max-len
 export const LOCKED_ACCOUNT_ERROR_MESSAGE = __('The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later.');


### PR DESCRIPTION
**Problem:**
* Config URL strings weren't uniformly prepended with slashes

**In this PR:**
* Prepended the URL strings with slashes, tested for possible issues with store codes - everything works fine
