### PR TITLE
#4797 - Display default sort on PLP

### DIFF
--- a/packages/scandipwa/src/component/CategorySort/CategorySort.component.js
+++ b/packages/scandipwa/src/component/CategorySort/CategorySort.component.js
@@ -41,7 +41,8 @@ export class CategorySort extends PureComponent {
             disabled: PropTypes.bool,
             label: PropTypes.string
         })).isRequired,
-        isMatchingInfoFilter: PropTypes.bool.isRequired
+        isMatchingInfoFilter: PropTypes.bool.isRequired,
+        isCurrentCategoryLoaded: PropTypes.bool.isRequired
     };
 
     onChange = this.onChange.bind(this);
@@ -66,10 +67,11 @@ export class CategorySort extends PureComponent {
             sortKey,
             sortDirection,
             selectOptions,
-            isMatchingInfoFilter
+            isMatchingInfoFilter,
+            isCurrentCategoryLoaded
         } = this.props;
 
-        if (!isMatchingInfoFilter) {
+        if (!isMatchingInfoFilter || !isCurrentCategoryLoaded) {
             return this.renderPlaceholder();
         }
 
@@ -79,7 +81,7 @@ export class CategorySort extends PureComponent {
               attr={ {
                   id: 'category-sort',
                   name: 'category-sort',
-                  defaultValue: `${sortDirection} ${sortKey}`,
+                  value: `${sortDirection} ${sortKey}`,
                   noPlaceholder: true
               } }
               events={ {

--- a/packages/scandipwa/src/component/CategorySort/CategorySort.container.js
+++ b/packages/scandipwa/src/component/CategorySort/CategorySort.container.js
@@ -30,7 +30,7 @@ export class CategorySortContainer extends PureComponent {
         isCurrentCategoryLoaded: PropTypes.bool,
         onSortChange: PropTypes.func.isRequired,
         sortKey: PropTypes.string.isRequired,
-        sortDirection: SortDirectionType.isRequired,
+        sortDirection: SortDirectionType.isRequired
     };
 
     static defaultProps = {

--- a/packages/scandipwa/src/component/CategorySort/CategorySort.container.js
+++ b/packages/scandipwa/src/component/CategorySort/CategorySort.container.js
@@ -27,18 +27,21 @@ export class CategorySortContainer extends PureComponent {
             }))
         ]),
         isMatchingInfoFilter: PropTypes.bool,
+        isCurrentCategoryLoaded: PropTypes.bool,
         onSortChange: PropTypes.func.isRequired,
         sortKey: PropTypes.string.isRequired,
-        sortDirection: SortDirectionType.isRequired
+        sortDirection: SortDirectionType.isRequired,
     };
 
     static defaultProps = {
         sortFields: [],
-        isMatchingInfoFilter: false
+        isMatchingInfoFilter: false,
+        isCurrentCategoryLoaded: false
     };
 
     containerProps() {
         const {
+            isCurrentCategoryLoaded,
             isMatchingInfoFilter,
             onSortChange,
             sortDirection,
@@ -46,6 +49,7 @@ export class CategorySortContainer extends PureComponent {
         } = this.props;
 
         return {
+            isCurrentCategoryLoaded,
             isMatchingInfoFilter,
             onSortChange,
             sortDirection,

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.js
@@ -268,6 +268,7 @@ export class CategoryPage extends PureComponent {
             selectedSort,
             onSortChange,
             isMatchingInfoFilter,
+            isCurrentCategoryLoaded,
             isMobile
         } = this.props;
 
@@ -281,6 +282,7 @@ export class CategoryPage extends PureComponent {
 
         return (
             <CategorySort
+              isCurrentCategoryLoaded={ isCurrentCategoryLoaded }
               isMatchingInfoFilter={ isMatchingInfoFilter }
               onSortChange={ onSortChange }
               sortFields={ updatedSortFields }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4797

**Problem:**
* PLP not use default sort field for category

**In this PR:**
* Display right default sort field on PLP
