### PR TITLE
#4233 - Create filter for out of stock grouped product

### DIFF
--- a/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.container.js
+++ b/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.container.js
@@ -61,9 +61,8 @@ export class GroupedProductsItemContainer extends PureComponent {
 
     setQuantity(itemCount) {
         const { setQuantity, product, product: { id } } = this.props;
-        const inStock = getProductInStock(product);
 
-        if (inStock) {
+        if (getProductInStock(product)) {
             setQuantity({ [id]: itemCount }, true);
         }
     }

--- a/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.container.js
+++ b/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.container.js
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import { ProductType } from 'Type/ProductList.type';
+import { getProductInStock } from 'Util/Product/Extract';
 
 import GroupedProductsItem from './GroupedProductsItem.component';
 
@@ -59,8 +60,12 @@ export class GroupedProductsItemContainer extends PureComponent {
     }
 
     setQuantity(itemCount) {
-        const { setQuantity, product: { id } } = this.props;
-        setQuantity({ [id]: itemCount }, true);
+        const { setQuantity, product, product: { id } } = this.props;
+        const inStock = getProductInStock(product);
+
+        if (inStock) {
+            setQuantity({ [id]: itemCount }, true);
+        }
     }
 
     render() {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4233

**Problem:**
* Grouped product is not added to cart if it contains Out of stock child product

**In this PR:**
* Grouped product is added to cart if it has Out of stock child product
