### PR TITLE
[4765] - Each word on product page and breadcrumbs capitalized - fixed

### DIFF
--- a/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.style.scss
+++ b/packages/scandipwa/src/component/Breadcrumb/Breadcrumb.style.scss
@@ -55,7 +55,6 @@
         }
 
         &-Name {
-            text-transform: capitalize;
             color: inherit;
         }
     }

--- a/packages/scandipwa/src/component/CategoryDetails/CategoryDetails.style.scss
+++ b/packages/scandipwa/src/component/CategoryDetails/CategoryDetails.style.scss
@@ -34,6 +34,7 @@
     }
 
     &-Heading {
+        text-transform: none;
         margin-block-end: 6px;
         margin-block-start: 0;
 
@@ -57,7 +58,7 @@
                 inset-block-start: -1px;
             }
         }
-        
+
         @include mobile {
             padding: 28px;
         }

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -48,6 +48,7 @@
 
     &-Title {
         margin-block: 8px;
+        text-transform: none;
 
         @include mobile {
             font-weight: 400;


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4765

**Problem:**
* Each word of product name and breadcrumbs is written with a capital letter

**In this PR:**
* Removed CSS rules that capitalized both
