### PR TITLE
#4778 - Request product on PDP always

### DIFF
--- a/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
+++ b/packages/scandipwa/src/route/ProductPage/ProductPage.container.js
@@ -228,16 +228,12 @@ export class ProductPageContainer extends PureComponent {
         const {
             isOffline,
             productSKU,
-            product: {
-                sku
-            }
+            product
         } = this.props;
 
         const {
             productSKU: prevProductSKU,
-            product: {
-                sku: prevSku
-            }
+            product: prevProduct
         } = prevProps;
 
         const { sku: stateSKU } = history?.state?.state?.product || {};
@@ -260,10 +256,10 @@ export class ProductPageContainer extends PureComponent {
         }
 
         /**
-         * If product ID was changed => it is loaded => we need to
+         * If product object was changed => it is loaded => we need to
          * update product specific information, i.e. breadcrumbs.
          */
-        if (sku !== prevSku) {
+        if (JSON.stringify(product) !== JSON.stringify(prevProduct)) {
             this.updateBreadcrumbs();
             this.updateHeaderState();
             this.updateMeta();


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4778 

**Problem:**
* If visiting PDP that was already visited previosly it won't request updated data, because it is already out there. But in this case if we update product in admin there won't be any fresh data.

**In this PR:**
* Request product always. Since service worker gets cached request to show + new one will be updated through broadcast it won't effect UI. Problem can only appear if product will load long since updates appear with replacing existing data.
