### PR TITLE
#2690 - Use style list type for lists

### DIFF
--- a/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
+++ b/packages/scandipwa/src/route/CmsPage/CmsPage.style.scss
@@ -113,12 +113,15 @@
 
     ul,
     ol {
+        padding-inline-start: 20px;
+
         li {
+            font-family: 'Open Sans', sans-serif;
+            list-style-position: inside;
+            list-style-type: inherit;
+
             &::before {
-                position: relative;
-                margin-inline-start: 10px;
-                margin-inline-end: 5px;
-                inset-block-start: -1px;
+                display: none;
             }
         }
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/2690

**Problem:**
* All types of Bullets displayed like Disc type on CMS page

**In this PR:**
* Selected type of Bullets (circle, square, disc) displayed according value in admin panel