### PR TITLE
[543] removed the animation for filter overlay

### DIFF
--- a/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.style.scss
+++ b/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.style.scss
@@ -29,7 +29,6 @@
     }
 
     @include mobile {
-        transition: transform 200ms ease-in-out;
         transform: translateY(100%);
         will-change: transform;
         overflow-y: hidden;


### PR DESCRIPTION
Related issue(s):

Fixes https://scandiflow.atlassian.net/browse/CTO2-543
Problem:

Filter overlay in mobile appears slowly, but disappears instantly
In this PR:

Removed the transition animation for filter overlay