### PR TITLE
[4686] - Page is scrolled up if user added some product to wishlist from PLP - fixed

### DIFF
--- a/packages/scandipwa/src/component/AddToCart/AddToCart.container.js
+++ b/packages/scandipwa/src/component/AddToCart/AddToCart.container.js
@@ -102,6 +102,7 @@ export class AddToCartContainer extends PureComponent {
         }
 
         e.preventDefault();
+        e.stopPropagation();
         this.setState({ isAdding: true });
 
         if (!this.validate()) {

--- a/packages/scandipwa/src/component/ProductCompareButton/ProductCompareButton.component.js
+++ b/packages/scandipwa/src/component/ProductCompareButton/ProductCompareButton.component.js
@@ -32,9 +32,16 @@ export class ProductCompareButton extends PureComponent {
         isActive: false
     };
 
+    _handleClick = this._handleClick.bind(this);
+
+    _handleClick(e) {
+        const { handleClick } = this.props;
+        e.stopPropagation();
+        handleClick(e);
+    }
+
     render() {
         const {
-            handleClick,
             isLoading,
             isActive,
             mix
@@ -49,7 +56,7 @@ export class ProductCompareButton extends PureComponent {
                 <button
                   block="ProductCompareButton"
                   elem="Button"
-                  onClick={ handleClick }
+                  onClick={ this._handleClick }
                   mix={ { block: 'Button' } }
                   aria-label={ __('Compare') }
                 >

--- a/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.component.js
+++ b/packages/scandipwa/src/component/ProductWishlistButton/ProductWishlistButton.component.js
@@ -68,6 +68,7 @@ export class ProductWishlistButton extends PureComponent {
         } = this.props;
 
         e.preventDefault();
+        e.stopPropagation();
 
         if (!isInWishlist) {
             return addToWishlist(magentoProduct);


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4686

**Problem:**
* In the registerSharedElement method at ProductCard.component, there's a line of code that causes the viewport to scroll to the top of the document when a product card is clicked

**In this PR:**
* added a stopPropagation method call to the product card action buttons so that interacting with them won't trigger the scoll
