### PR TITLE
replaced row-gap with margin bottom because older IOS versions

### DIFF
--- a/packages/scandipwa/src/component/ProductReviewForm/ProductReviewForm.style.scss
+++ b/packages/scandipwa/src/component/ProductReviewForm/ProductReviewForm.style.scss
@@ -21,9 +21,12 @@
     &-RatingWrapper {
         display: flex;
         flex-direction: column;
-        row-gap: 24px;
 
         .FieldGroup-Wrapper {
+            &:not(:last-child) {
+                margin-block-end: 24px;
+            }
+
             .FieldGroup {
                 &_hasError, &_isValid {
                     padding-inline-start: 0;
@@ -133,7 +136,7 @@
     textarea {
         width: 100%;
     }
-    
+
     textarea {
         margin-block-end: -3px;
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4664

**Problem:**
* Row-gap wasn't supported with older IOS versions

**In this PR:**
* Used margin-bottom instead of row-gap
