### PR TITLE
remove-padding

### DIFF
--- a/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.component.js
+++ b/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.component.js
@@ -77,7 +77,10 @@ export class SearchOverlay extends PureComponent {
         const resultsToRender = (isLoading || this.timeout) ? Array(AMOUNT_OF_PLACEHOLDERS).fill({}) : searchResults;
 
         return (
-            <ul>
+            <ul
+              block="SearchOverlay"
+              elem="ItemsHolder"
+            >
                 { resultsToRender.map((item, i) => this.renderSearchItem(item, i)) }
             </ul>
         );

--- a/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.style.scss
+++ b/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.style.scss
@@ -25,6 +25,10 @@
         }
     }
 
+    &-ItemsHolder {
+        margin-block-start: -20px;
+    }
+
     &-Results {
         background: var(--color-white);
         display: none;
@@ -36,6 +40,7 @@
         }
 
         @include desktop {
+            padding-block-start: 20px;
             padding-block-end: 10px;
             padding-inline-end: 0;
             position: absolute;

--- a/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.style.scss
+++ b/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.style.scss
@@ -36,7 +36,6 @@
         }
 
         @include desktop {
-            padding-block-start: 20px;
             padding-block-end: 10px;
             padding-inline-end: 0;
             position: absolute;

--- a/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.style.scss
+++ b/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.style.scss
@@ -20,13 +20,8 @@
         .SearchOverlay {
             &-Results {
                 display: block;
-                padding: 16px;
             }
         }
-    }
-
-    &-ItemsHolder {
-        margin-block-start: -20px;
     }
 
     &-Results {
@@ -36,12 +31,11 @@
         width: 100%;
 
         .NoResults {
-            padding-inline-start: 20px;
+            padding: 20px;
+            margin: 0;
         }
 
         @include desktop {
-            padding-block-start: 20px;
-            padding-block-end: 10px;
             padding-inline-end: 0;
             position: absolute;
             width: 100%;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4945

**Problem:**
* Excessive padding on search overlay

**In this PR:**
* Edited `SearchOverlay.style.scss` to remove `padding-block-start`.
