### PR TITLE
#4736 - oops page on IOS 12.1 - fixed

### DIFF
--- a/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
@@ -361,8 +361,13 @@ export class MyAccountContainer extends PureComponent {
     }
 
     tabsFilterEnabled() {
-        return Object.fromEntries(Object.entries(MyAccountContainer.tabMap)
-            .filter(([tabName]) => MyAccountContainer.isTabEnabled(this.props, tabName)));
+        const obj = {};
+        Object.entries(MyAccountContainer.tabMap)
+            .filter(([tabName]) => MyAccountContainer.isTabEnabled(this.props, tabName))
+            // eslint-disable-next-line no-return-assign
+            .map(([key, value]) => (obj[key] = value));
+
+        return obj;
     }
 
     changeActiveTab(activeTab) {

--- a/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.container.js
@@ -361,13 +361,10 @@ export class MyAccountContainer extends PureComponent {
     }
 
     tabsFilterEnabled() {
-        const obj = {};
-        Object.entries(MyAccountContainer.tabMap)
-            .filter(([tabName]) => MyAccountContainer.isTabEnabled(this.props, tabName))
-            // eslint-disable-next-line no-return-assign
-            .map(([key, value]) => (obj[key] = value));
-
-        return obj;
+        return Object.entries(MyAccountContainer.tabMap).reduce((enabledTabs, [key, value]) => (
+            MyAccountContainer.isTabEnabled(this.props, key)
+                ? { ...enabledTabs, [key]: value } : enabledTabs
+        ), {});
     }
 
     changeActiveTab(activeTab) {


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4736

**Problem:**
* Older IOS devices may not support the Object.fromEntries syntax, resulting in errors on pages that use it

**In this PR:**
* Replaced the aforementioned syntax with equivalent logic written in a more widely supported syntax. 
