### PR TITLE
removed line-height for textareas

### DIFF
--- a/packages/scandipwa/src/component/FieldGroup/FieldGroup.style.scss
+++ b/packages/scandipwa/src/component/FieldGroup/FieldGroup.style.scss
@@ -15,6 +15,7 @@
             color: var(--primary-error-color);
             font-size: 12px;
             margin-block-end: -.1em;
+            padding-block-start: 6px;
         }
     }
 

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -59,7 +59,7 @@
         @include description-tags {
             line-height: 20px;
         }
-        
+
         font-size: 14px;
         margin-block: 16px;
         line-height: 20px;

--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
@@ -39,17 +39,19 @@
 
             &_type {
                 &_textarea, &_text {
+                    line-height: 0px;
+
                     & + .Field-SubLabelContainer {
                         margin-block-start: 6px;
 
                         .Field-SubLabel {
                             font-weight: normal;
                         }
-                    }   
+                    }
 
                     & + .Field-ErrorMessages {
                         margin-block-end: 0;
-                    }    
+                    }
 
                     & + .Field-ErrorMessages + .Field-SubLabelContainer {
                         margin-block-start: 0;
@@ -58,7 +60,7 @@
                             font-weight: normal;
                         }
                     }
-                }   
+                }
 
                 &_textarea {
                     textarea {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4705

**Problem:**
* The space between error messages and textarea was different in contrast to inputs because of line-height

**In this PR:**
* removed the line-height for textarea and also corrected padding for error message of grouped fields
