### PR TITLE
[3731] - wrong content on quick route changes w/ slow internet - fixed

### DIFF
--- a/packages/scandipwa/src/util/Request/QueryDispatcher.js
+++ b/packages/scandipwa/src/util/Request/QueryDispatcher.js
@@ -35,6 +35,7 @@ export class QueryDispatcher {
         this.name = name;
         this.cacheTTL = cacheTTL;
         this.promise = null;
+        this.controller = null;
     }
 
     /**
@@ -55,12 +56,14 @@ export class QueryDispatcher {
         const queries = rawQueries instanceof Field ? [rawQueries] : rawQueries;
 
         if (this.promise) {
-            this.promise.cancel();
+            this.controller.abort();
         }
 
         this.promise = makeCancelable(
             new Promise((resolve, reject) => {
-                executeGet(prepareQuery(queries), name, cacheTTL)
+                this.controller = new AbortController();
+                const { signal } = this.controller;
+                executeGet(prepareQuery(queries), name, cacheTTL, signal)
                     .then(
                         /** @namespace Util/Request/QueryDispatcher/QueryDispatcher/handleData/makeCancelable/executeGet/then/resolve */
                         (data) => resolve(data),

--- a/packages/scandipwa/src/util/Request/QueryDispatcher.js
+++ b/packages/scandipwa/src/util/Request/QueryDispatcher.js
@@ -77,7 +77,11 @@ export class QueryDispatcher {
             /** @namespace Util/Request/QueryDispatcher/QueryDispatcher/handleData/then */
             (data) => this.onSuccess(data, dispatch, options),
             /** @namespace Util/Request/QueryDispatcher/QueryDispatcher/handleData/then/catch */
-            (error) => this.onError(error, dispatch, options),
+            (error) => {
+                if (!this.controller.signal.aborted) {
+                    this.onError(error, dispatch, options);
+                }
+            },
         );
 
         listenForBroadCast(name).then(

--- a/packages/scandipwa/src/util/Request/QueryDispatcher.js
+++ b/packages/scandipwa/src/util/Request/QueryDispatcher.js
@@ -52,10 +52,9 @@ export class QueryDispatcher {
         const abort = this.promise && this.controller.abort();
 
         this.controller = new AbortController();
-        const { signal } = this.controller;
 
         try {
-            this.promise = await executeGet(prepareQuery(queries), name, cacheTTL, signal);
+            this.promise = await executeGet(prepareQuery(queries), name, cacheTTL, this.controller.signal);
             this.onSuccess(this.promise, dispatch, options);
         } catch (err) {
             this.onError(err, dispatch, options);

--- a/packages/scandipwa/src/util/Request/Request.js
+++ b/packages/scandipwa/src/util/Request/Request.js
@@ -92,9 +92,10 @@ export const formatURI = (query, variables, url) => {
  * @returns {Promise<Response>}
  * @namespace Util/Request/getFetch
  */
-export const getFetch = (uri, name) => fetch(uri,
+export const getFetch = (uri, name, signal) => fetch(uri,
     {
         method: 'GET',
+        signal,
         headers: appendTokenToHeaders({
             'Content-Type': 'application/json',
             'Application-Model': `${ name }_${ getWindowId() }`,
@@ -196,7 +197,7 @@ export const HTTP_201_CREATED = 201;
  * @return {Promise<Request>} Fetch promise to GraphQL endpoint
  * @namespace Util/Request/executeGet
  */
-export const executeGet = (queryObject, name, cacheTTL) => {
+export const executeGet = (queryObject, name, cacheTTL, signal) => {
     const { query, variables } = queryObject;
     const uri = formatURI(query, variables, getGraphqlEndpoint());
 
@@ -206,7 +207,7 @@ export const executeGet = (queryObject, name, cacheTTL) => {
     }
 
     return parseResponse(new Promise((resolve, reject) => {
-        getFetch(uri, name).then(
+        getFetch(uri, name, signal).then(
             /** @namespace Util/Request/executeGet/parseResponse/getFetch/then */
             (res) => {
                 if (res.status === HTTP_410_GONE) {
@@ -214,7 +215,7 @@ export const executeGet = (queryObject, name, cacheTTL) => {
                         /** @namespace Util/Request/executeGet/parseResponse/getFetch/then/putPersistedQuery/then */
                         (putResponse) => {
                             if (putResponse.status === HTTP_201_CREATED) {
-                                getFetch(uri, name).then(
+                                getFetch(uri, name, signal).then(
                                     /** @namespace Util/Request/executeGet/parseResponse/getFetch/then/putPersistedQuery/then/getFetch/then/resolve */
                                     (res) => resolve(res)
                                 );

--- a/packages/scandipwa/src/util/Request/Request.js
+++ b/packages/scandipwa/src/util/Request/Request.js
@@ -227,6 +227,13 @@ export const executeGet = (queryObject, name, cacheTTL, signal) => {
                 } else {
                     resolve(res);
                 }
+            }, /** @namespace Util/Request/executeGet/parseResponse/getFetch/then/catch */
+            (err) => {
+                if (!signal.aborted) {
+                    return err;
+                }
+
+                return '';
             }
         );
     }));


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/3731

**Problem:**
* QuereyDispatcher's fetch cancel functionality didn't work. On a slow connection, the app would send loads of requests quickly which would all try to update the same state, resulting in race conditions. 

**In this PR:**
* Introduced AbortController, an API designed specifically to allow developers to cancel fetch requests programmatically.
