### PR TITLE
#4957 Edited `requiresConfiguration()` to check grouped items for options too

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -249,7 +249,7 @@ export class ProductCard extends Product {
             }
         } = this.props;
 
-        const configureBundleAndGrouped = type === PRODUCT_TYPE.bundle || type === PRODUCT_TYPE.grouped;
+        const configureBundleAndGrouped = type === PRODUCT_TYPE.bundle;
         const configureConfig = (type === PRODUCT_TYPE.configurable
             && Object.keys(super.getConfigurableAttributes())
                 .length !== Object.keys(this.getConfigurableAttributes()).length)

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -246,6 +246,7 @@ export class ProductCard extends Product {
             product: {
                 type_id: type,
                 options = [],
+                items = [],
                 links_purchased_separately
             }
         } = this.props;
@@ -270,11 +271,18 @@ export class ProductCard extends Product {
             || (Object.keys(allAttrs).length > 0 && Object.keys(parameters).length === 0)
         );
 
+        const configureGrouped = type === PRODUCT_TYPE.grouped
+            && !items.some(({ qty }) => qty !== 0);
+
         const configureCustomize = options.some(({ required = false }) => required);
 
         const configureDownloadableLinks = PRODUCT_TYPE.downloadable && links_purchased_separately === 1;
 
-        return configureBundle || configureConfig || configureCustomize || configureDownloadableLinks;
+        return configureGrouped
+            || configureBundle
+            || configureConfig
+            || configureCustomize
+            || configureDownloadableLinks;
     }
 
     renderAddToCart() {

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -272,7 +272,7 @@ export class ProductCard extends Product {
         );
 
         const configureGrouped = type === PRODUCT_TYPE.grouped
-            && !items.some(({ qty }) => qty !== 0);
+            && items.every(({ qty }) => qty === 0);
 
         const configureCustomize = options.some(({ required = false }) => required);
 

--- a/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.component.js
@@ -242,6 +242,7 @@ export class ProductCard extends Product {
 
     requiresConfiguration() {
         const {
+            parameters,
             product: {
                 type_id: type,
                 options = [],
@@ -249,17 +250,31 @@ export class ProductCard extends Product {
             }
         } = this.props;
 
-        const configureBundleAndGrouped = type === PRODUCT_TYPE.bundle;
-        const configureConfig = (type === PRODUCT_TYPE.configurable
-            && Object.keys(super.getConfigurableAttributes())
-                .length !== Object.keys(this.getConfigurableAttributes()).length)
-            || (type === PRODUCT_TYPE.configurable
-               && Object.values(this.getConfigurableAttributes()).some((value) => value.attribute_values.length === 0));
+        const configureBundle = type === PRODUCT_TYPE.bundle;
+
+        const allAttrs = super.getConfigurableAttributes();
+        const plpConfigurableAttrs = this.getConfigurableAttributes();
+
+        const isConfigurable = type === PRODUCT_TYPE.configurable;
+
+        const configureConfig = isConfigurable && (
+            (
+                Object.keys(allAttrs).length
+                !== Object.keys(plpConfigurableAttrs).length
+            )
+            || (
+                Object.values(plpConfigurableAttrs).some(
+                    (value) => value.attribute_values.length === 0
+                )
+            )
+            || (Object.keys(allAttrs).length > 0 && Object.keys(parameters).length === 0)
+        );
+
         const configureCustomize = options.some(({ required = false }) => required);
 
         const configureDownloadableLinks = PRODUCT_TYPE.downloadable && links_purchased_separately === 1;
 
-        return configureBundleAndGrouped || configureConfig || configureCustomize || configureDownloadableLinks;
+        return configureBundle || configureConfig || configureCustomize || configureDownloadableLinks;
     }
 
     renderAddToCart() {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4957
* Also depends on https://github.com/scandipwa/scandipwa/pull/4956

**Problem:**
* Couldn't add grouped or bundle items with no required options

**In this PR:**
* I modified `requiresConfiguration()` function to consider more cases for items. Now you can add items without options without getting redirected.
* This PR also depends on #4956 because otherwise redirect would happen every time, because of link issue.
