### PR TITLE
#5060 - Select none for not required bundle radio option

### DIFF
--- a/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.component.js
+++ b/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.component.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import Field from 'Component/Field';
-import { FIELD_TYPE } from 'Component/Field/Field.config';
+import { FIELD_RADIO_NONE, FIELD_TYPE } from 'Component/Field/Field.config';
 import FieldGroup from 'Component/FieldGroup';
 import { ItemOptionsType } from 'Type/ProductList.type';
 import {
@@ -205,7 +205,7 @@ export class ProductBundleOption extends PureComponent {
         } = this.props;
 
         const label = this.getLabel(option);
-        const stock = getProductInStock(product);
+        const stock = (product && uid !== FIELD_RADIO_NONE) ? getProductInStock(product) : 'true';
 
         return (
             <div block="ProductBundleItem" elem="Radio" mods={ { customQuantity: canChangeQuantity } } key={ uid }>

--- a/packages/scandipwa/src/util/Product/Transform.js
+++ b/packages/scandipwa/src/util/Product/Transform.js
@@ -341,7 +341,7 @@ export const nonRequiredRadioOptions = (
         return options;
     }
 
-    const hasDefault = options.find(({ is_default }) => is_default);
+    const hasDefault = options.find(({ is_default, product }) => is_default && getProductInStock(product));
 
     return [
         {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5060

**Problem:**
* By default None option isn't selected for not required bundle option on PDP

**In this PR:**
* None option is selected by default if this option isn't required
