### PR TITLE
[4770] - MyAccount content width fix

### DIFF
--- a/packages/scandipwa/src/route/MyAccount/MyAccount.style.scss
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.style.scss
@@ -69,7 +69,7 @@
         }
 
         @include mobile {
-            margin-inline: 5px;
+            padding: 0 16px;
         }
 
         @include desktop {


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4770

**Problem:**
The content of the MyAccount page wasn't aligned with the rest of the content on Mobile

**In this PR:**
* Added padding to the element