### PR TITLE
took the beforeItems out from suspens

### DIFF
--- a/packages/scandipwa/src/component/Router/Router.component.js
+++ b/packages/scandipwa/src/component/Router/Router.component.js
@@ -415,7 +415,6 @@ export class Router extends PureComponent {
 
         return (
             <>
-                { this.renderSectionOfType(BEFORE_ITEMS_TYPE) }
                 <div block="Router" elem="MainItems">
                     { this.renderMainItems() }
                 </div>
@@ -438,11 +437,12 @@ export class Router extends PureComponent {
         return (
             <>
                 <Meta />
-                <Suspense fallback={ this.renderFallbackPage() }>
-                    <ReactRouter history={ history }>
+                <ReactRouter history={ history }>
+                    { this.renderSectionOfType(BEFORE_ITEMS_TYPE) }
+                    <Suspense fallback={ this.renderFallbackPage() }>
                         { this.renderRouterContent() }
-                    </ReactRouter>
-                </Suspense>
+                    </Suspense>
+                </ReactRouter>
             </>
         );
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes #2948 

**Problem:**
* The Navigation Tabs were rendered with suspense on mobile

**In this PR:**
* Took out from suspense the before components
