### PR TITLE
#4971 Update navigation menu on every route change

### DIFF
--- a/packages/scandipwa/i18n/da_DK.json
+++ b/packages/scandipwa/i18n/da_DK.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/de_DE.json
+++ b/packages/scandipwa/i18n/de_DE.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/es_ES.json
+++ b/packages/scandipwa/i18n/es_ES.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/fa_IR.json
+++ b/packages/scandipwa/i18n/fa_IR.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/fi_FI.json
+++ b/packages/scandipwa/i18n/fi_FI.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/fr_FR.json
+++ b/packages/scandipwa/i18n/fr_FR.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/it_IT.json
+++ b/packages/scandipwa/i18n/it_IT.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/lv_LV.json
+++ b/packages/scandipwa/i18n/lv_LV.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/nb_NO.json
+++ b/packages/scandipwa/i18n/nb_NO.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/nl_NL.json
+++ b/packages/scandipwa/i18n/nl_NL.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/pl_PL.json
+++ b/packages/scandipwa/i18n/pl_PL.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/pt_BR.json
+++ b/packages/scandipwa/i18n/pt_BR.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/ru_RU.json
+++ b/packages/scandipwa/i18n/ru_RU.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/sl_SI.json
+++ b/packages/scandipwa/i18n/sl_SI.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/sv_SE.json
+++ b/packages/scandipwa/i18n/sv_SE.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/tr_TR.json
+++ b/packages/scandipwa/i18n/tr_TR.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/i18n/zh_TW.json
+++ b/packages/scandipwa/i18n/zh_TW.json
@@ -613,5 +613,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "Error fetching Menu!": null
 }

--- a/packages/scandipwa/src/component/Menu/Menu.container.js
+++ b/packages/scandipwa/src/component/Menu/Menu.container.js
@@ -22,7 +22,8 @@ import Menu from './Menu.component';
 /** @namespace Component/Menu/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     device: state.ConfigReducer.device,
-    compareTotals: state.ProductCompareReducer.count
+    compareTotals: state.ProductCompareReducer.count,
+    redux_menu: state.MenuReducer.menu
 });
 
 /** @namespace Component/Menu/Container/mapDispatchToProps */

