### PR TITLE
4949 - jumping loaders - fixed

### DIFF
--- a/packages/scandipwa/src/component/Loader/Loader.style.scss
+++ b/packages/scandipwa/src/component/Loader/Loader.style.scss
@@ -40,3 +40,13 @@
         }
     }
 }
+
+#root {
+    div[class^='LocalizationWrapper'] {
+        > .Loader {
+            .Loader-Scale {
+                position: fixed;
+            }
+        }
+    }
+}

--- a/packages/scandipwa/src/component/Loader/Loader.style.scss
+++ b/packages/scandipwa/src/component/Loader/Loader.style.scss
@@ -40,13 +40,3 @@
         }
     }
 }
-
-#root {
-    div[class^='LocalizationWrapper'] {
-        > .Loader {
-            .Loader-Scale {
-                position: fixed;
-            }
-        }
-    }
-}

--- a/packages/scandipwa/src/component/Router/Router.component.js
+++ b/packages/scandipwa/src/component/Router/Router.component.js
@@ -369,7 +369,7 @@ export class Router extends PureComponent {
 
     renderSectionOfType(type) {
         return (
-            <Suspense fallback={ <Loader isLoading /> }>
+            <Suspense>
                 { this.renderComponentsOfType(type) }
             </Suspense>
         );

--- a/packages/scandipwa/src/component/Router/Router.style.scss
+++ b/packages/scandipwa/src/component/Router/Router.style.scss
@@ -14,8 +14,14 @@
         min-height: calc(100vh - var(--header-total-height) + 10px);
     }
 
-    &-Loader {
-        height: calc(100vh - var(--header-total-height) - 10px);
-        inset-block-start: calc(var(--header-total-height) + 10px);
+    @include desktop {
+        &-Loader {
+            height: calc(100vh - var(--header-total-height) - 10px);
+            inset-block-start: calc(var(--header-total-height) + 10px);
+
+            .Loader-Scale {
+                position: fixed;
+            }
+        }
     }
 }

--- a/packages/scandipwa/src/component/Router/Router.style.scss
+++ b/packages/scandipwa/src/component/Router/Router.style.scss
@@ -14,14 +14,16 @@
         min-height: calc(100vh - var(--header-total-height) + 10px);
     }
 
+    &-Loader {
+        .Loader-Scale {
+            position: fixed;
+        }
+    }
+
     @include desktop {
         &-Loader {
             height: calc(100vh - var(--header-total-height) - 10px);
             inset-block-start: calc(var(--header-total-height) + 10px);
-
-            .Loader-Scale {
-                position: fixed;
-            }
         }
     }
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4949

**Problem:**
* On initial load, there were a lot of loaders that had different CSS rulesets applied to them, making them jump on the viewport.

**In this PR:**
* Added specific CSS rulesets to these initial loaders so that they behave identically.
