### PR TITLE
4730 - removed red outline on deleting coupon

### DIFF
--- a/packages/scandipwa/src/component/CartCoupon/CartCoupon.component.js
+++ b/packages/scandipwa/src/component/CartCoupon/CartCoupon.component.js
@@ -123,9 +123,6 @@ export class CartCoupon extends PureComponent {
                       events={ {
                           onChange: this.handleCouponCodeChange
                       } }
-                      validationRule={ {
-                          isRequired: true
-                      } }
                       validateOn={ ['onChange'] }
                       mix={ { mods: { hasError: isFieldWithError }, block: 'Field' } }
                     />


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4730 

**Problem:**
* Red outline appeared when deleting coupon text. 

**In this PR:**
* Removed the "isRequired" rule that made that happen. 
