### PR TITLE
[4859] Added overflow property so the text doesn't overlaps 

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -48,6 +48,7 @@
 
     &Options-List {
         min-height: 30px;
+        overflow-wrap: break-word;
 
         @include desktop {
             padding-inline: 9px;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4859#event-6718689509

**Problem:**
* Long file name overlaps to the next product card in Wishlist


**In this PR:**
* Added overflow property so the text doesn't overlap with the next product.
