### PR TITLE
#4747 - made price appear if it's 0

### DIFF
--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
@@ -130,7 +130,7 @@ export class ProductPrice extends PureComponent {
         // Use <ins></ins> <del></del> to represent new price and the old (deleted) one
         const PriceSemanticElementName = discountPercentage > 0 ? 'ins' : 'span';
 
-        if (priceValue === undefined) {
+        if (!priceValue && priceValue !== 0) {
             return null;
         }
 

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
@@ -130,9 +130,7 @@ export class ProductPrice extends PureComponent {
         // Use <ins></ins> <del></del> to represent new price and the old (deleted) one
         const PriceSemanticElementName = discountPercentage > 0 ? 'ins' : 'span';
 
-        // force unequal comparison - unsure of resulting type
-        // eslint-disable-next-line
-        if (priceValue == 0) {
+        if (priceValue === undefined) {
             return null;
         }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4747 

**Problem:**
* Price did not appear if it was equal to 0

**In this PR:**
* Made price only disappear if it's undefined, instead of 0. 
