### PR TITLE
Fix for page builder style support

### DIFF
--- a/packages/m2-theme/public/index.php
+++ b/packages/m2-theme/public/index.php
@@ -78,7 +78,7 @@ $icons = $this->getAppIconData();
     </style>
 </head>
 
-<body>
+<body id="html-body">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
 </body>


### PR DESCRIPTION
**Problem:**
* Same problem was fixed here https://github.com/scandipwa/scandipwa/pull/4206, however index.php is uses when BUILD_MODE=magento.

**In this PR:**
* Will add id=html-body on <body> tag so these page builder styles work
