### PR TITLE
#5050 - Validate message field in share wishlist form

### DIFF
--- a/packages/scandipwa/src/component/ShareWishlistForm/ShareWishlistForm.form.js
+++ b/packages/scandipwa/src/component/ShareWishlistForm/ShareWishlistForm.form.js
@@ -36,6 +36,7 @@ export const shareWishlistForm = () => [
     {
         label: __('Message'),
         type: FIELD_TYPE.textarea,
+        validateOn: ['onChange'],
         attr: {
             name: 'message',
             placeholder: __('Message'),

--- a/packages/scandipwa/src/component/ShareWishlistForm/ShareWishlistForm.form.js
+++ b/packages/scandipwa/src/component/ShareWishlistForm/ShareWishlistForm.form.js
@@ -41,6 +41,9 @@ export const shareWishlistForm = () => [
             name: 'message',
             placeholder: __('Message'),
             'aria-label': __('Message')
+        },
+        validationRule: {
+            isRequired: false
         }
     }
 ];


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5050

**Problem:**
* Field for Message stays grey after validation in Share Wishlist form in My Account

**In this PR:**
* Field for Message becomes green because it's not required
