### PR TITLE
#5046 - Not set subscribe status if customer is empty

### DIFF
--- a/packages/scandipwa/src/component/MyAccountNewsletterSubscription/MyAccountNewsletterSubscription.container.js
+++ b/packages/scandipwa/src/component/MyAccountNewsletterSubscription/MyAccountNewsletterSubscription.container.js
@@ -56,13 +56,31 @@ export class MyAccountNewsletterSubscriptionContainer extends PureComponent {
     };
 
     __construct(props) {
-        const { customer: { is_subscribed } = {} } = props;
+        const { customer, customer: { is_subscribed } = {} } = props;
 
         super.__construct(props);
         this.state = {
-            isLoading: false,
+            isLoading: Object.keys(customer).length === 0,
             isSubscriptionSelected: is_subscribed || false
         };
+    }
+
+    componentDidUpdate(prevProps) {
+        const {
+            customer: prevCustomer
+        } = prevProps;
+
+        const {
+            customer,
+            customer: { is_subscribed } = {}
+        } = this.props;
+
+        if (Object.keys(prevCustomer).length === 0 && Object.keys(customer).length !== 0) {
+            this.setState({
+                isSubscriptionSelected: is_subscribed,
+                isLoading: false
+            });
+        }
     }
 
     containerProps() {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5046

**Problem:**
* Checkbox 'General subscription' is not selected if customer is subscribed

**In this PR:**
* Checkbox 'General subscription' is selected if customer is subscribed
