### PR TITLE
#4690 - Field stay green after submit if not required

### DIFF
--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -257,10 +257,6 @@
                 input,
                 textarea,
                 select {
-                    &:placeholder-shown {
-                        border: 1px solid var(--color-dark-gray);
-                    }
-
                     border: 1px solid var(--primary-success-color);
                 }
             }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4690

**Problem:**
* Not required fields stays grey after submit

**In this PR:**
* Not required fields becomes green after submit