### PR TITLE
[4165] - transparent footer background on mobile

### DIFF
--- a/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.style.scss
+++ b/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.style.scss
@@ -129,6 +129,7 @@
         --option-margin-inline: 6px;
 
         @include mobile {
+            max-width: 100vw;
             --option-margin-block: 7px;
             --option-margin-inline: 7px;
 

--- a/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.style.scss
+++ b/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.style.scss
@@ -181,6 +181,7 @@
             inset-block-end: 0;
             background-color: var(--color-white);
             border-block-start: 1px solid var(--primary-divider-color);
+            padding-block-end: calc(16px + env(safe-area-inset-bottom));
         }
 
         .CategoryFilterOverlay-NoResults ~ & {

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
@@ -54,7 +54,7 @@
         padding-inline-start: 0;
 
         @include mobile {
-            padding: 14px 0;
+            padding: 0 0 14px;
         }
 
         &:last-child {
@@ -247,23 +247,9 @@
     }
 
     &-ButtonWrapper {
-        @include mobile {
-            --footer-totals-height: 123px;
-
-            height: var(--footer-totals-height);
-            position: fixed;
-            width: 100%;
-            inset-inline-start: 0;
-            padding-inline: 16px;
-            padding-block-end: 16px;
-            inset-block-end: var(--footer-total-height);
-            background-color: var(--color-white);
-            border-block-start: 1px solid var(--primary-divider-color);
-            z-index: 80;
-
-            .hideOnScroll & {
-                transform: translateY(var(--footer-nav-height));
-            }
+        @include mobile-bottom-wrapper {
+            padding: 16px;
+            inset-block-end: 16px;
         }
 
         &_isEmpty {

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.style.scss
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.style.scss
@@ -83,20 +83,9 @@
             inset-block-start: calc(0px - var(--myaccount-wishlist-action-bar-offset));
         }
 
-        @include mobile {
-            background-color: var(--my-account-content-background);
-            inset-block-end: var(--footer-total-height);
-            display: block;
-            inset-inline-start: 0;
-            padding: 14px;
-            position: fixed;
-            width: 100%;
-            border-block-start: 1px solid var(--primary-divider-color);
-            z-index: 10;
-
-            .hideOnScroll & {
-                transform: translateY(var(--footer-nav-height));
-            }
+        @include mobile-bottom-wrapper {
+            padding: 16px;
+            inset-block-end: 16px;
         }
 
         @include tablet {

--- a/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.style.scss
+++ b/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.style.scss
@@ -26,11 +26,11 @@
     z-index: 100;
     background-color: var(--header-background);
     padding-block-end: env(safe-area-inset-bottom);
-    transform: translateY(0);
-    transition: transform 200ms cubic-bezier(.47, 0, .745, .715);
+    // transform: translateY(0);
+    transition: inset-block-end 200ms cubic-bezier(.47, 0, .745, .715);
 
     .hideOnScroll & {
-        transform: translateY(100%);
+        inset-block-end: calc(var(--footer-total-height) * (-1));
     }
 
     @include mobile {

--- a/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.style.scss
+++ b/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.style.scss
@@ -26,11 +26,11 @@
     z-index: 100;
     background-color: var(--header-background);
     padding-block-end: env(safe-area-inset-bottom);
-    // transform: translateY(0);
-    transition: inset-block-end 200ms cubic-bezier(.47, 0, .745, .715);
+    transform: translateY(0);
+    transition: transform 200ms cubic-bezier(.47, 0, .745, .715);
 
     .hideOnScroll & {
-        inset-block-end: calc(var(--footer-total-height) * (-1));
+        transform: translateY(100%);
     }
 
     @include mobile {

--- a/packages/scandipwa/src/component/Popup/Popup.style.scss
+++ b/packages/scandipwa/src/component/Popup/Popup.style.scss
@@ -131,6 +131,6 @@
     }
 
     @include mobile {
-        overflow-y: hidden;
+        overflow: hidden;
     }
 }

--- a/packages/scandipwa/src/component/Popup/Popup.style.scss
+++ b/packages/scandipwa/src/component/Popup/Popup.style.scss
@@ -74,7 +74,8 @@
         padding: var(--popup-content-padding);
         padding-block-end: 0;
         min-width: var(--popup-min-width);
-        max-width: calc(var(--content-wrapper-width) * .8);
+        max-width: 100%;
+        overflow-x: hidden;
         max-height: var(--popup-max-height);
         overflow-y: auto;
 

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -203,15 +203,11 @@
     }
 
     &-AddToCartFixed {
-        position: fixed;
-        inset-block-end: var(--footer-total-height);
-        z-index: 5;
-        background-color: var(--color-white);
-        width: 100%;
-        display: flex;
-        padding: 12px 16px;
-        border-block-start: 1px solid var(--primary-divider-color);
-        inset-inline-start: 0;
+        @include mobile-bottom-wrapper {
+            padding: 12px 16px;
+            inset-block-end: 16px;
+            display: flex;
+        }
 
         .ProductWishlistButton {
             margin-inline: 18px 4px;
@@ -228,10 +224,6 @@
                     }
                 }
             }
-        }
-
-        .hideOnScroll & {
-            transform: translateY(var(--footer-nav-height));
         }
     }
 

--- a/packages/scandipwa/src/route/Checkout/Checkout.style.scss
+++ b/packages/scandipwa/src/route/Checkout/Checkout.style.scss
@@ -46,19 +46,9 @@
     }
 
     &-StickyButtonWrapper {
-        @include mobile {
-            border-block-start: 1px solid var(--primary-divider-color);
-            position: fixed;
-            inset-inline-start: 0;
-            width: 100%;
-            z-index: 85;
-            inset-block-end: var(--footer-total-height);
-            background-color: var(--color-white);
+        @include mobile-bottom-wrapper {
             padding: 16px;
-
-            .hideOnScroll & {
-                transform: translateY(var(--footer-nav-height));
-            }
+            inset-block-end: 16px;
         }
 
         .Button {

--- a/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
@@ -19,6 +19,11 @@
     }
 
     &-Content {
+        @include mobile {
+            max-width: 100%;
+            overflow-x: hidden;
+        }
+
         h2 {
             @include mobile {
                 text-align: center;
@@ -109,7 +114,7 @@
     .widget {
         overflow-x: auto;
     }
-    
+
     ul,
     ol {
         li {

--- a/packages/scandipwa/src/style/abstract/_parts.scss
+++ b/packages/scandipwa/src/style/abstract/_parts.scss
@@ -54,11 +54,11 @@
         width: 100%;
         z-index: 85;
         background-color: var(--color-white);
-        padding-block-end: var(--footer-nav-height);
+        padding-block-end: var(--footer-total-height);
         transition: transform 200ms cubic-bezier(.47, 0, .745, .715);
 
         .hideOnScroll & {
-            transform: translateY(var(--footer-nav-height));
+            transform: translateY(var(--footer-total-height));
         }
     }
 }

--- a/packages/scandipwa/src/style/abstract/_parts.scss
+++ b/packages/scandipwa/src/style/abstract/_parts.scss
@@ -58,7 +58,7 @@
         transition: transform 200ms cubic-bezier(.47, 0, .745, .715);
 
         .hideOnScroll & {
-            transform: translateY(var(--footer-total-height));
+            transform: translateY(var(--footer-nav-height));
         }
     }
 }

--- a/packages/scandipwa/src/style/abstract/_parts.scss
+++ b/packages/scandipwa/src/style/abstract/_parts.scss
@@ -43,3 +43,22 @@
         @content
     }
 }
+
+@mixin mobile-bottom-wrapper {
+    @include mobile {
+        @content;
+
+        border-block-start: 1px solid var(--primary-divider-color);
+        position: fixed;
+        inset-inline-start: 0;
+        width: 100%;
+        z-index: 85;
+        background-color: var(--color-white);
+        padding-block-end: var(--footer-nav-height);
+        transition: transform 200ms cubic-bezier(.47, 0, .745, .715);
+
+        .hideOnScroll & {
+            transform: translateY(var(--footer-nav-height));
+        }
+    }
+}


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4165

**Problem:**
* On mobile devices without a physical home screen, the navbar would disappear and leave transparent space in it's place.

**In this PR:**
* Added the navbar's height to the action wrapper UI as whitespace to make up for the navbar disappearing
* Moved the ruleset defining that UI to _parts.scss so that it's reusable across the codebase
