### PR TITLE
#4340 - Remove meta update when category is not yet received

### DIFF
--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.js
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.js
@@ -235,11 +235,6 @@ export class CategoryPageContainer extends PureComponent {
         scrollToTop();
 
         /**
-         * Ensure transition PLP => homepage => PLP always having proper meta
-         */
-        this.updateMeta();
-
-        /**
          * Always make sure the navigation show / hide mode (on scroll)
          * is activated when entering the category page.
          * */


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4340

**Problem:**
* Wrong meta title for dynamic pages

**In this PR:**
* Remove meta update when category is not yet received
