### PR TITLE
fix yt videos with hyphens, set base image position to a valid one

### DIFF
--- a/packages/scandipwa/src/component/ProductGallery/ProductGallery.container.js
+++ b/packages/scandipwa/src/component/ProductGallery/ProductGallery.container.js
@@ -179,7 +179,6 @@ export class ProductGalleryContainer extends PureComponent {
 
         if (returnValue === -1) {
             return 0;
-            //in case there is no base image, there could be a video at position 0 and this will put it in view
         }
 
         return returnValue;

--- a/packages/scandipwa/src/component/ProductGallery/ProductGallery.container.js
+++ b/packages/scandipwa/src/component/ProductGallery/ProductGallery.container.js
@@ -175,7 +175,14 @@ export class ProductGalleryContainer extends PureComponent {
             return acc;
         }, []).sort((a, b) => a - b);
 
-        return positionsArray.findIndex((value) => value === position);
+        const returnValue = positionsArray.findIndex((value) => value === position);
+
+        if (returnValue === -1) {
+            return 0;
+            //in case there is no base image, there could be a video at position 0 and this will put it in view
+        }
+
+        return returnValue;
     }
 
     getGalleryPictures() {

--- a/packages/scandipwa/src/component/VideoPopup/VideoPopup.config.js
+++ b/packages/scandipwa/src/component/VideoPopup/VideoPopup.config.js
@@ -18,4 +18,4 @@ export const VIDEO_POPUP_ID = 'VIDEO_POPUP_ID';
  * @type {RegExp}
  */
 export const VIMEO_FORMAT = new RegExp('(?:https?//)?vimeo.com[\\w/]*/(\\d+)$');
-export const YOUTUBE_FORMAT = new RegExp('(?:https?//)?www.youtube.com/watch\\?v=(\\w+)');
+export const YOUTUBE_FORMAT = new RegExp('(?:https?//)?www.youtube.com/watch\\?v=([\\w\\-]+)');


### PR DESCRIPTION
**Related issue(s):**
* Fixes [product gallery disappears if there is no base image and yt videos with hyphens don't work ](https://github.com/scandipwa/scandipwa/issues/4938)

**Problem:**
* product that only has a video and no other thumbnails, the video gallery carousel disappears
* product that has a youtube video with a link that contains a hyphen in the videocode, playback does not happen

**In this PR:**
* changed the base image position to zero instead of -1 if there is no base image for the video
* changed the youtube video regex to support videos with a hyphen in the videocode
