### PR TITLE
#4782 - Set default currency as USD in formatPrice

### DIFF
--- a/packages/scandipwa/src/util/Price/Price.js
+++ b/packages/scandipwa/src/util/Price/Price.js
@@ -15,8 +15,9 @@ import currencyMap, { HUNDRED_PERCENT } from './Price.config';
 export const formatCurrency = (currency = 'USD') => currencyMap[currency];
 
 /** @namespace Util/Price/formatPrice */
-export const formatPrice = (price, currency = 'USD') => {
+export const formatPrice = (price, currentCurrency) => {
     const language = navigator.languages ? navigator.languages[0] : navigator.language;
+    const currency = currentCurrency || 'USD';
 
     return new Intl.NumberFormat(language, { style: 'currency', currency }).format(price);
 };


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4782

**Problem:**
* Ooops page opens on PLP when switch currency

**In this PR:**
* Set default currency as USD in formatPrice, Oops page not opening when switching currency

**Notice:**
* PR solves only the problem with the Oops page, the problem with the correct display of the selected currency was not affected
