### PR TITLE
#4899 Stop scrollbar and scroller block from overriding each-others' `scrollLeft`

### DIFF
--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.component.js
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.component.js
@@ -185,13 +185,13 @@ export class ProductCompare extends Component {
         return (
             <>
             { this.renderScroll() }
-
             <div
               id="productCompare"
               block="ProductCompare"
               onScroll={ handleBlockScroll }
               ref={ productCompare }
             >
+
                 <div
                   id="productCompareRow"
                   block="ProductCompare"

--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.component.js
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.component.js
@@ -183,13 +183,15 @@ export class ProductCompare extends Component {
         const { handleBlockScroll, productCompare, productCompareRow } = this.props;
 
         return (
+            <>
+            { this.renderScroll() }
+
             <div
               id="productCompare"
               block="ProductCompare"
               onScroll={ handleBlockScroll }
               ref={ productCompare }
             >
-                { this.renderScroll() }
                 <div
                   id="productCompareRow"
                   block="ProductCompare"
@@ -212,9 +214,10 @@ export class ProductCompare extends Component {
                             { this.renderProductPrices() }
                         </div>
                     </div>
-                    { this.renderAttributes() }
+                      { this.renderAttributes() }
                 </div>
             </div>
+            </>
         );
     }
 

--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.component.js
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.component.js
@@ -184,39 +184,39 @@ export class ProductCompare extends Component {
 
         return (
             <>
-            { this.renderScroll() }
-            <div
-              id="productCompare"
-              block="ProductCompare"
-              onScroll={ handleBlockScroll }
-              ref={ productCompare }
-            >
+                { this.renderScroll() }
+                <div
+                  id="productCompare"
+                  block="ProductCompare"
+                  onScroll={ handleBlockScroll }
+                  ref={ productCompare }
+                >
 
-                <div
-                  id="productCompareRow"
-                  block="ProductCompare"
-                  elem="Row"
-                  mix={ { block: 'ProductCardRow' } }
-                  ref={ productCompareRow }
-                >
-                    { this.renderClearButton() }
-                    { this.renderProductCards() }
-                </div>
-                <div
-                  block="ProductCompare"
-                  elem="AttributeTable"
-                >
                     <div
-                      block="ProductCompareAttributeRow"
+                      id="productCompareRow"
+                      block="ProductCompare"
+                      elem="Row"
+                      mix={ { block: 'ProductCardRow' } }
+                      ref={ productCompareRow }
                     >
-                        { this.renderPriceLabel() }
-                        <div block="ProductCompareAttributeRow" elem="Values">
-                            { this.renderProductPrices() }
-                        </div>
+                        { this.renderClearButton() }
+                        { this.renderProductCards() }
                     </div>
-                      { this.renderAttributes() }
+                    <div
+                      block="ProductCompare"
+                      elem="AttributeTable"
+                    >
+                        <div
+                          block="ProductCompareAttributeRow"
+                        >
+                            { this.renderPriceLabel() }
+                            <div block="ProductCompareAttributeRow" elem="Values">
+                                { this.renderProductPrices() }
+                            </div>
+                        </div>
+                        { this.renderAttributes() }
+                    </div>
                 </div>
-            </div>
             </>
         );
     }

--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.style.scss
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.style.scss
@@ -62,8 +62,7 @@
     }
 
     &-Item {
-        content-visibility: auto;
-        contain-intrinsic-size: 0 var(--product-compare-column-width);
+     
         flex: 1;
         width: var(--product-compare-column-width);
         max-width: var(--product-compare-column-width);

--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.style.scss
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.style.scss
@@ -20,7 +20,6 @@
 }
 
 .ProductCompare {
-    content-visibility: auto;
     overflow: auto;
     padding-block-end: 15px;
     scrollbar-width: none;
@@ -63,6 +62,8 @@
     }
 
     &-Item {
+        content-visibility: auto;
+        contain-intrinsic-size: 0 var(--product-compare-column-width);
         flex: 1;
         width: var(--product-compare-column-width);
         max-width: var(--product-compare-column-width);

--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.style.scss
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.style.scss
@@ -62,7 +62,6 @@
     }
 
     &-Item {
-     
         flex: 1;
         width: var(--product-compare-column-width);
         max-width: var(--product-compare-column-width);

--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.style.scss
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.style.scss
@@ -20,6 +20,7 @@
 }
 
 .ProductCompare {
+    content-visibility: auto;
     overflow: auto;
     padding-block-end: 15px;
     scrollbar-width: none;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4899

**Problem:**
* Scrollbar and scroller block element were overriding each-other's `scrollLeft` parameter, which caused noticeable product twitching in Safari and Firefox in Product Compare component.

**In this PR:**
* I modified `ProductCompare.continer.js` to correctly handle scroll events and ignore calls depending on whether they come from the user or function.
* I also modified `ProductCompare.component.js` to not include scrollbar inside the scrolling component, otherwise, that caused another conflict with scroll events.