--- a/packages/scandipwa/src/component/Router/Router.container.js
+++ b/packages/scandipwa/src/component/Router/Router.container.js
@@ -68,7 +68,7 @@ export const mapDispatchToProps = (dispatch) => ({
     updateMeta: (meta) => dispatch(updateMeta(meta)),
     updateConfigDevice: (device) => dispatch(updateConfigDevice(device)),
     setBigOfflineNotice: (isBig) => dispatch(setBigOfflineNotice(isBig)),
-    updateInitialCartData: async () => {
+    updateInitialCartData: () => {
         CartDispatcher.then(
             ({ default: dispatcher }) => dispatcher.updateInitialCartData(dispatch)
         );

--- a/packages/scandipwa/src/component/Router/Router.container.js
+++ b/packages/scandipwa/src/component/Router/Router.container.js
@@ -149,7 +149,7 @@ export class RouterContainer extends PureComponent {
     componentDidMount() {
         window.addEventListener('resize', this.handleResize);
 
-        history.listen(this.updateCartOnRouteChange);
+        history.listen(this.handleRouteChange);
     }
 
     componentDidUpdate(prevProps) {
@@ -193,12 +193,16 @@ export class RouterContainer extends PureComponent {
         window.removeEventListener('resize', this.handleResize);
     }
 
-    updateCartOnRouteChange(history) {
+    handleRouteChange(history) {
         if (this.previousRoute !== history.pathname) {
-            const { updateInitialCartData } = this.props;
-            updateInitialCartData();
+            this.updateCartOnRouteChange();
             this.previousRoute = history.pathname;
         }
+    }
+
+    updateCartOnRouteChange() {
+        const { updateInitialCartData } = this.props;
+        updateInitialCartData();
     }
 
     async handleResize() {

--- a/packages/scandipwa/src/component/Router/Router.container.js
+++ b/packages/scandipwa/src/component/Router/Router.container.js
@@ -47,6 +47,10 @@ export const MyAccountDispatcher = import(
     /* webpackMode: "lazy", webpackChunkName: "dispatchers" */
     'Store/MyAccount/MyAccount.dispatcher'
 );
+export const MenuDispatcher = import(
+    /* webpackMode: "lazy", webpackChunkName: "dispatchers" */
+    'Store/Menu/Menu.dispatcher'
+);
 
 /** @namespace Component/Router/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
@@ -73,6 +77,11 @@ export const mapDispatchToProps = (dispatch) => ({
             ({ default: dispatcher }) => dispatcher.updateInitialCartData(dispatch)
         );
     },
+    updateMenuData: () => {
+        MenuDispatcher.then(
+            ({ default: dispatcher }) => dispatcher.updateMenuData(dispatch)
+        );
+    },
     init: async () => {
         ConfigDispatcher.then(
             ({ default: dispatcher }) => dispatcher.handleData(dispatch)
@@ -84,11 +93,14 @@ export const mapDispatchToProps = (dispatch) => ({
         WishlistDispatcher.then(
             ({ default: dispatcher }) => dispatcher.updateInitialWishlistData(dispatch)
         );
+        ProductCompareDispatcher.then(
+            ({ default: dispatcher }) => dispatcher.updateInitialProductCompareData(dispatch)
+        );
         CartDispatcher.then(
             ({ default: dispatcher }) => dispatcher.updateInitialCartData(dispatch)
         );
-        ProductCompareDispatcher.then(
-            ({ default: dispatcher }) => dispatcher.updateInitialProductCompareData(dispatch)
+        MenuDispatcher.then(
+            ({ default: dispatcher }) => dispatcher.updateMenuData(dispatch)
         );
     }
 });
@@ -110,7 +122,8 @@ export class RouterContainer extends PureComponent {
         isBigOffline: PropTypes.bool,
         meta_title: MetaTitleType,
         status_code: PropTypes.string,
-        updateCartData: PropTypes.func.isRequired
+        updateCartData: PropTypes.func.isRequired,
+        updateMenuData: PropTypes.func.isRequired
     };
 
     static defaultProps = {
@@ -129,6 +142,8 @@ export class RouterContainer extends PureComponent {
     handleResize = this.handleResize.bind(this);
 
     updateCartOnRouteChange = this.updateCartOnRouteChange.bind(this);
+
+    updateMenuOnRouteChange = this.updateMenuOnRouteChange.bind(this);
 
     previousRoute = null;
 
@@ -150,7 +165,8 @@ export class RouterContainer extends PureComponent {
         window.addEventListener('resize', this.handleResize);
 
         history.listen(this.handleRouteChange([
-            this.updateCartOnRouteChange
+            this.updateCartOnRouteChange,
+            this.updateMenuOnRouteChange
         ]));
     }
 
@@ -207,6 +223,11 @@ export class RouterContainer extends PureComponent {
     updateCartOnRouteChange() {
         const { updateCartData } = this.props;
         updateCartData();
+    }
+
+    updateMenuOnRouteChange() {
+        const { updateMenuData } = this.props;
+        updateMenuData();
     }
 
     async handleResize() {

--- a/packages/scandipwa/src/component/Router/Router.container.js
+++ b/packages/scandipwa/src/component/Router/Router.container.js
@@ -68,7 +68,7 @@ export const mapDispatchToProps = (dispatch) => ({
     updateMeta: (meta) => dispatch(updateMeta(meta)),
     updateConfigDevice: (device) => dispatch(updateConfigDevice(device)),
     setBigOfflineNotice: (isBig) => dispatch(setBigOfflineNotice(isBig)),
-    updateInitialCartData: () => {
+    updateCartData: () => {
         CartDispatcher.then(
             ({ default: dispatcher }) => dispatcher.updateInitialCartData(dispatch)
         );
@@ -110,7 +110,7 @@ export class RouterContainer extends PureComponent {
         isBigOffline: PropTypes.bool,
         meta_title: MetaTitleType,
         status_code: PropTypes.string,
-        updateInitialCartData: PropTypes.func.isRequired
+        updateCartData: PropTypes.func.isRequired
     };
 
     static defaultProps = {
@@ -205,8 +205,8 @@ export class RouterContainer extends PureComponent {
     }
 
     updateCartOnRouteChange() {
-        const { updateInitialCartData } = this.props;
-        updateInitialCartData();
+        const { updateCartData } = this.props;
+        updateCartData();
     }
 
     async handleResize() {

--- a/packages/scandipwa/src/component/Router/Router.container.js
+++ b/packages/scandipwa/src/component/Router/Router.container.js
@@ -17,6 +17,7 @@ import { updateConfigDevice } from 'Store/Config/Config.action';
 import { updateMeta } from 'Store/Meta/Meta.action';
 import { setBigOfflineNotice } from 'Store/Offline/Offline.action';
 import { MetaTitleType } from 'Type/Common.type';
+import history from 'Util/History';
 import {
     isMobile,
     isMobileClientHints,
@@ -67,6 +68,11 @@ export const mapDispatchToProps = (dispatch) => ({
     updateMeta: (meta) => dispatch(updateMeta(meta)),
     updateConfigDevice: (device) => dispatch(updateConfigDevice(device)),
     setBigOfflineNotice: (isBig) => dispatch(setBigOfflineNotice(isBig)),
+    updateInitialCartData: async () => {
+        CartDispatcher.then(
+            ({ default: dispatcher }) => dispatcher.updateInitialCartData(dispatch)
+        );
+    },
     init: async () => {
         ConfigDispatcher.then(
             ({ default: dispatcher }) => dispatcher.handleData(dispatch)
@@ -103,7 +109,8 @@ export class RouterContainer extends PureComponent {
         isLoading: PropTypes.bool,
         isBigOffline: PropTypes.bool,
         meta_title: MetaTitleType,
-        status_code: PropTypes.string
+        status_code: PropTypes.string,
+        updateInitialCartData: PropTypes.func.isRequired
     };
 
     static defaultProps = {
@@ -121,6 +128,10 @@ export class RouterContainer extends PureComponent {
 
     handleResize = this.handleResize.bind(this);
 
+    updateCartOnRouteChange = this.updateCartOnRouteChange.bind(this);
+
+    previousRoute = null;
+
     __construct(props) {
         super.__construct(props);
 
@@ -137,6 +148,8 @@ export class RouterContainer extends PureComponent {
 
     componentDidMount() {
         window.addEventListener('resize', this.handleResize);
+
+        history.listen(this.updateCartOnRouteChange);
     }
 
     componentDidUpdate(prevProps) {
@@ -178,6 +191,14 @@ export class RouterContainer extends PureComponent {
 
     componentWillUnmount() {
         window.removeEventListener('resize', this.handleResize);
+    }
+
+    updateCartOnRouteChange(history) {
+        if (this.previousRoute !== history.pathname) {
+            const { updateInitialCartData } = this.props;
+            updateInitialCartData();
+            this.previousRoute = history.pathname;
+        }
     }
 
     async handleResize() {

--- a/packages/scandipwa/src/component/Router/Router.container.js
+++ b/packages/scandipwa/src/component/Router/Router.container.js
@@ -149,7 +149,9 @@ export class RouterContainer extends PureComponent {
     componentDidMount() {
         window.addEventListener('resize', this.handleResize);
 
-        history.listen(this.handleRouteChange);
+        history.listen(this.handleRouteChange([
+            this.updateCartOnRouteChange
+        ]));
     }
 
     componentDidUpdate(prevProps) {
@@ -193,11 +195,13 @@ export class RouterContainer extends PureComponent {
         window.removeEventListener('resize', this.handleResize);
     }
 
-    handleRouteChange(history) {
-        if (this.previousRoute !== history.pathname) {
-            this.updateCartOnRouteChange();
-            this.previousRoute = history.pathname;
-        }
+    handleRouteChange(callbacks) {
+        return (history) => {
+            if (this.previousRoute !== history.pathname) {
+                callbacks.forEach((cb) => cb());
+                this.previousRoute = history.pathname;
+            }
+        };
     }
 
     updateCartOnRouteChange() {

--- a/packages/scandipwa/src/store/Menu/Menu.action.js
+++ b/packages/scandipwa/src/store/Menu/Menu.action.js
@@ -1,0 +1,22 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/scandipwa
+ */
+
+export const UPDATE_MENU_ITEMS = 'UPDATE_MENU_ITEMS';
+
+/**
+ * Set navigation menu items
+ * @param  {Object} menu Object with all menu items
+ * @return {void}
+ * @namespace Store/Menu/Action/updateMenuitems */
+export const updateMenuitems = (menu) => ({
+    type: UPDATE_MENU_ITEMS,
+    menu
+});

--- a/packages/scandipwa/src/store/Menu/Menu.action.js
+++ b/packages/scandipwa/src/store/Menu/Menu.action.js
@@ -15,8 +15,8 @@ export const UPDATE_MENU_ITEMS = 'UPDATE_MENU_ITEMS';
  * Set navigation menu items
  * @param  {Object} menu Object with all menu items
  * @return {void}
- * @namespace Store/Menu/Action/updateMenuitems */
-export const updateMenuitems = (menu) => ({
+ * @namespace Store/Menu/Action/updateMenuItems */
+export const updateMenuItems = (menu) => ({
     type: UPDATE_MENU_ITEMS,
     menu
 });

--- a/packages/scandipwa/src/store/Menu/Menu.dispatcher.js
+++ b/packages/scandipwa/src/store/Menu/Menu.dispatcher.js
@@ -16,7 +16,7 @@ import {
     executeGet
 } from 'Util/Request';
 
-import { updateMenuitems } from './Menu.action';
+import { updateMenuItems } from './Menu.action';
 
 export const ONE_MONTH_IN_SECONDS = 2592000;
 
@@ -27,8 +27,7 @@ export class MenuDispatcher {
 
         try {
             const { menu } = await executeGet(prepareQuery(query), 'Menu', ONE_MONTH_IN_SECONDS);
-
-            dispatch(updateMenuitems(menu));
+            dispatch(updateMenuItems(menu));
         } catch (error) {
             showNotification('error', __('Error fetching Menu!'), error);
         }

--- a/packages/scandipwa/src/store/Menu/Menu.dispatcher.js
+++ b/packages/scandipwa/src/store/Menu/Menu.dispatcher.js
@@ -1,0 +1,46 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/scandipwa
+ */
+
+import MenuQuery from 'Query/Menu.query';
+import { showNotification } from 'Store/Notification/Notification.action';
+import { prepareQuery } from 'Util/Query';
+import {
+    executeGet
+} from 'Util/Request';
+
+import { updateMenuitems } from './Menu.action';
+
+export const ONE_MONTH_IN_SECONDS = 2592000;
+
+/** @namespace Store/Menu/Dispatcher */
+export class MenuDispatcher {
+    async updateMenuData(dispatch) {
+        const query = [MenuQuery.getQuery(this._getMenuOptions())];
+
+        try {
+            const { menu } = await executeGet(prepareQuery(query), 'Menu', ONE_MONTH_IN_SECONDS);
+
+            dispatch(updateMenuitems(menu));
+        } catch (error) {
+            showNotification('error', __('Error fetching Menu!'), error);
+        }
+    }
+
+    _getMenuOptions() {
+        const { header_content: { header_menu } = {} } = window.contentConfiguration;
+
+        return {
+            identifier: header_menu || 'new-main-menu'
+        };
+    }
+}
+
+export default new MenuDispatcher();

--- a/packages/scandipwa/src/store/Menu/Menu.reducer.js
+++ b/packages/scandipwa/src/store/Menu/Menu.reducer.js
@@ -1,0 +1,42 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/scandipwa
+ */
+import MenuHelper from 'Util/Menu';
+
+import { UPDATE_MENU_ITEMS } from './Menu.action';
+
+/** @namespace Store/Menu/Reducer/updateMenuItems */
+export const updateMenuItems = (action, state) => {
+    const { menu } = action;
+    const reducedMenu = MenuHelper.reduce(menu);
+    return { ...state, menu: reducedMenu };
+};
+
+/** @namespace Store/Menu/Reducer/getInitialState */
+export const getInitialState = () => ({
+    menu: {}
+});
+
+/** @namespace Store/Menu/Reducer/MenuReducer */
+export const MenuReducer = (
+    state = getInitialState(),
+    action
+) => {
+    const { type } = action;
+
+    switch (type) {
+    case UPDATE_MENU_ITEMS:
+        return updateMenuItems(action, state);
+    default:
+        return state;
+    }
+};
+
+export default MenuReducer;

--- a/packages/scandipwa/src/store/index.js
+++ b/packages/scandipwa/src/store/index.js
@@ -12,6 +12,7 @@ import CartReducer from 'Store/Cart/Cart.reducer';
 import CheckoutReducer from 'Store/Checkout/Checkout.reducer';
 import ConfigReducer from 'Store/Config/Config.reducer';
 import ContactFormReducer from 'Store/ContactForm/ContactForm.reducer';
+import MenuReducer from 'Store/Menu/Menu.reducer';
 import MetaReducer from 'Store/Meta/Meta.reducer';
 import MyAccountReducer from 'Store/MyAccount/MyAccount.reducer';
 import NavigationReducer from 'Store/Navigation/Navigation.reducer';
@@ -44,7 +45,8 @@ export const getStaticReducers = () => ({
     CheckoutReducer,
     ContactFormReducer,
     ProductCompareReducer,
-    StoreInPickUpReducer
+    StoreInPickUpReducer,
+    MenuReducer
 });
 
 export default function injectStaticReducers(store) {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4971
* Parent branch: #4975 

**Problem:**
* Navigation menu was not updating unless full site refresh, because it was getting cached in the browser

**In this PR:**
* `Menu.container.js` doesn't use `DataContainer` anymore, `DataContainer` was caching fetched data into `window.dataCache`
* `Menu.container.js` doesn't use local state to save menu items anymore, I created global store - `MenuReducer.menu` for it.
* `Router.container.js` will now call `updateMenuOnRouteChange()` on every route change.
