### PR TITLE
#4330 - Update meta if category didn`t changed after CMS

### DIFF
--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.js
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.js
@@ -252,6 +252,7 @@ export class CategoryPageContainer extends PureComponent {
         if (categoryIds === id) {
             this.updateBreadcrumbs();
             this.updateHeaderState();
+            this.updateMeta();
         } else {
             /**
              * Still update header and breadcrumbs, but ignore


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4340

**Problem:**
* If open category -> CMS -> same category, title wasn`t updated

**In this PR:**
* Update title if category the same(after CMS page)
