### PR TITLE
[4974] - 'is same as shipping' box is now checked for guests on Billing

### DIFF
--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -29,6 +29,7 @@ import {
     trimCheckoutAddress,
     trimCheckoutCustomerAddress
 } from 'Util/Address';
+import { isSignedIn } from 'Util/Auth';
 import { getCartTotalSubPrice } from 'Util/Cart';
 import scrollToError from 'Util/Form/Form';
 import transformToNameValuePair from 'Util/Form/Transform';
@@ -123,6 +124,12 @@ export class CheckoutBillingContainer extends PureComponent {
             prevPaymentMethods: paymentMethods,
             paymentMethod: ''
         };
+    }
+
+    componentDidMount() {
+        if (!isSignedIn()) {
+            this.setState({ isSameAsShipping: true });
+        }
     }
 
     componentDidUpdate(prevState) {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4974 

**Problem:**
* 'Is same as shipping address' checkbox wasn't checked for guest users by default

**In this PR:**
* In CheckoutBilling.container, added an authorization check that sets isSameAsShipping state to true for guest users
