### PR TITLE
let the label shrink for customizable items

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -331,8 +331,10 @@
             will-change: background-color, border-color;
             margin-inline-end: 11px;
 
-            + .ProductBundleItem-Label {
-                flex: 1;
+            + .ProductCustomizableItem, +.ProductBundleItem {
+                &-Label {
+                    flex: 1;
+                }
             }
 
             @include desktop {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4970

**Problem:**
* Checkboxes and Radio were resized for Bundle Product

**In this PR:**
* let the label shrink and not resize the checkboxes and radio
