### PR TITLE
[3552] GraphQl optimization for add to cart

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.config.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.config.js
@@ -1,0 +1,20 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+import { STOCK_TYPE } from 'Component/Product/Stock.config';
+
+export const STATUS = {
+    ok: 'STATUS_OK',
+    qty: 'ERR_QTY',
+    stock: STOCK_TYPE.OUT_OF_STOCK
+};
+
+export default STATUS;

--- a/packages/scandipwa/src/component/CartItem/CartItem.container.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.container.js
@@ -13,15 +13,15 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
-import PRODUCT_TYPE from 'Component/Product/Product.config';
 import SwipeToDelete from 'Component/SwipeToDelete';
 import { showNotification } from 'Store/Notification/Notification.action';
 import { CartItemType } from 'Type/MiniCart.type';
-import { getMaxQuantity, getMinQuantity, getProductInStock } from 'Util/Product/Extract';
+import { getMaxQuantity, getMinQuantity } from 'Util/Product/Extract';
 import { makeCancelable } from 'Util/Promise';
 import { objectToUri } from 'Util/Url';
 
 import CartItem from './CartItem.component';
+import STATUS from './CartItem.config';
 
 export const CartDispatcher = import(
     /* webpackMode: "lazy", webpackChunkName: "dispatchers" */
@@ -106,22 +106,13 @@ export class CartItemContainer extends PureComponent {
         }
     }
 
