### PR TITLE
[4798] - error on clicking Add to Cart while the product is loading

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -246,10 +246,10 @@ export class ProductCard extends Product {
 
         const configureBundleAndGrouped = type === PRODUCT_TYPE.bundle || type === PRODUCT_TYPE.grouped;
         const configureConfig = (type === PRODUCT_TYPE.configurable
-            // eslint-disable-next-line max-len
-            && Object.keys(super.getConfigurableAttributes()).length !== Object.keys(this.getConfigurableAttributes()).length)
-            // eslint-disable-next-line max-len
-            || (type === PRODUCT_TYPE.configurable && Object.values(this.getConfigurableAttributes()).some((value) => value.attribute_values.length === 0));
+            && Object.keys(super.getConfigurableAttributes())
+                .length !== Object.keys(this.getConfigurableAttributes()).length)
+            || (type === PRODUCT_TYPE.configurable
+               && Object.values(this.getConfigurableAttributes()).some((value) => value.attribute_values.length === 0));
         const configureCustomize = options.some(({ required = false }) => required);
         const configureDownloadableLinks = PRODUCT_TYPE.downloadable && links_purchased_separately === 1;
 
@@ -317,7 +317,7 @@ export class ProductCard extends Product {
     }
 
     renderCardContent() {
-        const { renderContent } = this.props;
+        const { renderContent, product: { name } } = this.props;
 
         if (renderContent) {
             return renderContent(this.contentObject);
@@ -325,7 +325,7 @@ export class ProductCard extends Product {
 
         return (
             this.renderCardLinkWrapper((
-                <div block="ProductCard" elem="LinkInnerWrapper">
+                <div block="ProductCard" elem="LinkInnerWrapper" mods={ { loaded: !!name } }>
                     <div block="ProductCard" elem="FigureReview">
                         <figure block="ProductCard" elem="Figure">
                             { this.renderPicture() }
@@ -347,7 +347,7 @@ export class ProductCard extends Product {
 
     renderCardListContent() {
         const {
-            children, layout, renderContent
+            children, layout, renderContent, product: { name }
         } = this.props;
 
         if (renderContent) {
@@ -371,7 +371,7 @@ export class ProductCard extends Product {
                         { this.renderPrice() }
                         { this.renderConfigurableOptions() }
                     </div>
-                    <div block="ProductCard" elem="ActionWrapper">
+                    <div block="ProductCard" elem="ActionWrapper" mods={ { loaded: !!name } }>
                         { this.renderAddToCart() }
                         { this.renderProductActions() }
                     </div>

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
@@ -186,13 +186,17 @@
         width: 100%;
         height: 100%;
 
-        &_loaded:hover {
+        &:hover {
             @include desktop {
                 box-shadow: 0 3px 6px -4px rgba(0, 0, 0, .1),
                     0 6px 16px rgba(0, 0, 0, .1),
                     0 9px 28px 8px rgba(0, 0, 0, .1);
                 z-index: 4;
+            }
+        }
 
+        &_loaded:hover {
+            @include desktop {
                 .ProductCard-VisibleOnHover {
                     background: var(--product-card-background);
                     width: inherit;

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
@@ -34,33 +34,6 @@
     display: flex;
     align-items: stretch;
 
-    &:hover {
-        @include desktop {
-            box-shadow: 0 3px 6px -4px rgba(0, 0, 0, .1),
-                0 6px 16px rgba(0, 0, 0, .1),
-                0 9px 28px 8px rgba(0, 0, 0, .1);
-            z-index: 4;
-
-            .ProductCard-VisibleOnHover {
-                background: var(--product-card-background);
-                width: inherit;
-                opacity: 1;
-                box-shadow: 0 3px 6px rgba(0, 0, 0, .1),
-                    0 6px 16px rgba(0, 0, 0, .1),
-                    0 9px 28px 8px rgba(0, 0, 0, .1);
-                z-index: -1;
-                display: flex;
-                flex-direction: column;
-                justify-content: flex-end;
-                flex-grow: 1;
-                padding-block-start: 0;
-                padding-block-end: 10px;
-                padding-inline: 15px;
-                position: absolute;
-                inset-block-start: 100%;
-            }
-        }
-    }
 
     &::before {
         content: none;
@@ -110,6 +83,11 @@
                 &-ActionWrapper {
                     align-items: center;
                     display: flex;
+                    visibility: hidden;
+
+                    &_loaded {
+                        visibility: visible;
+                    }
 
                     button {
                         margin-inline-end: 10px;
@@ -207,6 +185,34 @@
     &-LinkInnerWrapper {
         width: 100%;
         height: 100%;
+
+        &_loaded:hover {
+            @include desktop {
+                box-shadow: 0 3px 6px -4px rgba(0, 0, 0, .1),
+                    0 6px 16px rgba(0, 0, 0, .1),
+                    0 9px 28px 8px rgba(0, 0, 0, .1);
+                z-index: 4;
+
+                .ProductCard-VisibleOnHover {
+                    background: var(--product-card-background);
+                    width: inherit;
+                    opacity: 1;
+                    box-shadow: 0 3px 6px rgba(0, 0, 0, .1),
+                        0 6px 16px rgba(0, 0, 0, .1),
+                        0 9px 28px 8px rgba(0, 0, 0, .1);
+                    z-index: -1;
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: flex-end;
+                    flex-grow: 1;
+                    padding-block-start: 0;
+                    padding-block-end: 10px;
+                    padding-inline: 15px;
+                    position: absolute;
+                    inset-block-start: 100%;
+                }
+            }
+        }
     }
 
     &-FigureReview {


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/3468
* Fixes scandipwa/scandipwa/issues/4798

**Problem:**
* On PLP, the Add to Cart buttons inside of Product Cards are viewable/clickable even though the product hasn't finished loading yet, which causes errors on click

**In this PR:**
* For Grid view: removed the hover state from product cards that haven't finished loading
* For list view: same problem solved by making the buttons invisible and non-interactive. 
