### PR TITLE
[4773] remove condition related to breadcrumbs visibility on my account page

### DIFF
--- a/packages/scandipwa/src/component/Breadcrumbs/Breadcrumbs.component.js
+++ b/packages/scandipwa/src/component/Breadcrumbs/Breadcrumbs.component.js
@@ -15,7 +15,6 @@ import { PureComponent } from 'react';
 import Breadcrumb from 'Component/Breadcrumb';
 import ContentWrapper from 'Component/ContentWrapper';
 import { CHECKOUT_URL } from 'Route/Checkout/Checkout.config';
-import { ACCOUNT_URL } from 'Route/MyAccount/MyAccount.config';
 import { BreadcrumbsType } from 'Type/Breadcrumbs.type';
 import { appendWithStoreCode, isHomePageUrl } from 'Util/Url';
 
@@ -65,7 +64,6 @@ export class Breadcrumbs extends PureComponent {
 
         return (
             !areBreadcrumbsVisible
-            || pathname.match(appendWithStoreCode(ACCOUNT_URL))
             || pathname.match(appendWithStoreCode(CHECKOUT_URL))
             || isHomePageUrl(pathname)
         );


### PR DESCRIPTION
**Related issue(s):**

-  Fixes https://github.com/scandipwa/scandipwa/issues/4773

**Problem:**

- Breadcrumbs are missing on /customer/account and /customer/account/edit page

**In this PR:**

- Remove condition pathname match for ACCOUNT_URL on Breadcrumbs component class