### PR TITLE
#4952 Wrong Qty of steps on Checkout

### DIFF
--- a/packages/scandipwa/src/route/Checkout/Checkout.component.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.component.js
@@ -212,7 +212,7 @@ export class Checkout extends PureComponent {
                     <div block="Checkout" elem="Step">
                         <span block="Checkout" elem="SelectedStep">{ number }</span>
                         <span block="Checkout" elem="StepsBorder">/</span>
-                        <span block="Checkout" elem="TotalSteps">{ Object.keys(this.stepMap).length }</span>
+                        <span block="Checkout" elem="TotalSteps">{ Object.keys(this.stepMap).length - 1 }</span>
                     </div>
                 </div>
                 <div block="Checkout" elem="StepBarTotal" />


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4952

**Problem:**
* Number of checkout steps was 3, had to be 2

**In this PR:**
* Modified `Checkout.component.js` to show 1 less step on checkout.
