### PR TITLE
[542] added padding for the left side

### DIFF
--- a/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.style.scss
+++ b/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.style.scss
@@ -35,6 +35,7 @@
             padding-block-start: 20px;
             padding-block-end: 10px;
             padding-inline-end: 0;
+            padding-inline-start: 20px;
             position: absolute;
             width: 100%;
             box-shadow: 0 5px 10px rgba(0, 0, 0, .1);


### PR DESCRIPTION
Related issue(s):

Fixes https://github.com/scandipwa/scandipwa/issues/4732
Issue in Jira: https://scandiflow.atlassian.net/browse/CTO2-542
Problem:

Message 'No results found!' has no padding from the left side.
In this PR:

Added padding to the left side.