### PR TITLE
#5020 - Centrilize plus/minus button for bundle products

### DIFF
--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
@@ -52,9 +52,7 @@
                     }
 
                     &_numberWithControls {
-                        @include mobile {
-                            display: flex;
-                        }
+                        display: flex;
                     }
                 }
             }

--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
@@ -50,6 +50,12 @@
                     &_select, &_checkbox, &_radio {
                         flex: 1 1;
                     }
+
+                    &_numberWithControls {
+                        @include mobile {
+                            display: flex;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5020

**Problem:**
* Plus and minus buttons are not centered for bundle product on mobile

**In this PR:**
* Plus and minus buttons are centered for bundle product on mobile
