### PR TITLE
4981 - Stores are absent in 'Select Store' popup for bundle product - fixed

### DIFF
--- a/packages/scandipwa/src/util/Cart/Cart.js
+++ b/packages/scandipwa/src/util/Cart/Cart.js
@@ -266,7 +266,11 @@ export const getItemsCountLabel = (items_qty) => (items_qty === 1 ? __('1 item')
 
 /** @namespace Util/Cart/getAllCartItemsSku */
 export const getAllCartItemsSku = (cartItems) => cartItems.reduce((acc, item) => {
-    acc.push({ sku: item.sku });
+    // if condition prevents bundle products from affecting the results of in-store pickup locations search in checkout
+    // this was done to replicate default magento behavior in 2.4.4
+    if (item.product.type_id !== 'bundle') {
+        acc.push({ sku: item.sku });
+    }
 
     return acc;
 }, []);


### PR DESCRIPTION
**Related issue(s):**
* Fixes #4981 

**Problem:**
* In-Store pickup location list was empty for bundle products

**In this PR:**
* Replicated the behavior of default Magento, as per [this comment](https://github.com/scandipwa/scandipwa/issues/4981#issuecomment-1190229541)

