### PR TITLE
#5062 - Display error message for wishlist if needed

### DIFF
--- a/packages/scandipwa/i18n/da_DK.json
+++ b/packages/scandipwa/i18n/da_DK.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/de_DE.json
+++ b/packages/scandipwa/i18n/de_DE.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/es_ES.json
+++ b/packages/scandipwa/i18n/es_ES.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/fa_IR.json
+++ b/packages/scandipwa/i18n/fa_IR.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/fi_FI.json
+++ b/packages/scandipwa/i18n/fi_FI.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/fr_FR.json
+++ b/packages/scandipwa/i18n/fr_FR.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/it_IT.json
+++ b/packages/scandipwa/i18n/it_IT.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/lv_LV.json
+++ b/packages/scandipwa/i18n/lv_LV.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/nb_NO.json
+++ b/packages/scandipwa/i18n/nb_NO.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/nl_NL.json
+++ b/packages/scandipwa/i18n/nl_NL.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/pl_PL.json
+++ b/packages/scandipwa/i18n/pl_PL.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/pt_BR.json
+++ b/packages/scandipwa/i18n/pt_BR.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/ru_RU.json
+++ b/packages/scandipwa/i18n/ru_RU.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/sl_SI.json
+++ b/packages/scandipwa/i18n/sl_SI.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/sv_SE.json
+++ b/packages/scandipwa/i18n/sv_SE.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/tr_TR.json
+++ b/packages/scandipwa/i18n/tr_TR.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/i18n/zh_TW.json
+++ b/packages/scandipwa/i18n/zh_TW.json
@@ -610,5 +610,6 @@
     "Send Confirmation Action": null,
     "This email does not require confirmation.": null,
     "Remove file": null,
-    "Region": null
+    "Region": null,
+    "We can`t add the item to Wishlist right now: %s": null
 }

--- a/packages/scandipwa/src/store/Wishlist/Wishlist.dispatcher.js
+++ b/packages/scandipwa/src/store/Wishlist/Wishlist.dispatcher.js
@@ -118,9 +118,18 @@ export class WishlistDispatcher {
             const { items = [], wishlistId = '' } = options;
 
             dispatch(updateIsLoading(true));
-            await fetchMutation(WishlistQuery.addProductsToWishlist(wishlistId, items));
-            dispatch(showNotification('success', __('Product added to wish-list!')));
-            await this._syncWishlistWithBE(dispatch);
+            const {
+                addProductsToWishlist: { user_errors }
+            } = await fetchMutation(WishlistQuery.addProductsToWishlist(wishlistId, items));
+
+            if (user_errors.length > 0) {
+                user_errors.map(({ message }) => dispatch(
+                    showNotification('error', __('We can`t add the item to Wishlist right now: %s', message).toString())
+                ));
+            } else {
+                dispatch(showNotification('success', __('Product added to wish-list!')));
+                await this._syncWishlistWithBE(dispatch);
+            }
         } catch {
             dispatch(showNotification('error', __('Error updating wish list!')));
         } finally {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5062

**Problem:**
* Success message 'Product added to wish-list!' appears but product isn't added to Wishlist

**In this PR:**
* Error message is displayed according error message from BE
