### PR TITLE
#4883 - Add wrap for options in wishlist

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.style.scss
@@ -48,6 +48,7 @@
 
     &Options-List {
         min-height: 30px;
+        word-break: break-word;
 
         @include desktop {
             padding-inline: 9px;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4859#event-6718689509

**Problem:**
* Long file name overlaps to the next product card in Wishlist

**In this PR:**
* File Name is moved to the second line in wishlist
