### PR TITLE
[4757] - Endless loader on the Thank You page - fixed

### DIFF
--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
@@ -33,7 +33,7 @@ export class CheckoutBilling extends PureComponent {
     state = {
         isOrderButtonVisible: true,
         isOrderButtonEnabled: true,
-        isTermsAndConditionsAccepted: false
+        isTACAccepted: false
     };
 
     static propTypes = {
@@ -93,8 +93,8 @@ export class CheckoutBilling extends PureComponent {
     }
 
     setTACAccepted() {
-        this.setState(({ isTermsAndConditionsAccepted: oldIsTACAccepted }) => ({
-            isTermsAndConditionsAccepted: !oldIsTACAccepted
+        this.setState(({ isTACAccepted: oldIsTACAccepted }) => ({
+            isTACAccepted: !oldIsTACAccepted
         }));
     }
 
@@ -132,7 +132,7 @@ export class CheckoutBilling extends PureComponent {
         );
     }
 
-    renderTermsAndConditions() {
+    renderTAC() {
         const {
             termsAreEnabled,
             termsAndConditions
@@ -142,7 +142,7 @@ export class CheckoutBilling extends PureComponent {
             checkbox_text = __('I agree to terms and conditions')
         } = termsAndConditions[0] || {};
 
-        const { isTermsAndConditionsAccepted } = this.state;
+        const { isTACAccepted } = this.state;
 
         if (!termsAreEnabled) {
             return null;
@@ -165,7 +165,7 @@ export class CheckoutBilling extends PureComponent {
                           id: 'termsAndConditions',
                           name: 'termsAndConditions',
                           value: 'termsAndConditions',
-                          checked: isTermsAndConditionsAccepted
+                          checked: isTACAccepted
                       } }
                       events={ {
                           onChange: this.setTACAccepted
@@ -231,7 +231,7 @@ export class CheckoutBilling extends PureComponent {
         const {
             isOrderButtonVisible,
             isOrderButtonEnabled,
-            isTermsAndConditionsAccepted
+            isTACAccepted
         } = this.state;
 
         const { termsAreEnabled } = this.props;
@@ -242,7 +242,7 @@ export class CheckoutBilling extends PureComponent {
 
         // if terms and conditions are enabled, validate for acceptance
         const isDisabled = termsAreEnabled
-            ? !isOrderButtonEnabled || !isTermsAndConditionsAccepted || paymentMethod === 'braintree_local_payment'
+            ? !isOrderButtonEnabled || !isTACAccepted || !paymentMethod
             : !isOrderButtonEnabled;
 
         return (
@@ -375,7 +375,7 @@ export class CheckoutBilling extends PureComponent {
                 { is_virtual && this.renderGuestForm() }
                 { this.renderAddresses() }
                 { this.renderPayments() }
-                { this.renderTermsAndConditions() }
+                { this.renderTAC() }
                 { this.renderActions() }
                 { this.renderPopup() }
             </Form>

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
@@ -61,11 +61,13 @@ export class CheckoutBilling extends PureComponent {
         termsAndConditions: PropTypes.arrayOf(PropTypes.shape({
             checkbox_text: PropTypes.string
         })).isRequired,
-        selectedShippingMethod: PropTypes.string.isRequired
+        selectedShippingMethod: PropTypes.string.isRequired,
+        paymentMethod: PropTypes.string
     };
 
     static defaultProps = {
-        cartTotalSubPrice: null
+        cartTotalSubPrice: null,
+        paymentMethod: ''
     };
 
     setOrderButtonEnableStatus = this.setOrderButtonEnableStatus.bind(this);
@@ -224,6 +226,8 @@ export class CheckoutBilling extends PureComponent {
     }
 
     renderActions() {
+        const { paymentMethod } = this.props;
+
         const {
             isOrderButtonVisible,
             isOrderButtonEnabled,
@@ -238,7 +242,7 @@ export class CheckoutBilling extends PureComponent {
 
         // if terms and conditions are enabled, validate for acceptance
         const isDisabled = termsAreEnabled
-            ? !isOrderButtonEnabled || !isTermsAndConditionsAccepted
+            ? !isOrderButtonEnabled || !isTermsAndConditionsAccepted || paymentMethod === 'braintree_local_payment'
             : !isOrderButtonEnabled;
 
         return (

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -120,14 +120,12 @@ export class CheckoutBillingContainer extends PureComponent {
         super.__construct(props);
 
         const { paymentMethods, customer } = props;
-        const [method] = paymentMethods;
-        const { code: paymentMethod } = method || {};
 
         this.state = {
             isSameAsShipping: this.isSameShippingAddress(customer),
             selectedCustomerAddressId: 0,
             prevPaymentMethods: paymentMethods,
-            paymentMethod
+            paymentMethod: ''
         };
     }
 

--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -149,7 +149,7 @@ export class CheckoutBillingContainer extends PureComponent {
             onPasswordChange,
             isGuestEmailSaved
         } = this.props;
-        const { isSameAsShipping } = this.state;
+        const { isSameAsShipping, paymentMethod } = this.state;
 
         return {
             cartTotalSubPrice,
@@ -167,7 +167,8 @@ export class CheckoutBillingContainer extends PureComponent {
             onEmailChange,
             onCreateUserChange,
             onPasswordChange,
-            isGuestEmailSaved
+            isGuestEmailSaved,
+            paymentMethod
         };
     }
 

--- a/packages/scandipwa/src/component/CheckoutDeliveryOptions/CheckoutDeliveryOptions.component.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOptions/CheckoutDeliveryOptions.component.js
@@ -22,43 +22,12 @@ export class CheckoutDeliveryOptions extends PureComponent {
     static propTypes = {
         shippingMethods: ShippingMethodsType.isRequired,
         selectShippingMethod: PropTypes.func.isRequired,
-        selectedShippingMethod: ShippingMethodType,
-        checkoutReducerShippingMethod: PropTypes.string.isRequired
+        selectedShippingMethod: ShippingMethodType
     };
 
     static defaultProps = {
         selectedShippingMethod: {}
     };
-
-    state = {
-        initialSelectedMethod: null
-    };
-
-    componentDidUpdate(prevProps) {
-        const { checkoutReducerShippingMethod, shippingMethods, selectShippingMethod } = this.props;
-        const { shippingMethods: prevShippingMethods } = prevProps;
-        const { initialSelectedMethod } = this.state;
-
-        if (
-            checkoutReducerShippingMethod
-            && (!prevShippingMethods.length && shippingMethods.length)
-        ) {
-            shippingMethods.forEach(
-                (method) => {
-                    const { available, method_code } = method;
-
-                    if (available && method_code === checkoutReducerShippingMethod) {
-                        // eslint-disable-next-line react/no-did-update-set-state
-                        this.setState({ initialSelectedMethod: method });
-                    }
-                }
-            );
-        } else if (initialSelectedMethod) {
-            selectShippingMethod(initialSelectedMethod);
-            // eslint-disable-next-line react/no-did-update-set-state
-            this.setState({ initialSelectedMethod: null });
-        }
-    }
 
     renderHeading() {
         return (
@@ -73,10 +42,9 @@ export class CheckoutDeliveryOptions extends PureComponent {
             selectShippingMethod,
             selectedShippingMethod: { method_code: selectedMethodCode }
         } = this.props;
-        const { initialSelectedMethod } = this.state;
 
         const { carrier_code, method_code } = option;
-        const isSelected = (initialSelectedMethod?.method_code || selectedMethodCode) === method_code;
+        const isSelected = selectedMethodCode === method_code;
 
         return (
             <CheckoutDeliveryOption

--- a/packages/scandipwa/src/component/CheckoutDeliveryOptions/CheckoutDeliveryOptions.container.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOptions/CheckoutDeliveryOptions.container.js
@@ -20,10 +20,7 @@ import { ShippingMethodsType } from 'Type/Checkout.type';
 import CheckoutDeliveryOptions from './CheckoutDeliveryOptions.component';
 
 /** @namespace Component/CheckoutDeliveryOptions/Container/mapStateToProps */
-export const mapStateToProps = (state) => ({
-    checkoutReducerShippingMethod: (
-        state.CheckoutReducer.shippingFields.shipping_method?.split('_', 1)[0]
-    )
+export const mapStateToProps = () => ({
 });
 
 /** @namespace Component/CheckoutDeliveryOptions/Container/mapDispatchToProps */
@@ -48,8 +45,7 @@ export class CheckoutDeliveryOptionsContainer extends PureComponent {
             error_message: PropTypes.string,
             price_excl_tax: PropTypes.number,
             price_incl_tax: PropTypes.number
-        }),
-        checkoutReducerShippingMethod: PropTypes.string.isRequired
+        })
     };
 
     static defaultProps = {
@@ -81,8 +77,7 @@ export class CheckoutDeliveryOptionsContainer extends PureComponent {
             onStoreSelect,
             shippingMethods,
             handleSelectDeliveryMethod,
-            selectedShippingMethod,
-            checkoutReducerShippingMethod
+            selectedShippingMethod
         } = this.props;
 
         return {
@@ -91,8 +86,7 @@ export class CheckoutDeliveryOptionsContainer extends PureComponent {
             onStoreSelect,
             selectedShippingMethod,
             shippingMethods,
-            handleSelectDeliveryMethod,
-            checkoutReducerShippingMethod
+            handleSelectDeliveryMethod
         };
     }
 

--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -148,8 +148,6 @@ export class Checkout extends PureComponent {
         }
     };
 
-    stepsCount = 2;
-
     componentDidMount() {
         this.updateHeader();
         this.updateStepURL(true);
@@ -214,7 +212,7 @@ export class Checkout extends PureComponent {
                     <div block="Checkout" elem="Step">
                         <span block="Checkout" elem="SelectedStep">{ number }</span>
                         <span block="Checkout" elem="StepsBorder">/</span>
-                        <span block="Checkout" elem="TotalSteps">{ this.stepsCount }</span>
+                        <span block="Checkout" elem="TotalSteps">{ Object.keys(this.stepMap).length }</span>
                     </div>
                 </div>
                 <div block="Checkout" elem="StepBarTotal" />

--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
@@ -124,6 +124,8 @@ export class CartDispatcher {
 
             setGuestQuoteId(quoteId);
 
+            dispatch(updateIsLoadingCart(false));
+
             return quoteId;
         } catch (error) {
             dispatch(showNotification('error', getErrorMessage(error)));

--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
@@ -83,6 +83,8 @@ export class CartDispatcher {
 
             return null;
         } catch (error) {
+            dispatch(updateIsLoadingCart(false));
+
             return this.createGuestEmptyCart(dispatch);
         }
     }
@@ -129,6 +131,8 @@ export class CartDispatcher {
             return quoteId;
         } catch (error) {
             dispatch(showNotification('error', getErrorMessage(error)));
+
+            dispatch(updateIsLoadingCart(false));
 
             return null;
         }


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4757

**Problem:**
* The full-page loader was preventing the order success message from rendering because the isCartLoading prop (Checkout.component) was always true for guest users.

**In this PR:**
* Added a line of code to Cart.dispatcher that sets the isCartLoading state to false once all the async operations are over
* Removed payment method auto-selection on checking the Terms and Conditions box on the billing page
* Removed redundant code 
