### PR TITLE
#5005 - Add wrap for short name

### DIFF
--- a/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.style.scss
@@ -44,10 +44,14 @@
         margin-block: 16px;
         line-height: 20px;
 
-        div[itemprop="description"] li::before {
-            position: relative;
-            margin-inline-end: 10px;
-            inset-block-start: -1px;
+        div[itemprop="description"] {
+            word-break: break-word;
+
+            li::before {
+                position: relative;
+                margin-inline-end: 10px;
+                inset-block-start: -1px;
+            }
         }
     }
 

--- a/packages/scandipwa/src/component/ProductInformation/ProductInformation.style.scss
+++ b/packages/scandipwa/src/component/ProductInformation/ProductInformation.style.scss
@@ -65,6 +65,8 @@
     }
 
     &-Description {
+        word-break: break-word;
+
         @include description-tags {
             font-size: 14px;
             line-height: 20px;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5005

**Problem:**
* PDP layout is broken if short or long description contain long word without spaces

**In this PR:**
* PDP layout isn`t broken if short or long description contain long word without spaces
