### PR TITLE
[4660] - login fields don't disappear on checkout after sign-in from header - fixed

### DIFF
--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.component.js
@@ -24,6 +24,7 @@ import { BILLING_STEP } from 'Route/Checkout/Checkout.config';
 import { Addresstype } from 'Type/Account.type';
 import { CheckoutStepType, PaymentMethodsType } from 'Type/Checkout.type';
 import { TotalsType } from 'Type/MiniCart.type';
+import { isSignedIn } from 'Util/Auth';
 import { formatPrice } from 'Util/Price';
 
 import './CheckoutBilling.style';
@@ -56,7 +57,6 @@ export class CheckoutBilling extends PureComponent {
         onCreateUserChange: PropTypes.func.isRequired,
         onPasswordChange: PropTypes.func.isRequired,
         isGuestEmailSaved: PropTypes.bool.isRequired,
-        isSignedIn: PropTypes.bool.isRequired,
         shippingAddress: Addresstype.isRequired,
         termsAndConditions: PropTypes.arrayOf(PropTypes.shape({
             checkbox_text: PropTypes.string
@@ -111,12 +111,11 @@ export class CheckoutBilling extends PureComponent {
             onEmailChange,
             onCreateUserChange,
             onPasswordChange,
-            isGuestEmailSaved,
-            isSignedIn
+            isGuestEmailSaved
         } = this.props;
         const isBilling = checkoutStep === BILLING_STEP;
 
-        if (isSignedIn) {
+        if (isSignedIn()) {
             return null;
         }
 

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.component.js
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.component.js
@@ -23,6 +23,7 @@ import { BILLING_STEP, SHIPPING_STEP } from 'Route/Checkout/Checkout.config';
 import { Addresstype } from 'Type/Account.type';
 import { CheckoutStepType, ShippingMethodsType, ShippingMethodType } from 'Type/Checkout.type';
 import { TotalsType } from 'Type/MiniCart.type';
+import { isSignedIn } from 'Util/Auth';
 import { getAllCartItemsSku } from 'Util/Cart';
 import { formatPrice } from 'Util/Price';
 
@@ -52,8 +53,7 @@ export class CheckoutShipping extends PureComponent {
         onEmailChange: PropTypes.func.isRequired,
         onCreateUserChange: PropTypes.func.isRequired,
         onPasswordChange: PropTypes.func.isRequired,
-        isGuestEmailSaved: PropTypes.bool.isRequired,
-        isSignedIn: PropTypes.bool.isRequired
+        isGuestEmailSaved: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -199,12 +199,11 @@ export class CheckoutShipping extends PureComponent {
             onEmailChange,
             onCreateUserChange,
             onPasswordChange,
-            isGuestEmailSaved,
-            isSignedIn
+            isGuestEmailSaved
         } = this.props;
         const isBilling = checkoutStep === BILLING_STEP;
 
-        if (isSignedIn) {
+        if (isSignedIn()) {
             return null;
         }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4660

**Problem:**
* The rendering of the login fields in checkout depended on a prop that was always undefined.

**In this PR:**
* Replaced that prop with a util method that returns correct login status.
