### PR TITLE
[4932] -  page with address can be resized on Android - fixed

### DIFF
--- a/packages/scandipwa/public/index.html
+++ b/packages/scandipwa/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
 <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no, user-scalable=no, viewport-fit=cover">
 
     <!-- Muli font import from Abode -->
     <link rel="preload" href="https://use.typekit.net/fji5tuz.css" as="style">


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4932

**Problem:**
* Mobile address view was user-resizeable

**In this PR:**
* Everything in the app is non-resizable on mobile
