### PR TITLE
[4293] - the excl. tax element is now aligned to the left

### DIFF
--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
@@ -10,7 +10,7 @@
  */
 
 import PropTypes from 'prop-types';
-import { createRef, PureComponent } from 'react';
+import { PureComponent } from 'react';
 
 import Field from 'Component/Field';
 import FIELD_TYPE from 'Component/Field/Field.config';
@@ -38,44 +38,11 @@ export class CheckoutDeliveryOption extends PureComponent {
         optionSubPrice: 0
     };
 
-    state = { isOverflowed: false };
-
-    rowRef = createRef();
-
-    subPriceRef = createRef();
-
-    componentDidMount() {
-        this.updateState();
-        window.addEventListener('resize', () => this.updateState());
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener('resize', () => this.updateState());
-    }
-
-    updateState() {
-        const { current: rowEl } = this.rowRef;
-        const { current: subPriceEl } = this.subPriceRef;
-
-        if (rowEl && subPriceEl) {
-            const rowLeft = rowEl.getBoundingClientRect().left;
-            const subPriceLeft = subPriceEl.getBoundingClientRect().left;
-
-            if (rowLeft >= subPriceLeft) {
-                this.setState({ isOverflowed: true });
-            } else {
-                this.setState({ isOverflowed: false });
-            }
-        }
-    }
-
     renderSubPrice() {
         const {
             currency,
             optionSubPrice
         } = this.props;
-
-        const { isOverflowed } = this.state;
 
         if (!optionSubPrice) {
             return null;
@@ -85,8 +52,6 @@ export class CheckoutDeliveryOption extends PureComponent {
             <div
               block="CheckoutDeliveryOption"
               elem="SubPrice"
-              mods={ { isOverflowed } }
-              ref={ this.subPriceRef }
             >
                 { __('Excl. tax: %s', formatPrice(optionSubPrice, currency)) }
             </div>
@@ -173,7 +138,6 @@ export class CheckoutDeliveryOption extends PureComponent {
             <div
               block="CheckoutDeliveryOption"
               elem="Row"
-              ref={ this.rowRef }
             >
                 <span block="CheckoutDeliveryOption" elem="Span" mods={ { isDisabled: !available } }>
                     { __('Carrier method: ') }

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
@@ -98,10 +98,11 @@ export class CheckoutDeliveryOption extends PureComponent {
         }
 
         return (
-            <span>
+            <div>
                 { __('Rate: ') }
                 <strong>{ method_title }</strong>
-            </span>
+                { this.renderPrice() }
+            </div>
         );
     }
 
@@ -139,13 +140,11 @@ export class CheckoutDeliveryOption extends PureComponent {
               block="CheckoutDeliveryOption"
               elem="Row"
             >
-                <span block="CheckoutDeliveryOption" elem="Span" mods={ { isDisabled: !available } }>
+                <div block="CheckoutDeliveryOption" elem="Span" mods={ { isDisabled: !available } }>
                     { __('Carrier method: ') }
                     <strong>{ carrier_title }</strong>
-                </span>
-                <br />
+                </div>
                 { this.renderRate() }
-                { this.renderPrice() }
                 { this.renderSubPrice() }
                 { this.renderAvailabilityMessage() }
             </div>

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
@@ -82,14 +82,14 @@ export class CheckoutDeliveryOption extends PureComponent {
         }
 
         return (
-            <span
+            <div
               block="CheckoutDeliveryOption"
               elem="SubPrice"
               mods={ { isOverflowed } }
               ref={ this.subPriceRef }
             >
                 { __('Excl. tax: %s', formatPrice(optionSubPrice, currency)) }
-            </span>
+            </div>
         );
     }
 
@@ -116,7 +116,6 @@ export class CheckoutDeliveryOption extends PureComponent {
         return (
             <strong>
                 { ` - ${ this.getOptionPrice() }` }
-                { this.renderSubPrice() }
             </strong>
         );
     }
@@ -183,6 +182,7 @@ export class CheckoutDeliveryOption extends PureComponent {
                 <br />
                 { this.renderRate() }
                 { this.renderPrice() }
+                { this.renderSubPrice() }
                 { this.renderAvailabilityMessage() }
             </div>
         );

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
@@ -89,7 +89,6 @@
     &-SubPrice {
         font-size: 12px;
         font-weight: 400;
-        margin-block-start: 8px;
     }
 
     &-Message {

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.style.scss
@@ -89,15 +89,7 @@
     &-SubPrice {
         font-size: 12px;
         font-weight: 400;
-        text-align: end;
-        position: absolute;
-        inset-inline-end: 0;
-        inset-block-start: 1.5em;
-        white-space: nowrap;
-
-        &_isOverflowed {
-            inset-inline-start: 0;
-        }
+        margin-block-start: 8px;
     }
 
     &-Message {


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4293

**Problem:**
* Excl. tax element wasn't properly aligned with the rest of the elements in its scope

**In this PR:**
* Changed layout/CSS so that it aligns properly now
