### PR TITLE
Created customer_id field and pass to BE to get its email

### DIFF
--- a/packages/scandipwa/composer.json
+++ b/packages/scandipwa/composer.json
@@ -26,7 +26,6 @@
         "scandipwa/cache": "1.1.5",
         "scandipwa/locale": "2",
         "scandipwa/contact-graphql": "1.0.0",
-        "scandipwa/klarna-graphql": "1.1.2",
         "scandipwa/compare-graphql": "1.0.9",
         "scandipwa/customer-downloadable-graphql": "1.0.5",
         "scandipwa/directory-graphql": "1.0.1",

--- a/packages/scandipwa/i18n/da_DK.json
+++ b/packages/scandipwa/i18n/da_DK.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/de_DE.json
+++ b/packages/scandipwa/i18n/de_DE.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/es_ES.json
+++ b/packages/scandipwa/i18n/es_ES.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/fa_IR.json
+++ b/packages/scandipwa/i18n/fa_IR.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/fi_FI.json
+++ b/packages/scandipwa/i18n/fi_FI.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/fr_FR.json
+++ b/packages/scandipwa/i18n/fr_FR.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/it_IT.json
+++ b/packages/scandipwa/i18n/it_IT.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/lv_LV.json
+++ b/packages/scandipwa/i18n/lv_LV.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/nb_NO.json
+++ b/packages/scandipwa/i18n/nb_NO.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/nl_NL.json
+++ b/packages/scandipwa/i18n/nl_NL.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/pl_PL.json
+++ b/packages/scandipwa/i18n/pl_PL.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/pt_BR.json
+++ b/packages/scandipwa/i18n/pt_BR.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/ru_RU.json
+++ b/packages/scandipwa/i18n/ru_RU.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/sl_SI.json
+++ b/packages/scandipwa/i18n/sl_SI.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/sv_SE.json
+++ b/packages/scandipwa/i18n/sv_SE.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/tr_TR.json
+++ b/packages/scandipwa/i18n/tr_TR.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/i18n/zh_TW.json
+++ b/packages/scandipwa/i18n/zh_TW.json
@@ -612,5 +612,6 @@
     "Send Confirmation Page": null,
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
-    "Remove file": null
+    "Remove file": null,
+    "Region": null
 }

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -90,7 +90,6 @@
             "scandipwa/cache": "1.1.5",
             "scandipwa/locale": "2",
             "scandipwa/contact-graphql": "1.0.0",
-            "scandipwa/klarna-graphql": "1.1.2",
             "scandipwa/compare-graphql": "1.0.9",
             "scandipwa/customer-downloadable-graphql": "1.0.5",
             "scandipwa/directory-graphql": "1.0.1",

--- a/packages/scandipwa/src/query/MyAccount.query.js
+++ b/packages/scandipwa/src/query/MyAccount.query.js
@@ -18,17 +18,23 @@ import { Field } from 'Util/Query';
 export class MyAccountQuery {
     /**
      * Get ResetPassword mutation
-     * @param {{token: String, password: String, password_confirmation: String}} options A object containing different aspects of query, each item can be omitted
+     * @param {{customer_id: String, token: String, password: String, password_confirmation: String}} options A object containing different aspects of query, each item can be omitted
      * @return {Field}
      * @memberof MyAccount
      */
     getResetPasswordMutation(options) {
-        const { token, password, password_confirmation } = options;
+        const {
+            customer_id,
+            token,
+            password,
+            password_confirmation
+        } = options;
 
         return new Field('s_resetPassword')
             .addArgument('token', 'String!', token)
             .addArgument('password', 'String!', password)
             .addArgument('password_confirmation', 'String!', password_confirmation)
+            .addArgument('customer_id', 'String!', customer_id)
             .addField('status');
     }
 

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -501,15 +501,12 @@ export class CheckoutContainer extends PureComponent {
 
     handleRedirectIfLessThanMinAmountInCart() {
         const {
-            minimumOrderAmount: { minimum_order_amount_reached = true },
-            match: {
-                params: {
-                    step: urlStep = ''
-                }
-            }
+            minimumOrderAmount: { minimum_order_amount_reached = true }
         } = this.props;
 
-        if (!minimum_order_amount_reached && !urlStep.includes(DETAILS_URL_STEP)) {
+        const { checkoutStep } = this.state;
+
+        if (!minimum_order_amount_reached && checkoutStep !== DETAILS_STEP) {
             history.push(appendWithStoreCode(CART_URL));
         }
     }

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -501,10 +501,15 @@ export class CheckoutContainer extends PureComponent {
 
     handleRedirectIfLessThanMinAmountInCart() {
         const {
-            minimumOrderAmount: { minimum_order_amount_reached = true }
+            minimumOrderAmount: { minimum_order_amount_reached = true },
+            match: {
+                params: {
+                    step: urlStep = ''
+                }
+            }
         } = this.props;
 
-        if (!minimum_order_amount_reached) {
+        if (!minimum_order_amount_reached && !urlStep.includes(DETAILS_URL_STEP)) {
             history.push(appendWithStoreCode(CART_URL));
         }
     }

--- a/packages/scandipwa/src/route/PasswordChangePage/PasswordChangePage.container.js
+++ b/packages/scandipwa/src/route/PasswordChangePage/PasswordChangePage.container.js
@@ -173,8 +173,14 @@ export class PasswordChangePageContainer extends PureComponent {
             const { resetPassword, location } = this.props;
             const { password, password_confirmation } = transformToNameValuePair(fields);
             const token = getQueryParam('token', location);
+            const customer_id = getQueryParam('id', location);
 
-            resetPassword({ token, password, password_confirmation });
+            resetPassword({
+                customer_id,
+                token,
+                password,
+                password_confirmation
+            });
         });
     }
 

--- a/packages/scandipwa/src/store/MyAccount/MyAccount.dispatcher.js
+++ b/packages/scandipwa/src/store/MyAccount/MyAccount.dispatcher.js
@@ -154,7 +154,7 @@ export class MyAccountDispatcher {
 
     /**
      * Reset password action
-     * @param {{token: String, password: String, password_confirmation: String}} [options={}]
+     * @param {{customer_id: String, token: String, password: String, password_confirmation: String}} [options={}]
      * @returns {Promise<{status: String}>} Reset password token
      * @memberof MyAccountDispatcher
      */


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4122 

**Problem:**
* In Magento 2.4.4 there is strict checking for an email while resetting a customer password via email

**In this PR:**
* The email message provides a customer with a link that leads to a resetting page and it contains `customer_id ` as one of the params, so in order to get the customer's email, I pass this id to BE and get the email from that id, and further pass the email to the reset method. Before this PR `null` was sent instead of email
* scandipwa/customer-graph-ql#34
