### PR TITLE
#3277 - Order of products are matching order in admin panel

### DIFF
--- a/packages/scandipwa/src/component/GroupedProductList/GroupedProductList.component.js
+++ b/packages/scandipwa/src/component/GroupedProductList/GroupedProductList.component.js
@@ -33,7 +33,7 @@ export class GroupedProductList extends PureComponent {
             setQuantity
         } = this.props;
 
-        const sortedItems = items.sort(({ position }, { position: cmpPosition }) => position > cmpPosition);
+        const sortedItems = items.sort(({ position }, { position: cmpPosition }) => position - cmpPosition);
 
         return (
             <ul>


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3277

**Problem:**
* Order of products are not matching order of products in Admin panel

**In this PR:**
* Order of products are matching order of products in Admin panel
