### PR TITLE
4732 padding search overlay

### DIFF
--- a/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.style.scss
+++ b/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.style.scss
@@ -31,6 +31,10 @@
         z-index: 110;
         width: 100%;
 
+        &>p {
+            padding-inline-start: 20px;
+        }
+
         @include desktop {
             padding-block-start: 20px;
             padding-block-end: 10px;


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4732

**Problem:**
* No padding in no match result for search overlay

**In this PR:**
* put for that padding as for search query
