### PR TITLE
passing base src if large is absent

### DIFF
--- a/packages/scandipwa/src/component/ProductGallery/ProductGallery.component.js
+++ b/packages/scandipwa/src/component/ProductGallery/ProductGallery.component.js
@@ -276,7 +276,7 @@ export class ProductGallery extends PureComponent {
             } = mediaData;
 
             const style = isImageZoomPopupActive ? { height: 'auto' } : {};
-            const src = isImageZoomPopupActive ? largeSrc : baseSrc;
+            const src = isImageZoomPopupActive ? largeSrc || baseSrc : baseSrc;
 
             return (
                 <Image


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4710 

**Problem:**
* The placeholder has only base src, zoom image component uses only large src of the image

**In this PR:**
* if large src is not defined then use base src
