### PR TITLE
Added required prop(value) to Field type numberWithControls in Groupe…

### DIFF
--- a/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.component.js
+++ b/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.component.js
@@ -116,6 +116,7 @@ export class GroupedProductsItem extends PureComponent {
                   min: 0,
                   max
               } }
+              value={ itemCount }
               validationRule={ {
                   inputType: VALIDATION_INPUT_TYPE_NUMBER.numeric,
                   isRequired: true,


### PR DESCRIPTION
GroupedProductsItem component

**Related issue(s):**
- Fixes https://github.com/scandipwa/scandipwa/issues/4801

**Problem:**
- User should click twice on + qty control button to increase qty from 1 to 2 for 0 qty child product in grouped product

**In this PR:**
- Added required prop(value) in Field type numberWithControls in GroupedProductsItem
