### PR TITLE
[4660] - double Order Summary loader on singn-in on checkout - fixed

### DIFF
--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -467,9 +467,9 @@ export class Checkout extends PureComponent {
     }
 
     render() {
-        const { isCartLoading } = this.props;
+        const { totals, checkoutStep } = this.props;
 
-        if (isCartLoading) {
+        if (totals.items.length < 1 && checkoutStep !== DETAILS_STEP) {
             return this.renderFullPageLoader();
         }
 

--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
@@ -118,21 +118,15 @@ export class CartDispatcher {
 
     async createGuestEmptyCart(dispatch) {
         try {
-            dispatch(updateIsLoadingCart(true));
-
             const {
                 createEmptyCart: quoteId = ''
             } = await fetchMutation(CartQuery.getCreateEmptyCartMutation());
 
             setGuestQuoteId(quoteId);
 
-            dispatch(updateIsLoadingCart(false));
-
             return quoteId;
         } catch (error) {
             dispatch(showNotification('error', getErrorMessage(error)));
-
-            dispatch(updateIsLoadingCart(false));
 
             return null;
         }


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4660

**Problem:**
* The issue reappeared after one of the latest PR merges 
* Another issue that appeared as a result of this - on checkout, the full page loader would render twice on sign-in

**In this PR:**
* Changed the conditions on which the full page loader renders so that it only appears when the cart is empty
* in Cart.dispatcher, removed the updateIsLoadingCart method calls from createGuestEmptyCart since they're not really needed there
