### PR TITLE
fixed line height for textareas from other places

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -39,6 +39,7 @@
     &-LabelContainer {
         display: flex;
         align-items: center;
+        line-height: 1;
 
         .ChevronIcon {
             width: 23px;
@@ -233,6 +234,10 @@
             .SubtractButton {
                 width: 24px;
             }
+        }
+
+        &_textarea {
+            line-height: 0;
         }
 
         &_text,

--- a/packages/scandipwa/src/component/ProductReviewForm/ProductReviewForm.style.scss
+++ b/packages/scandipwa/src/component/ProductReviewForm/ProductReviewForm.style.scss
@@ -136,8 +136,4 @@
     textarea {
         width: 100%;
     }
-
-    textarea {
-        margin-block-end: -3px;
-    }
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4705

**Problem:**
* Line height for textareas was inconsistent for other places in the app

**In this PR:**
* Made line height 0 and 1 for the labels
