### PR TITLE
[4710] changed the secondary light color

### DIFF
--- a/packages/scandipwa/public/index.html
+++ b/packages/scandipwa/public/index.html
@@ -28,6 +28,11 @@
         window.storeList = ['default'].sort().reverse();
         window.storeRegexText = `/(${window.storeList.join('|')})?`;
     </script>
+     <style>
+        :root {
+            --imported_secondary_light_color: #ffffff;
+        }
+    </style>
 
     <!-- Font -->
     <link rel="stylesheet" href="https://use.typekit.net/fji5tuz.css">

--- a/packages/scandipwa/public/index.html
+++ b/packages/scandipwa/public/index.html
@@ -28,11 +28,6 @@
         window.storeList = ['default'].sort().reverse();
         window.storeRegexText = `/(${window.storeList.join('|')})?`;
     </script>
-     <style>
-        :root {
-            --imported_secondary_light_color: #ffffff;
-        }
-    </style>
 
     <!-- Font -->
     <link rel="stylesheet" href="https://use.typekit.net/fji5tuz.css">

--- a/packages/scandipwa/src/component/Draggable/Draggable.style.scss
+++ b/packages/scandipwa/src/component/Draggable/Draggable.style.scss
@@ -13,7 +13,8 @@
     user-select: none; // because it selects text when dragged
     -webkit-user-drag: none;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-    background-color: var(--imported_secondary_light_color, white);
+    //background-color: var(--imported_secondary_light_color, white);
+    background-color: var(--color-white);
     touch-action: pan-y;
     backface-visibility: hidden;
     overscroll-behavior: contain;

--- a/packages/scandipwa/src/component/Draggable/Draggable.style.scss
+++ b/packages/scandipwa/src/component/Draggable/Draggable.style.scss
@@ -13,7 +13,6 @@
     user-select: none; // because it selects text when dragged
     -webkit-user-drag: none;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-    //background-color: var(--imported_secondary_light_color, white);
     background-color: var(--color-white);
     touch-action: pan-y;
     backface-visibility: hidden;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4710

**Problem:**
* Highlight color is blinking if user zoom first image
* Background for first image on PDP painted by Secondary color 'Highligh'
* Highlight color shown in image popup is user click on default image (if custom image is absent)

**In this PR:**
* changed the secondary light color variable to white color
