### PR TITLE
fixed padding for error messages

### DIFF
--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
@@ -38,6 +38,13 @@
                 margin-block-end: 6px;
             }
 
+            &_type_select + .Field-ErrorMessages {
+                position: absolute;
+                inset-inline-start: 0;
+                inset-block-end: 10px;
+                transform: translateY(100%);
+            }
+
             &-Wrapper {
                 &_type {
                     &_select, &_checkbox, &_radio {

--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
@@ -35,6 +35,7 @@
 
             &_type_select {
                 margin-block-start: 0;
+                margin-block-end: 6px;
             }
 
             &_type_select + .Field-ErrorMessages {
@@ -52,10 +53,6 @@
                 }
             }
         }
-    }
-
-    &-Select.Field_hasError {
-        margin-block-end: 20px;
     }
 
     &-PriceLabel {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4543 
* Fixes #4707 

**Problem:**
* Indent between select field and error label was too big

**In this PR:**
* corrected styles
