### PR TITLE
#4802 - hid all payments but free one for total 0

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.component.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.component.js
@@ -348,7 +348,7 @@ export class CartItem extends PureComponent {
 
         return (
             <CartItemPrice
-              row_total={ row_total }
+              row_total={ Number(row_total || 0).toFixed(2) }
               row_total_incl_tax={ row_total_incl_tax }
               currency_code={ currency_code }
               mix={ {

--- a/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.component.js
+++ b/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.component.js
@@ -23,11 +23,13 @@ export class CheckoutPayment extends PureComponent {
     static propTypes = {
         method: PaymentMethodType.isRequired,
         onClick: PropTypes.func.isRequired,
-        isSelected: PropTypes.bool
+        isSelected: PropTypes.bool,
+        noCheckbox: PropTypes.bool
     };
 
     static defaultProps = {
-        isSelected: false
+        isSelected: false,
+        noCheckbox: false
     };
 
     onClick = this.onClick.bind(this);
@@ -44,6 +46,7 @@ export class CheckoutPayment extends PureComponent {
     render() {
         const {
             isSelected,
+            noCheckbox,
             method: { title }
         } = this.props;
 
@@ -52,7 +55,7 @@ export class CheckoutPayment extends PureComponent {
             <li block="CheckoutPayment">
                 <button
                   block="CheckoutPayment"
-                  mods={ { isSelected } }
+                  mods={ { isSelected, noCheckbox } }
                   elem="Button"
                   type="button"
                   onClick={ this.onClick }
@@ -65,7 +68,7 @@ export class CheckoutPayment extends PureComponent {
                           checked: isSelected
                       } }
                       label={ title }
-                      isDisabled={ false }
+                      isDisabled={ noCheckbox }
                     />
                 </button>
             </li>

--- a/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.style.scss
+++ b/packages/scandipwa/src/component/CheckoutPayment/CheckoutPayment.style.scss
@@ -44,7 +44,16 @@
         display: flex;
         align-items: flex-start;
         font-size: 14px;
-        cursor: pointer;
+
+        &_noCheckbox {
+            .Field [type='checkbox']:disabled {
+                opacity: 0;
+            }
+
+            .Field [type='checkbox'] + .input-control {
+                display: none;
+            }
+        }
     }
 
     .Field_type_checkbox {

--- a/packages/scandipwa/src/component/CheckoutPayments/CheckoutPayments.component.js
+++ b/packages/scandipwa/src/component/CheckoutPayments/CheckoutPayments.component.js
@@ -20,7 +20,7 @@ import { PurchaseOrder } from 'Component/PurchaseOrder/PurchaseOrder.component';
 import { BILLING_STEP } from 'Route/Checkout/Checkout.config';
 import { PaymentMethodsType } from 'Type/Checkout.type';
 
-import { KLARNA, PURCHASE_ORDER } from './CheckoutPayments.config';
+import { CODE_FREE, KLARNA, PURCHASE_ORDER } from './CheckoutPayments.config';
 
 import './CheckoutPayments.style';
 
@@ -118,9 +118,8 @@ export class CheckoutPayments extends PureComponent {
     renderPayments() {
         const { paymentMethods } = this.props;
         const { totals: { grand_total } } = this.props;
-        const codeFree = 'free';
 
-        const paymentFree = paymentMethods.find((payment) => payment.code === codeFree);
+        const paymentFree = paymentMethods.find((payment) => payment.code === CODE_FREE);
 
         if (!grand_total && paymentFree) {
             return this.renderPayment(paymentFree);

--- a/packages/scandipwa/src/component/CheckoutPayments/CheckoutPayments.component.js
+++ b/packages/scandipwa/src/component/CheckoutPayments/CheckoutPayments.component.js
@@ -118,7 +118,9 @@ export class CheckoutPayments extends PureComponent {
     renderPayments() {
         const { paymentMethods } = this.props;
         const { totals: { grand_total } } = this.props;
-        const paymentFree = paymentMethods.find((payment) => payment.code === 'free');
+        const codeFree = 'free';
+
+        const paymentFree = paymentMethods.find((payment) => payment.code === codeFree);
 
         if (!grand_total && paymentFree) {
             return this.renderPayment(paymentFree);

--- a/packages/scandipwa/src/component/CheckoutPayments/CheckoutPayments.component.js
+++ b/packages/scandipwa/src/component/CheckoutPayments/CheckoutPayments.component.js
@@ -47,6 +47,9 @@ export class CheckoutPayments extends PureComponent {
             region: PropTypes.string,
             street: PropTypes.arrayOf(PropTypes.string),
             telephone: PropTypes.string
+        }).isRequired,
+        totals: PropTypes.shape({
+            grand_total: PropTypes.number
         }).isRequired
     };
 
@@ -114,6 +117,12 @@ export class CheckoutPayments extends PureComponent {
 
     renderPayments() {
         const { paymentMethods } = this.props;
+        const { totals: { grand_total } } = this.props;
+        const paymentFree = paymentMethods.find((payment) => payment.code === 'free');
+
+        if (!grand_total && paymentFree) {
+            return this.renderPayment(paymentFree);
+        }
 
         return paymentMethods.map(this.renderPayment);
     }

--- a/packages/scandipwa/src/component/CheckoutPayments/CheckoutPayments.config.js
+++ b/packages/scandipwa/src/component/CheckoutPayments/CheckoutPayments.config.js
@@ -14,3 +14,4 @@ export const CHECK_MONEY = 'checkmo';
 export const PAYPAL_EXPRESS = 'paypal_express';
 export const PAYPAL_EXPRESS_CREDIT = 'paypal_express_bml';
 export const PURCHASE_ORDER = 'purchaseorder';
+export const CODE_FREE = 'free';

--- a/packages/scandipwa/src/component/CheckoutPayments/CheckoutPayments.container.js
+++ b/packages/scandipwa/src/component/CheckoutPayments/CheckoutPayments.container.js
@@ -79,7 +79,8 @@ export class CheckoutPaymentsContainer extends PureComponent {
             billingAddress,
             paymentMethods,
             setOrderButtonEnableStatus,
-            showError
+            showError,
+            totals
         } = this.props;
 
         const { selectedPaymentCode } = this.state;
@@ -89,7 +90,8 @@ export class CheckoutPaymentsContainer extends PureComponent {
             paymentMethods,
             selectedPaymentCode,
             setOrderButtonEnableStatus,
-            showError
+            showError,
+            totals
         };
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4802 

**Problem:**
* All payment methods were being displayed even when the total was 0. 

**In this PR:**
* Changed code so that if "Zero Subtotal Checkout" was enabled only "no payment required" would show. 
