### PR TITLE
#4803 - added order total and subtotal fields to orders equal to 0

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.component.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.component.js
@@ -348,7 +348,7 @@ export class CartItem extends PureComponent {
 
         return (
             <CartItemPrice
-              row_total={ row_total }
+              row_total={ Number(row_total || 0).toFixed(2) }
               row_total_incl_tax={ row_total_incl_tax }
               currency_code={ currency_code }
               mix={ {

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -103,7 +103,7 @@ export class CartOverlay extends PureComponent {
     renderOrderTotalExlTax() {
         const { cartTotalSubPrice } = this.props;
 
-        if (!cartTotalSubPrice) {
+        if (!cartTotalSubPrice && cartTotalSubPrice !== 0) {
             return null;
         }
 

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -258,10 +258,10 @@ export class CheckoutOrderSummary extends PureComponent {
         const title = __('Order total');
         return (
                 <CheckoutOrderSummaryPriceLine
-                  price={ grand_total.toFixed(2) }
+                  price={ Number(grand_total || 0).toFixed(2) }
                   currency={ quote_currency_code }
                   title={ title }
-                  subPrice={ cartTotalSubPrice && cartTotalSubPrice.toFixed(2) }
+                  subPrice={ Number(cartTotalSubPrice || 0).toFixed(2) }
                   mods={ { isTotal: true } }
                 />
         );

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -256,20 +256,15 @@ export class CheckoutOrderSummary extends PureComponent {
             cartTotalSubPrice
         } = this.props;
         const title = __('Order total');
-
-        if (cartTotalSubPrice) {
-            return (
+        return (
                 <CheckoutOrderSummaryPriceLine
-                  price={ grand_total }
+                  price={ grand_total.toFixed(2) }
                   currency={ quote_currency_code }
                   title={ title }
-                  subPrice={ cartTotalSubPrice }
+                  subPrice={ cartTotalSubPrice && cartTotalSubPrice.toFixed(2) }
                   mods={ { isTotal: true } }
                 />
-            );
-        }
-
-        return this.renderPriceLine(grand_total.toFixed(2), title, { isTotal: true });
+        );
     }
 
     renderTaxFullSummary() {

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -68,10 +68,6 @@ export class CheckoutOrderSummary extends PureComponent {
     };
 
     renderPriceLine(price, title, mods) {
-        if (!price) {
-            return null;
-        }
-
         const { totals: { quote_currency_code } } = this.props;
 
         return (
@@ -205,18 +201,14 @@ export class CheckoutOrderSummary extends PureComponent {
 
         const title = __('Subtotal');
 
-        if (cartSubtotal) {
-            return (
+        return (
                 <CheckoutOrderSummaryPriceLine
-                  price={ cartSubtotal }
+                  price={ cartSubtotal.toFixed(2) }
                   currency={ quote_currency_code }
                   title={ title }
-                  subPrice={ cartSubtotalSubPrice }
+                  subPrice={ cartSubtotalSubPrice.toFixed(2) }
                 />
-            );
-        }
-
-        return this.renderPriceLine(cartSubtotal, title);
+        );
     }
 
     getShippingLabel() {
@@ -277,7 +269,7 @@ export class CheckoutOrderSummary extends PureComponent {
             );
         }
 
-        return this.renderPriceLine(grand_total, title, { isTotal: true });
+        return this.renderPriceLine(grand_total.toFixed(2), title, { isTotal: true });
     }
 
     renderTaxFullSummary() {

--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.style.scss
@@ -238,6 +238,7 @@
 
         span {
             line-height: 16px;
+            font-size: 12px;
         }
     }
 

--- a/packages/scandipwa/src/component/CheckoutOrderSummaryPriceLine/CheckoutOrderSummaryPriceLine.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummaryPriceLine/CheckoutOrderSummaryPriceLine.component.js
@@ -98,7 +98,7 @@ export class CheckoutOrderSummaryPriceLine extends PureComponent {
             return null;
         }
 
-        if (+price === 0 && !itemsQty) {
+        if (price === 0 && !itemsQty) {
             return null;
         }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4803 
* Fixes #4796

**Problem:**
* Order total and subtotal were not appearing when the items total cost was 0. 
* Font size did not match the one in Luma. 

**In this PR:**
* Removed some conditionals and changed numbers to strings for order totals. 
* Edited font size to 12px. 
