### PR TITLE
#3718 - added promotion block to header

### DIFF
--- a/packages/scandipwa/src/component/Header/Header.component.js
+++ b/packages/scandipwa/src/component/Header/Header.component.js
@@ -19,6 +19,7 @@ import ChevronIcon from 'Component/ChevronIcon';
 import { LEFT } from 'Component/ChevronIcon/ChevronIcon.config';
 import ClickOutside from 'Component/ClickOutside';
 import CloseIcon from 'Component/CloseIcon';
+import CmsBlock from 'Component/CmsBlock';
 import CompareIcon from 'Component/CompareIcon';
 import CurrencySwitcher from 'Component/CurrencySwitcher';
 import ExclamationMarkIcon from 'Component/ExclamationMarkIcon';
@@ -719,22 +720,36 @@ export class Header extends NavigationAbstract {
         return (
             <div block="Header" elem="TopMenu">
                 <div block="Header" elem="News">
-                    <ExclamationMarkIcon />
-                    <span>{ __('Check new arrivals') }</span>
-                    <Link
-                      to="/"
-                      key="news"
-                      block="Header"
-                      elem="NewsButton"
-                    >
-                        { __('here!') }
-                    </Link>
+                    { this.renderCMSBlock() }
                 </div>
                 <div block="Header" elem="Switcher">
                     <CurrencySwitcher />
                     <StoreSwitcher />
                 </div>
             </div>
+        );
+    }
+
+    renderCMSBlock() {
+        const { header_content: { contacts_cms } = {} } = window.contentConfiguration;
+
+        if (contacts_cms) {
+            return <CmsBlock identifier={ contacts_cms } />;
+        }
+
+        return (
+            <>
+                <ExclamationMarkIcon />
+                <span>{ __('Check new arrivals') }</span>
+                <Link
+                  to="/"
+                  key="news"
+                  block="Header"
+                  elem="NewsButton"
+                >
+                    { __('here!') }
+                </Link>
+            </>
         );
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3718

**Problem:**
* Promotional block was hardcoded into the website and did not update on CMS block change. 

**In this PR:**
* Edited the promotional block into CMS block so it would update according to the admin settings for CMS blocks. 
