### PR TITLE
#5004 - Cannot read properties of null (reading 'toFixed') in CheckoutOrderSummary renderSubTotal

### DIFF
--- a/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/packages/scandipwa/src/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -206,7 +206,7 @@ export class CheckoutOrderSummary extends PureComponent {
                   price={ cartSubtotal.toFixed(2) }
                   currency={ quote_currency_code }
                   title={ title }
-                  subPrice={ cartSubtotalSubPrice.toFixed(2) }
+                  subPrice={ cartSubtotalSubPrice?.toFixed(2) ?? null }
                 />
         );
     }


### PR DESCRIPTION
Fixes: TypeError: Cannot read properties of null (reading 'toFixed') in CheckoutOrderSummary renderSubTotal

**Related issue(s):**
* Fixes [#5004](https://github.com/scandipwa/scandipwa/issues/5004)

**Problem:**
* Cart crashes if 'Display Subtotal' is not 'Including and Excluding Tax'

**In this PR:**
* Added `null` fallback
