### PR TITLE
[4934] - wrong data in the wishlist

### DIFF
--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -1,7 +1,3 @@
-/* eslint-disable consistent-return */
-/* eslint-disable array-callback-return */
-/* eslint-disable no-unused-vars */
-/* eslint-disable radix */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *
@@ -134,9 +130,7 @@ export class MyAccountMyWishlist extends PureComponent {
     renderProduct([id, product]) {
         const { isEditingActive, loadingItemsMap, setIsQtyUpdateInProgress } = this.props;
         const {
-            wishlist = {},
-            price_range,
-            bundle_options
+            wishlist = {}
         } = product;
 
         // assign wishlist.options to a new list
@@ -157,6 +151,8 @@ export class MyAccountMyWishlist extends PureComponent {
                         [selections[i - 1]]: e
                     });
                 }
+
+                return '';
             });
             const quantities = buy_request.match(/bundle_option_qty(.*)/g)[0].match(/\d+/g);
             const parsedQuantities = [];
@@ -166,6 +162,8 @@ export class MyAccountMyWishlist extends PureComponent {
                         selections[i - 1], e
                     ]);
                 }
+
+                return '';
             });
 
             wishlist.options = wishlist.options.reduce(

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -130,20 +130,20 @@ export class MyAccountMyWishlist extends PureComponent {
     renderProduct([id, product]) {
         const { isEditingActive, loadingItemsMap, setIsQtyUpdateInProgress } = this.props;
         const {
-            wishlist
+            wishlist = {}
         } = product;
-
-        // the order of items in wishlist.options always corresponds with the order of items
-        // in buy_request. turn buy_request object into an array
-        const quantities = Object.values(
-            JSON.parse(wishlist.buy_request).bundle_option_qty
-        );
 
         // assign wishlist.options to a new list
         // remove the first part of the value string that indicated quantity
         // append with a value from buy_request instead
         // get the value using index
-        if (wishlist.options) {
+        if (wishlist.options && wishlist.buy_request.bundle_option_qty) {
+            // the order of items in wishlist.options always corresponds with the order of items
+            // in buy_request. turn buy_request object into an array
+            const quantities = Object.values(
+                JSON.parse(wishlist.buy_request).bundle_option_qty
+            );
+
             wishlist.options = wishlist.options.reduce(
                 (p, { label, value }, i) => [...p,
                     { label, value: `${quantities[i][0]} ${value.substring(value.indexOf('x'))}` }],

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -1,3 +1,5 @@
+/* eslint-disable consistent-return */
+/* eslint-disable array-callback-return */
 /* eslint-disable no-unused-vars */
 /* eslint-disable radix */
 /**
@@ -137,21 +139,42 @@ export class MyAccountMyWishlist extends PureComponent {
             bundle_options
         } = product;
 
+        console.log(product);
+
         // assign wishlist.options to a new list
         // remove the first part of the value string that indicated quantity
         // append with a value from buy_request instead
         // get the value using index
         if (wishlist.options.length >= 1) {
             // the order of items in wishlist.options always corresponds with the order of items
-            // in buy_request. turn buy_request object into an array
+            // in buy_request.
+            // we're using regex instead of JSON parse bc we need to preserve the order of the data
+            // objects are inherently unordered
             const { buy_request } = wishlist;
-            const foo = buy_request.match(/bundle_option(.*)bundle/g)[0].match(/\d+/g);
+            const selections = buy_request.match(/bundle_option(.*)bundle/g)[0].match(/\d+/g);
+            const parsedSelections = [];
+            selections.map((e, i) => {
+                if ((i + 1) % 2 === 0) {
+                    parsedSelections.push({
+                        [selections[i - 1]]: e
+                    });
+                }
+            });
+            const quantities = buy_request.match(/bundle_option_qty(.*)/g)[0].match(/\d+/g);
+            const parsedQuantities = [];
+            quantities.map((e, i) => {
+                if ((i + 1) % 2 === 0) {
+                    parsedQuantities.push([
+                        selections[i - 1], e
+                    ]);
+                }
+            });
 
-            // wishlist.options = wishlist.options.reduce(
-            //     (p, { label, value }, i) => [...p,
-            //         { label, value: `${quantities[i][0]} ${value.substring(value.indexOf('x'))}` }],
-            //     []
-            // );
+            wishlist.options = wishlist.options.reduce(
+                (p, { label, value }, i) => [...p,
+                    { label, value: `${parsedQuantities[i][1]} ${value.substring(value.indexOf('x'))}` }],
+                []
+            );
         }
 
         return (

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -135,8 +135,6 @@ export class MyAccountMyWishlist extends PureComponent {
             bundle_options
         } = product;
 
-        console.log(product);
-
         // assign wishlist.options to a new list
         // remove the first part of the value string that indicated quantity
         // append with a value from buy_request instead

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -22,6 +22,8 @@ import WishlistItem from 'Component/WishlistItem';
 import { ProductType } from 'Type/ProductList.type';
 import CSS from 'Util/CSS';
 
+import { BUNDLE_PRODUCT_TYPE_ID } from './MyAccountMyWishlist.config';
+
 import './MyAccountMyWishlist.style';
 
 /** @namespace Component/MyAccountMyWishlist/Component */
@@ -140,7 +142,7 @@ export class MyAccountMyWishlist extends PureComponent {
         // remove the first part of the value string that indicated quantity
         // append with a value from buy_request instead
         // get the value using index
-        if (wishlist.options.length >= 1) {
+        if (wishlist.options.length >= 1 && product.type_id === BUNDLE_PRODUCT_TYPE_ID) {
             // the order of items in wishlist.options always corresponds with the order of items
             // in buy_request.
             // we're using regex instead of JSON parse bc we need to preserve the order of the data

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -129,6 +129,27 @@ export class MyAccountMyWishlist extends PureComponent {
 
     renderProduct([id, product]) {
         const { isEditingActive, loadingItemsMap, setIsQtyUpdateInProgress } = this.props;
+        const {
+            wishlist
+        } = product;
+
+        // the order of items in wishlist.options always corresponds with the order of items
+        // in buy_request. turn buy_request object into an array
+        const quantities = Object.values(
+            JSON.parse(wishlist.buy_request).bundle_option_qty
+        );
+
+        // assig wihlist.options to a new list
+        // remove the first part of the value string that indicated quantity
+        // append with a value from buy_request instead
+        // get the value using index
+        if (wishlist.options) {
+            wishlist.options = wishlist.options.reduce(
+                (p, { label, value }, i) => [...p,
+                    { label, value: `${quantities[i][0]} ${value.substring(value.indexOf('x'))}` }],
+                []
+            );
+        }
 
         return (
             <WishlistItem

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -186,7 +186,7 @@ export class MyAccountMyWishlist extends PureComponent {
                 p[1] + (bundle_options.filter(({ option_id }) => option_id === parseInt(c[0], 10))[0]
                     .selection_details.filter(
                         ({ selection_id }) => selection_id
-                === parseInt(parsedSelections[i][1], 10)
+                === parseInt(c[1], 10)
                     )[0]?.final_option_price_excl_tax * parsedQuantities[i][1])
             ]),
             [0, 0]);

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -1,4 +1,3 @@
-/* eslint-disable consistent-return */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -139,7 +139,7 @@ export class MyAccountMyWishlist extends PureComponent {
             JSON.parse(wishlist.buy_request).bundle_option_qty
         );
 
-        // assig wihlist.options to a new list
+        // assign wishlist.options to a new list
         // remove the first part of the value string that indicated quantity
         // append with a value from buy_request instead
         // get the value using index

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -137,7 +137,7 @@ export class MyAccountMyWishlist extends PureComponent {
         // remove the first part of the value string that indicated quantity
         // append with a value from buy_request instead
         // get the value using index
-        if (wishlist.options && wishlist.buy_request.bundle_option_qty) {
+        if (wishlist.options.length >= 1) {
             // the order of items in wishlist.options always corresponds with the order of items
             // in buy_request. turn buy_request object into an array
             const quantities = Object.values(

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -147,9 +147,9 @@ export class MyAccountMyWishlist extends PureComponent {
             const parsedSelections = [];
             selections.map((e, i) => {
                 if ((i + 1) % 2 === 0) {
-                    parsedSelections.push({
-                        [selections[i - 1]]: e
-                    });
+                    parsedSelections.push([
+                        selections[i - 1], e
+                    ]);
                 }
 
                 return '';

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable radix */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *
@@ -130,7 +132,9 @@ export class MyAccountMyWishlist extends PureComponent {
     renderProduct([id, product]) {
         const { isEditingActive, loadingItemsMap, setIsQtyUpdateInProgress } = this.props;
         const {
-            wishlist = {}
+            wishlist = {},
+            price_range,
+            bundle_options
         } = product;
 
         // assign wishlist.options to a new list
@@ -140,15 +144,14 @@ export class MyAccountMyWishlist extends PureComponent {
         if (wishlist.options.length >= 1) {
             // the order of items in wishlist.options always corresponds with the order of items
             // in buy_request. turn buy_request object into an array
-            const quantities = Object.values(
-                JSON.parse(wishlist.buy_request).bundle_option_qty
-            );
+            const { buy_request } = wishlist;
+            const foo = buy_request.match(/bundle_option(.*)bundle/g)[0].match(/\d+/g);
 
-            wishlist.options = wishlist.options.reduce(
-                (p, { label, value }, i) => [...p,
-                    { label, value: `${quantities[i][0]} ${value.substring(value.indexOf('x'))}` }],
-                []
-            );
+            // wishlist.options = wishlist.options.reduce(
+            //     (p, { label, value }, i) => [...p,
+            //         { label, value: `${quantities[i][0]} ${value.substring(value.indexOf('x'))}` }],
+            //     []
+            // );
         }
 
         return (

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -139,8 +139,6 @@ export class MyAccountMyWishlist extends PureComponent {
             bundle_options
         } = product;
 
-        console.log(product);
-
         // assign wishlist.options to a new list
         // remove the first part of the value string that indicated quantity
         // append with a value from buy_request instead

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.component.js
@@ -1,3 +1,4 @@
+/* eslint-disable consistent-return */
 /**
  * ScandiPWA - Progressive Web App for Magento
  *
@@ -174,16 +175,19 @@ export class MyAccountMyWishlist extends PureComponent {
                 []
             );
 
-            const [final_price, final_price_excl_tax] = bundle_options.reduce((p, c, i) => [
-                p[0] + (c.selection_details.filter(
-                    ({ selection_id }) => selection_id
+            const [final_price, final_price_excl_tax] = parsedSelections.reduce((p, c, i) => ([
+                p[0] + (bundle_options.filter(({ option_id }) => option_id === parseInt(c[0], 10))[0]
+                    .selection_details.filter(
+                        ({ selection_id }) => selection_id
+                === parseInt(c[1], 10)
+                    )[0]?.final_option_price * parsedQuantities[i][1]),
+                p[1] + (bundle_options.filter(({ option_id }) => option_id === parseInt(c[0], 10))[0]
+                    .selection_details.filter(
+                        ({ selection_id }) => selection_id
                 === parseInt(parsedSelections[i][1], 10)
-                )[0]?.final_option_price * parsedQuantities[i][1]),
-                p[1] + (c.selection_details.filter(
-                    ({ selection_id }) => selection_id
-                === parseInt(parsedSelections[i][1], 10)
-                )[0]?.final_option_price_excl_tax * parsedQuantities[i][1])
-            ], [0, 0]);
+                    )[0]?.final_option_price_excl_tax * parsedQuantities[i][1])
+            ]),
+            [0, 0]);
 
             const finalPrices = {
                 maximum_price: {

--- a/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.config.js
+++ b/packages/scandipwa/src/component/MyAccountMyWishlist/MyAccountMyWishlist.config.js
@@ -1,0 +1,14 @@
+/* eslint-disable import/prefer-default-export */
+
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export const BUNDLE_PRODUCT_TYPE_ID = 'bundle';

--- a/packages/scandipwa/src/component/Product/Product.container.js
+++ b/packages/scandipwa/src/component/Product/Product.container.js
@@ -49,6 +49,7 @@ export const mapDispatchToProps = (dispatch) => ({
 
 /** @namespace Component/Product/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
+    currencyData: state.ConfigReducer.currencyData,
     cartId: state.CartReducer.id,
     device: state.ConfigReducer.device,
     isWishlistEnabled: state.ConfigReducer.wishlist_general_active
@@ -62,6 +63,7 @@ export const mapStateToProps = (state) => ({
 */
 export class ProductContainer extends PureComponent {
     static propTypes = {
+        currencyData: PropTypes.string.isRequired,
         product: ProductType.isRequired,
         addProductToCart: PropTypes.func.isRequired,
         showError: PropTypes.func.isRequired,
@@ -236,7 +238,8 @@ export class ProductContainer extends PureComponent {
             product: { options = [] } = {},
             configFormRef,
             device,
-            isWishlistEnabled
+            isWishlistEnabled,
+            currencyData: { current_currency_code }
         } = this.props;
 
         const activeProduct = this.getActiveProduct();
@@ -252,7 +255,8 @@ export class ProductContainer extends PureComponent {
             maxQuantity: getMaxQuantity(activeProduct),
             minQuantity: getMinQuantity(activeProduct),
             productName: getName(product),
-            productPrice: fromCache(getPrice, [priceRange, dynamicPrice, adjustedPrice, type, options])
+            productPrice: fromCache(getPrice,
+                [priceRange, dynamicPrice, adjustedPrice, type, options, current_currency_code])
         };
 
         return {

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
@@ -227,8 +227,13 @@ export class WishlistItem extends PureComponent {
         const { label, value } = option;
 
         return (
-            <span block="WishlistItemOption" key={ `${ label }-${ value }` }>
-                { `${ value} x ${label }` }
+            <span block="WishlistItem" elem="Option" key={ `${ label }-${ value }` }>
+                <div block="WishlistItem" elem="GroupedProductTitle">
+                    <strong>{ `${label}:` }</strong>
+                </div>
+                <div block="WishlistItem" elem="GroupedProductValue">
+                    { `${value}` }
+                </div>
             </span>
         );
     }
@@ -237,9 +242,14 @@ export class WishlistItem extends PureComponent {
         const { label, value } = option;
 
         return (
-            <span block="WishlistItemOption" key={ `${ label }-${ value }` }>
-                { `${label }: ${ value}` }
-            </span>
+            <div block="WishlistItem" elem="Option" key={ `${ label }-${ value }` }>
+                <div block="WishlistItem" elem="BundleGroupTitle">
+                    <strong>{ `${label}:` }</strong>
+                </div>
+                <div block="WishlistItem" elem="BundleGroupValue">
+                    { `${value}` }
+                </div>
+            </div>
         );
     }
 
@@ -250,14 +260,14 @@ export class WishlistItem extends PureComponent {
 
         if (renderMethod) {
             return (
-                <div block="WishlistItemOptions" elem="List">
+                <div block="WishlistItem" elem="OptionsList">
                     { options.map(renderMethod) }
                 </div>
             );
         }
 
         return (
-            <div block="WishlistItemOptions" elem="List">
+            <div block="WishlistItem" elem="OptionsList">
                 { options.map(({ value }) => value).join(', ') }
             </div>
         );
@@ -267,7 +277,7 @@ export class WishlistItem extends PureComponent {
         const { product: { rating_summary, review_count } } = this.props;
 
         if (review_count < 1) {
-            return <div block="WishlistItem" elem="RatingPlaceholder" />;
+            return '';
         }
 
         return <ProductReviewRating summary={ rating_summary } count={ review_count } />;
@@ -279,6 +289,10 @@ export class WishlistItem extends PureComponent {
                 attributes: { brand: { attribute_value: brand } = {} } = {}
             }
         } = this.props;
+
+        if (!brand) {
+            return '';
+        }
 
         return (
             <div block="WishlistItem" elem="Brand">{ brand }</div>

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
@@ -232,7 +232,7 @@ export class WishlistItem extends PureComponent {
                     <strong>{ `${label}:` }</strong>
                 </div>
                 <div block="WishlistItem" elem="GroupedProductValue">
-                    { `${value}` }
+                    { value }
                 </div>
             </span>
         );
@@ -247,7 +247,7 @@ export class WishlistItem extends PureComponent {
                     <strong>{ `${label}:` }</strong>
                 </div>
                 <div block="WishlistItem" elem="BundleGroupValue">
-                    { `${value}` }
+                    { value }
                 </div>
             </div>
         );

--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -35,18 +35,18 @@
         justify-content: space-between;
     }
 
-    &Options-List,
-    &Option {
-        font-weight: 400;
+    &-OptionsList,
+    &-Option,
+    &-Option * {
         font-size: 12px;
         color: var(--secondary-dark-color);
     }
 
-    &Option {
+    &-Option {
         padding-inline-end: 5px;
     }
 
-    &Options-List {
+    &-OptionsList {
         min-height: 30px;
 
         @include desktop {

--- a/packages/scandipwa/src/util/Product/Extract.js
+++ b/packages/scandipwa/src/util/Product/Extract.js
@@ -212,7 +212,8 @@ export const getPrice = (
     dynamicPrice = false,
     adjustedPrice = {},
     type = PRODUCT_TYPE.simple,
-    options = []
+    options = [],
+    storeCurrency = 'USD'
 ) => {
     const priceAcc = type === PRODUCT_TYPE.bundle
         ? 'default_final_price'
@@ -226,7 +227,7 @@ export const getPrice = (
 
     const {
         [accessRange]: {
-            [priceAcc]: { currency = 'USD', value: basePrice = 0 } = {},
+            [priceAcc]: { currency = storeCurrency, value: basePrice = 0 } = {},
             [priceExcTaxAcc]: { value: basePriceExclTax = 0 } = {},
             discount: {
                 percent_off: percentOffRef = 0,


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4934

**Problem:**
* Wishlist item description showed default options quantities instead of user-defined

**In this PR:**
* replaced options qty values received from backend with the ones parsed from buy_request
* Still need to fix price