-    productIsInStock() {
-        const { item: { product } } = this.props;
-
-        return getProductInStock(product);
-    }
-
     /**
      * @returns {Product}
      */
     getCurrentProduct() {
         const { item: { product } } = this.props;
-        const variantIndex = this._getVariantIndex();
 
-        return variantIndex < 0
-            ? product
-            : product.variants[variantIndex];
+        return product;
     }
 
     setStateNotLoading() {
@@ -132,6 +123,7 @@ export class CartItemContainer extends PureComponent {
     containerProps() {
         const {
             item,
+            item: { status = STATUS.ok },
             currency_code,
             isEditing,
             isCartOverlay,
@@ -152,7 +144,7 @@ export class CartItemContainer extends PureComponent {
             thumbnail: this._getProductThumbnail(),
             minSaleQuantity: getMinQuantity(this.getCurrentProduct()),
             maxSaleQuantity: getMaxQuantity(this.getCurrentProduct()),
-            isProductInStock: this.productIsInStock(),
+            isProductInStock: status === STATUS.ok,
             optionsLabels: this.getConfigurableOptionsLabels(),
             isMobileLayout: this.getIsMobileLayout()
         };
@@ -165,7 +157,14 @@ export class CartItemContainer extends PureComponent {
      */
     handleChangeQuantity(quantity) {
         this.setState({ isLoading: true }, () => {
-            const { changeItemQty, item: { item_id, qty = 1 }, cartId } = this.props;
+            const {
+                changeItemQty,
+                item: {
+                    uid,
+                    qty = 1
+                } = {},
+                cartId
+            } = this.props;
 
             if (quantity === qty) {
                 this.setState({ isLoading: false });
@@ -174,7 +173,7 @@ export class CartItemContainer extends PureComponent {
             }
 
             this.hideLoaderAfterPromise(changeItemQty({
-                uid: btoa(item_id),
+                uid,
                 quantity,
                 cartId
             }));
@@ -280,104 +279,66 @@ export class CartItemContainer extends PureComponent {
     _getProductLinkTo() {
         const {
             item: {
+                configurable_options: options,
                 product,
                 product: {
-                    type_id,
-                    configurable_options,
-                    parent,
+                    configurable_options: attributeData,
                     url
                 } = {}
             } = {}
         } = this.props;
 
-        if (type_id !== PRODUCT_TYPE.configurable) {
+        if (!options) {
             return {
                 pathname: url,
                 state: { product }
             };
         }
 
-        const variant = this.getProductVariant();
+        const parameters = {};
 
-        if (!variant) {
-            return {};
-        }
-        const { attributes } = variant;
+        attributeData.forEach(({ uid, attribute_code }) => {
+            const {
+                configurable_product_option_value_uid: valueUid
+            } = options.find(({ configurable_product_option_uid: optionUid }) => optionUid === uid);
 
-        const parameters = Object.entries(attributes).reduce(
-            (parameters, [code, { attribute_value }]) => {
-                if (Object.keys(configurable_options).includes(code)) {
-                    return { ...parameters, [code]: attribute_value };
-                }
+            const valueParts = atob(valueUid).split('/');
 
-                return parameters;
-            }, {}
-        );
-
-        const stateProduct = parent || product;
+            parameters[attribute_code] = valueParts[valueParts.length - 1];
+        });
 
         return {
             pathname: url,
-            state: { product: stateProduct },
+            state: { product },
             search: objectToUri(parameters)
         };
     }
 
     _getProductThumbnail() {
         const product = this.getCurrentProduct();
-        const { thumbnail: { url: thumbnail } = {} } = product;
+        const { thumbnail } = product;
 
-        return thumbnail || '';
-    }
-
-    getConfigurationOptionLabel([key, attribute]) {
-        const {
-            item: {
-                product: {
-                    configurable_options = {}
-                }
-            }
-        } = this.props;
-
-        const { attribute_code, attribute_value } = attribute;
-
-        if (!Object.keys(configurable_options).includes(key) || attribute_value === null) {
-            return null;
+        if (!thumbnail) {
+            return '';
         }
 
-        const {
-            [attribute_code]: { // configurable option attribute
-                attribute_options: {
-                    [attribute_value]: { // attribute option value label
-                        label
-                    }
-                }
-            }
-        } = configurable_options;
+        const { url = '' } = thumbnail;
 
-        return label;
+        return url || '';
     }
 
     getConfigurableOptionsLabels() {
         const {
             item: {
-                product: {
-                    configurable_options,
-                    variants
-                }
+                configurable_options
             }
         } = this.props;
 
-        if (!variants || !configurable_options) {
+        if (!configurable_options) {
             return [];
         }
 
-        const { attributes = [] } = this.getCurrentProduct() || {};
-
-        return Object.entries(attributes)
-            .filter(([attrKey]) => Object.keys(configurable_options).includes(attrKey))
-            .map(this.getConfigurationOptionLabel.bind(this))
-            .filter((label) => label);
+        return configurable_options.map(({ value_label }) => value_label);
     }
 
     notifyAboutLoadingStateChange(isLoading) {

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.component.js
@@ -36,7 +36,6 @@ export class CartOverlay extends PureComponent {
         showOverlay: PropTypes.func.isRequired,
         activeOverlay: PropTypes.string.isRequired,
         hasOutOfStockProductsInCart: PropTypes.bool,
-        cartTotalSubPrice: PropTypes.number,
         cartDisplaySettings: CartDisplayType.isRequired,
         isMobile: PropTypes.bool.isRequired,
         onCartItemLoading: PropTypes.func,
@@ -47,7 +46,6 @@ export class CartOverlay extends PureComponent {
         hasOutOfStockProductsInCart: false,
         onCartItemLoading: null,
         currencyCode: null,
-        cartTotalSubPrice: null,
         minimumOrderAmountReached: true
     };
 
@@ -103,7 +101,13 @@ export class CartOverlay extends PureComponent {
     }
 
     renderOrderTotalExlTax() {
-        const { cartTotalSubPrice } = this.props;
+        const {
+            totals: {
+                prices: {
+                    grand_total_excluding_tax: cartTotalSubPrice = 0
+                }
+            }
+        } = this.props;
 
         if (!cartTotalSubPrice && cartTotalSubPrice !== 0) {
             return null;
@@ -169,17 +173,20 @@ export class CartOverlay extends PureComponent {
     renderDiscount() {
         const {
             totals: {
-                applied_rule_ids,
-                discount_amount,
-                coupon_code
-            }
+                applied_coupons: appliedCoupons = [],
+                prices: {
+                    discounts = []
+                } = {}
+            } = {}
         } = this.props;
 
-        if (!applied_rule_ids || !discount_amount) {
+        if (!(appliedCoupons && appliedCoupons.length) && !(discounts && discounts.length)) {
             return null;
         }
 
-        const label = coupon_code ? __('Coupon code discount ') : __('Discount: ');
+        const label = appliedCoupons.length ? __('Coupon code discount ') : __('Discount: ');
+        const { amount: { value: discount = 0 } = {} } = discounts[0] || {};
+        const { code } = appliedCoupons[0] || {};
 
         return (
             <dl
@@ -188,9 +195,9 @@ export class CartOverlay extends PureComponent {
             >
                 <dt>
                     { label }
-                    { this.renderCouponCode(coupon_code) }
+                    { this.renderCouponCode(code) }
                 </dt>
-                <dd>{ `-${this.renderPriceLine(Math.abs(discount_amount))}` }</dd>
+                <dd>{ `-${this.renderPriceLine(Math.abs(discount))}` }</dd>
             </dl>
         );
     }

--- a/packages/scandipwa/src/component/CartOverlay/CartOverlay.container.js
+++ b/packages/scandipwa/src/component/CartOverlay/CartOverlay.container.js
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
+import STATUS from 'Component/CartItem/CartItem.config';
 import { CART_EDITING, CART_OVERLAY } from 'Component/Header/Header.config';
 import { CUSTOMER_ACCOUNT_OVERLAY_KEY } from 'Component/MyAccountOverlay/MyAccountOverlay.config';
 import { CHECKOUT_URL } from 'Route/Checkout/Checkout.config';
@@ -29,7 +30,6 @@ import {
     getCartTotalSubPrice
 } from 'Util/Cart';
 import history from 'Util/History';
-import { getProductInStock } from 'Util/Product/Extract';
 import { appendWithStoreCode } from 'Util/Url';
 
 import CartOverlay from './CartOverlay.component';
@@ -146,7 +146,7 @@ export class CartOverlayContainer extends PureComponent {
     }
 
     hasOutOfStockProductsInCartItems(items = []) {
-        return items.some(({ product }) => !getProductInStock(product));
+        return items.some(({ status = STATUS.ok }) => status !== STATUS.ok);
     }
 
     handleCheckoutClick(e) {

--- a/packages/scandipwa/src/query/Cart.query.js
+++ b/packages/scandipwa/src/query/Cart.query.js
@@ -345,7 +345,8 @@ export class CartQuery {
             this._getPricesField(),
             this._getAppliedCouponsField(),
             this._getItemsField(),
-            this._getShippingAddressesField()
+            this._getShippingAddressesField(),
+            this._getMinimumOrderAmountField()
         ];
     }
 
@@ -425,7 +426,7 @@ export class CartQuery {
         ];
     }
 
-    _getMinimumOrderAmount() {
+    _getMinimumOrderAmountField() {
         return new Field('minimum_order_amount')
             .addFieldList(this._getMinimumOrderAmountFields());
     }

--- a/packages/scandipwa/src/query/Cart.query.js
+++ b/packages/scandipwa/src/query/Cart.query.js
@@ -10,10 +10,8 @@
  * @link https://github.com/scandipwa/scandipwa
  */
 
-import ProductListQuery from 'Query/ProductList.query';
-import { CHECKOUT_URL } from 'Route/Checkout/Checkout.config';
 import { isSignedIn } from 'Util/Auth';
-import { Field } from 'Util/Query';
+import { Field, Fragment } from 'Util/Query';
 
 /** @namespace Query/Cart/Query */
 export class CartQuery {
@@ -22,7 +20,7 @@ export class CartQuery {
         return new Field('addProductsToCart')
             .addArgument('cartId', 'String!', cartId)
             .addArgument('cartItems', '[CartItemInput!]!', cartItems)
-            .addField(this._getUserErrorsField());
+            .addField(this._getCartField());
     }
 
     getUpdateCartItemsMutation(input) {
@@ -38,13 +36,10 @@ export class CartQuery {
 
     //#region QUERIES
     getCartQuery(quoteId) {
-        const query = new Field('getCartForCustomer')
-            .addFieldList(this._getCartTotalsFields())
+        const query = new Field('cart')
+            .addArgument('cart_id', 'String!', isSignedIn() ? '' : quoteId)
+            .addFieldList(this._getCartFields())
             .setAlias('cartData');
-
-        if (!isSignedIn()) {
-            query.addArgument('guestCartId', 'String', quoteId);
-        }
 
         return query;
     }
@@ -61,6 +56,302 @@ export class CartQuery {
     _getUserErrorsField() {
         return new Field('user_errors')
             .addFieldList(this._getUserErrorsFields());
+    }
+    //#endregion
+
+    //#region ITEMS
+    _getProductPricesFields() {
+        return [
+            this._getMoneyField('row_total'),
+            this._getMoneyField('row_total_including_tax'),
+            this._getMoneyField('total_item_discount')
+        ];
+    }
+
+    _getProductPricesField() {
+        return new Field('prices')
+            .addFieldList(this._getProductPricesFields());
+    }
+
+    _getConfigOptionsField() {
+        return new Field('configurable_options')
+            .addFieldList([
+                'option_label',
+                'value_label',
+                'configurable_product_option_value_uid',
+                'configurable_product_option_uid'
+            ]);
+    }
+
+    _getConfigOptionsFragmentFields() {
+        return [
+            this._getConfigOptionsField(),
+            this._getCustomizableOptionsField('customizable_options_config')
+        ];
+    }
+
+    _getConfigOptionsFragmentField() {
+        return new Fragment('ConfigurableCartItem')
+            .addFieldList(this._getConfigOptionsFragmentFields());
+    }
+
+    _getBundleOptionsValueField() {
+        return new Field('values')
+            .addFieldList([
+                'uid',
+                'label',
+                'quantity'
+            ]);
+    }
+
+    _getBundleOptionsField() {
+        return new Field('bundle_options')
+            .addFieldList([
+                'uid',
+                'label',
+                this._getBundleOptionsValueField()
+            ]);
+    }
+
+    _getBundleOptionsFragmentFields() {
+        return [
+            this._getBundleOptionsField(),
+            this._getCustomizableOptionsField('customizable_options_bundle')
+        ];
+    }
+
+    _getBundleOptionsFragmentField() {
+        return new Fragment('BundleCartItem')
+            .addFieldList(this._getBundleOptionsFragmentFields());
+    }
+
+    _getDownloadableLinkTitleField() {
+        return new Field('title')
+            .setAlias('label');
+    }
+
+    _getDownloadableLinkField() {
+        return new Field('links')
+            .addFieldList([
+                'uid',
+                this._getDownloadableLinkTitleField()
+            ]).setAlias('downloadable_links');
+    }
+
+    _getDownloadableOptionsFragmentFields() {
+        return [
+            this._getDownloadableLinkField(),
+            this._getCustomizableOptionsField('customizable_options_downloadable')
+        ];
+    }
+
+    _getDownloadableOptionsFragmentField() {
+        return new Fragment('DownloadableCartItem')
+            .addFieldList(this._getDownloadableOptionsFragmentFields());
+    }
+
+    _getSimpleOptionsFragmentField() {
+        return new Fragment('SimpleCartItem')
+            .addField(this._getCustomizableOptionsField('customizable_options_simple'));
+    }
+
+    _getVirtualOptionsFragmentField() {
+        return new Fragment('VirtualCartItem')
+            .addField(this._getCustomizableOptionsField('customizable_options_virtual'));
+    }
+
+    _getCustomizableOptionsValueField() {
+        return new Field('values')
+            .addFieldList([
+                'customizable_option_value_uid',
+                'label',
+                'value'
+            ]);
+    }
+
+    _getCustomizableOptionsFields() {
+        return [
+            'customizable_option_uid',
+            'label',
+            this._getCustomizableOptionsValueField()
+        ];
+    }
+
+    _getCustomizableOptionsField(alias = 'customizable_options') {
+        return new Field('customizable_options')
+            .addFieldList(this._getCustomizableOptionsFields())
+            .setAlias(alias);
+    }
+
+    _getItemImageField() {
+        return new Field('thumbnail').addFieldList(['url']);
+    }
+
+    _getConfigurableProductFields() {
+        return new Field('configurable_options')
+            .addFieldList(['uid', 'attribute_code']);
+    }
+
+    _getConfigurableProductField() {
+        return new Fragment('ConfigurableProduct')
+            .addField(this._getConfigurableProductFields());
+    }
+
+    _getStockItemFields() {
+        return [
+            'min_sale_qty',
+            'max_sale_qty',
+            'qty_increments'
+        ];
+    }
+
+    _getStockItemField() {
+        return new Field('stock_item')
+            .addFieldList(this._getStockItemFields());
+    }
+
+    _getItemProductFields() {
+        return [
+            'name',
+            'sku',
+            'url',
+            this._getStockItemField(),
+            this._getItemImageField(),
+            this._getConfigurableProductField()
+        ];
+    }
+
+    _getItemProductField() {
+        return new Field('product')
+            .addFieldList(this._getItemProductFields());
+    }
+
+    _getItemsFields() {
+        return [
+            'uid',
+            'quantity',
+            'status',
+            this._getProductPricesField(),
+            this._getItemProductField(),
+            this._getConfigOptionsFragmentField(),
+            this._getDownloadableOptionsFragmentField(),
+            this._getBundleOptionsFragmentField(),
+            this._getVirtualOptionsFragmentField(),
+            this._getSimpleOptionsFragmentField()
+        ];
+    }
+
+    _getItemsField() {
+        return new Field('items')
+            .addFieldList(this._getItemsFields());
+    }
+    //#endregion
+
+    //#region PRICE
+    _getMoneyFields() {
+        return [
+            'value',
+            'currency'
+        ];
+    }
+
+    _getMoneyField(fieldName) {
+        return new Field(fieldName)
+            .addFieldList(this._getMoneyFields());
+    }
+
+    _getPriceGroupFields(extraFields = []) {
+        return [
+            'label',
+            this._getMoneyField('amount'),
+            ...extraFields
+        ];
+    }
+
+    _getPriceGroupField(fieldName, extraFields = []) {
+        return new Field(fieldName)
+            .addFieldList(this._getPriceGroupFields(extraFields));
+    }
+
+    _getPricesFields() {
+        return [
+            this._getMoneyField('grand_total'),
+            this._getMoneyField('subtotal_excluding_tax'),
+            this._getMoneyField('subtotal_including_tax'),
+            this._getPriceGroupField('discounts'),
+            this._getPriceGroupField('applied_taxes', [
+                'title',
+                'percent'
+            ])
+        ];
+    }
+
+    _getPricesField() {
+        return new Field('prices')
+            .addFieldList(this._getPricesFields());
+    }
+    //#endregion
+
+    //#region COUPONS
+    _getAppliedCouponsFields() {
+        return [
+            'code'
+        ];
+    }
+
+    _getAppliedCouponsField() {
+        return new Field('applied_coupons')
+            .addFieldList(this._getAppliedCouponsFields());
+    }
+    //#endregion
+
+    //#region SHIPPING ADDRESSES
+    _getSelectedShippingMethodFields() {
+        return [
+            'method_code',
+            // 'carrier_code',
+            'carrier_title',
+            'method_title',
+            this._getMoneyField('amount'),
+            this._getMoneyField('amount_inc_tax')
+        ];
+    }
+
+    _getSelectedShippingMethodField() {
+        return new Field('selected_shipping_method')
+            .addFieldList(this._getSelectedShippingMethodFields());
+    }
+
+    _getShippingAddressesFields() {
+        return [
+            this._getSelectedShippingMethodField()
+        ];
+    }
+
+    _getShippingAddressesField() {
+        return new Field('shipping_addresses')
+            .addFieldList(this._getShippingAddressesFields());
+    }
+    //#endregion
+
+    //#region CART
+    _getTotalQuantityField() {
+        return new Field('total_quantity').setAlias('items_qty');
+    }
+
+    _getCartFields() {
+        return [
+            this._getTotalQuantityField(),
+            this._getPricesField(),
+            this._getAppliedCouponsField(),
+            this._getItemsField(),
+            this._getShippingAddressesField()
+        ];
+    }
+
+    _getCartField() {
+        return new Field('cart')
+            .addFieldList(this._getCartFields());
     }
     //#endregion
 
@@ -117,162 +408,10 @@ export class CartQuery {
             .addField('id');
     }
 
-    _getSaveCartItemFields(quoteId) {
-        return [
-            this.getCartQuery(quoteId)
-        ];
-    }
-
     _getRemoveCartItemFields(quoteId) {
         return [
             this.getCartQuery(quoteId)
         ];
-    }
-
-    _getCartTotalsFields() {
-        const { pathname = '' } = location;
-        const checkoutData = (
-            pathname.includes(CHECKOUT_URL)
-                ? [this._getOrderShippingAddressField()]
-                : []
-        );
-
-        return [
-            'id',
-            'subtotal',
-            'subtotal_incl_tax',
-            'items_qty',
-            'tax_amount',
-            'grand_total',
-            'discount_amount',
-            'quote_currency_code',
-            'subtotal_with_discount',
-            'coupon_code',
-            'shipping_amount',
-            'shipping_incl_tax',
-            'shipping_tax_amount',
-            'is_virtual',
-            'applied_rule_ids',
-            'shipping_amount',
-            'shipping_incl_tax',
-            'shipping_tax_amount',
-            'shipping_method',
-            ...checkoutData,
-            'is_in_store_pickup_available',
-            this._getCartItemsField(),
-            this._getAppliedTaxesField(),
-            this._getMinimumOrderAmount()
-        ];
-    }
-
-    _getOrderShippingAddressField() {
-        return new Field('shipping_address')
-            .addFieldList(this._getOrderAddressFields());
-    }
-
-    _getOrderAddressFields() {
-        return [
-            'city',
-            'country_id',
-            'firstname',
-            'lastname',
-            'postcode',
-            'region',
-            'telephone',
-            'vat_id',
-            'email',
-            'street'
-        ];
-    }
-
-    _getBundleOptionValuesFields() {
-        return [
-            'id',
-            'label',
-            'quantity',
-            'price'
-        ];
-    }
-
-    _getBundleOptionValuesField() {
-        return new Field('values')
-            .addFieldList(this._getBundleOptionValuesFields());
-    }
-
-    _getBundleOptionsFields() {
-        return [
-            'id',
-            'label',
-            this._getBundleOptionValuesField()
-        ];
-    }
-
-    _getBundleOptionsField() {
-        return new Field('bundle_options')
-            .addFieldList(this._getBundleOptionsFields());
-    }
-
-    _getCustomizableOptionValueFields() {
-        return [
-            'id',
-            'label',
-            'value'
-        ];
-    }
-
-    _getCustomizableOptionValueField() {
-        return new Field('values')
-            .addFieldList(this._getCustomizableOptionValueFields());
-    }
-
-    _getCustomizableOptionsFields() {
-        return new Field('customizable_options')
-            .addFieldList([
-                'id',
-                'label',
-                this._getCustomizableOptionValueField()
-            ]);
-    }
-
-    _getDownloadableLinksField() {
-        return new Field('downloadable_links')
-            .addFieldList(this._getDownloadableLinksFields());
-    }
-
-    _getDownloadableLinksFields() {
-        return [
-            'id',
-            'label'
-        ];
-    }
-
-    _getCartItemFields() {
-        return [
-            'qty',
-            'sku',
-            'price',
-            'item_id',
-            'row_total',
-            'row_total_incl_tax',
-            'tax_amount',
-            'tax_percent',
-            'discount_amount',
-            'discount_percent',
-            this._getCustomizableOptionsFields(),
-            this._getDownloadableLinksField(),
-            this._getBundleOptionsField(),
-            this._getProductField()
-        ];
-    }
-
-    _getProductField() {
-        return new Field('product')
-            .addFieldList(ProductListQuery._getCartProductInterfaceFields());
-    }
-
-    _getCartItemsField() {
-        return new Field('items')
-            .addFieldList(this._getCartItemFields());
     }
 
     _getCartDisplayConfigFields() {
@@ -283,23 +422,6 @@ export class CartQuery {
             'include_tax_in_order_total',
             'display_full_tax_summary',
             'display_zero_tax_subtotal'
-        ];
-    }
-
-    _getAppliedTaxesField() {
-        return new Field('applied_taxes')
-            .addField(this._getAppliedTaxesRatesField());
-    }
-
-    _getAppliedTaxesRatesField() {
-        return new Field('rates')
-            .addFieldList(this._getAppliedTaxesRatesFields());
-    }
-
-    _getAppliedTaxesRatesFields() {
-        return [
-            'percent',
-            'title'
         ];
     }
 

--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
@@ -204,7 +204,7 @@ export class CartDispatcher {
                 return Promise.reject();
             }
 
-            const { addProductsToCart: { user_errors: errors = [] } = {} } = await fetchMutation(
+            const { addProductsToCart: { cart: cartData, user_errors: errors = [] } = {} } = await fetchMutation(
                 CartQuery.getAddProductToCartMutation(cartId, products)
             );
 
@@ -216,8 +216,10 @@ export class CartDispatcher {
                 return Promise.reject();
             }
 
-            await this.updateInitialCartData(dispatch);
-            dispatch(showNotification('success', __('Product was added to cart!')));
+            if (cartData) {
+                await this._updateCartData(cartData, dispatch);
+                dispatch(showNotification('success', __('Product was added to cart!')));
+            }
         } catch (error) {
             if (!navigator.onLine) {
                 dispatch(showNotification('error', __('Not possible to fetch while offline')));

--- a/packages/scandipwa/src/store/Cart/Cart.reducer.js
+++ b/packages/scandipwa/src/store/Cart/Cart.reducer.js
@@ -10,7 +10,6 @@
  */
 
 import BrowserDatabase from 'Util/BrowserDatabase';
-import { getIndexedProduct } from 'Util/Product';
 
 import { UPDATE_IS_LOADING_CART, UPDATE_SHIPPING_PRICE, UPDATE_TOTALS } from './Cart.action';
 
@@ -18,24 +17,104 @@ export const CART_TOTALS = 'cart_totals';
 
 /** @namespace Store/Cart/Reducer/updateCartTotals */
 export const updateCartTotals = (action) => {
-    const { cartData: { items = [], ...rest } = {} } = action;
+    const {
+        cartData: {
+            items = [],
+            prices: {
+                grand_total: { value: grandTotalValue = 0, currency } = {},
+                subtotal_excluding_tax: { value: subtotalExclTax = 0 } = {},
+                subtotal_including_tax: { value: subtotalInclTax = 0 } = {},
+                applied_taxes = [],
+                discounts = []
+            } = {},
+            ...rest
+        } = {}
+    } = action;
+
+    // Backwards compatability fields:
+    const fixedItems = items.map((item) => {
+        const {
+            customizable_options_virtual,
+            customizable_options_simple,
+            customizable_options_downloadable,
+            customizable_options_bundle,
+            customizable_options_config,
+            quantity: qty,
+            prices: {
+                row_total: {
+                    value: row_total,
+                    currency_code
+                },
+                row_total_including_tax: {
+                    value: row_total_incl_tax
+                }
+            },
+            product: {
+                sku
+            },
+            product,
+            uid,
+            ...restItem
+        } = item;
+
+        // Migrates different customizable options types into one
+        const options = customizable_options_virtual
+            || customizable_options_simple
+            || customizable_options_downloadable
+            || customizable_options_bundle
+            || customizable_options_config;
+
+        return {
+            ...restItem,
+            product: {
+                ...product,
+                cart_price: row_total,
+                cart_price_incl_tax: row_total_incl_tax
+            },
+            uid,
+            item_id: atob(uid),
+            sku,
+            qty,
+            row_total,
+            row_total_incl_tax,
+            customizable_options: options,
+            currency_code
+        };
+    });
+
+    const totalDiscount = !discounts ? 0 : discounts.reduce(
+        (total, { amount: { value = 0 } = {} }) => total + value, 0
+    );
+    const totalTax = !applied_taxes ? 0 : applied_taxes.reduce(
+        (total, { amount: { value = 0 } = {} }) => total + value, 0
+    );
+    const grandTotalExcludingTax = grandTotalValue - totalTax;
 
     const cartTotals = {
         ...rest,
-        items: []
+        quote_currency_code: currency,
+        currency,
+        grand_total: grandTotalValue,
+        grand_total_excluding_tax: grandTotalExcludingTax,
+        subtotal_excluding_tax: subtotalExclTax,
+        subtotal_including_tax: subtotalInclTax,
+        tax_amount: totalTax,
+        discount_amount: totalDiscount,
+        applied_taxes,
+        discounts,
+        prices: {
+            currency,
+            grand_total: grandTotalValue,
+            grand_total_excluding_tax: grandTotalExcludingTax,
+            subtotal_excluding_tax: subtotalExclTax,
+            subtotal_including_tax: subtotalInclTax,
+            tax_amount: totalTax,
+            discount_amount: totalDiscount,
+            applied_taxes,
+            discounts
+        },
+        items: fixedItems
     };
-
-    if (items.length) {
-        const normalizedItemsProduct = items.map((item) => {
-            const { variants, ...normalizedItem } = item;
-
-            normalizedItem.product = getIndexedProduct(item.product, item.sku);
-
-            return normalizedItem;
-        });
-
-        cartTotals.items = normalizedItemsProduct;
-    }
 
     BrowserDatabase.setItem(
         cartTotals,

--- a/packages/scandipwa/src/util/Cache/Cache.js
+++ b/packages/scandipwa/src/util/Cache/Cache.js
@@ -10,6 +10,27 @@
  */
 
 /**
+ * Prefetches image
+ * - By fetching one image at time, this allows us to inject request between caching.
+ * @param curr
+ * @param next
+ * @namespace Util/Cache/cacheImage
+ */
+export const cacheImage = (curr, next = []) => {
+    const img = new Image();
+
+    if (next.length > 0) {
+        img.onload = () => {
+            cacheImage(next[0], next.slice(1, next.length - 1));
+        };
+    }
+
+    img.importance = 'low';
+    img.src = curr;
+    window.prefetchedImages[curr] = img;
+};
+
+/**
  * Prefetches images
  * @param urls
  * @returns {Promise<void>}
@@ -28,12 +49,9 @@ export const cacheImages = (urls = []) => {
 
     const filteredUrls = urls.filter((url) => !window.prefetchedImages[url]);
 
-    filteredUrls.forEach((url) => {
-        const img = new Image();
-
-        img.src = url;
-        window.prefetchedImages[url] = img;
-    });
+    if (filteredUrls.length > 0) {
+        cacheImage(filteredUrls[0], filteredUrls.slice(1, filteredUrls.length - 1));
+    }
 };
 
 /**


### PR DESCRIPTION
**Required PR:**
* https://github.com/scandipwa/quote-graphql/pull/93

**Related issue(s):**
* Fixes #3552 

**Problem:**
* Loads all images when choosing variant. If I choose a variant and then click "Add to cart" I would still have to wait for some time till event is called for - addToCart as it is blocked by ~100 loading images (for provided example).
* Having two graphql requests to add item to cart -> addToCart(this is fast) + updateCart (this one take some time to execute)
* Way too much data is returned for cart item (it should contain only selected/entered options instead of all possible variants).

**In this PR:**
* Caching image after image so that request can be injected between
* Updated to new magento graphql for cart & add to cart
* Returning only that info that is selected.
* For backwards comparability reducer adds missing fields that where used previously.