### PR TITLE
#4922 - Hide totals if cart is empty

### DIFF
--- a/packages/scandipwa/src/route/CartPage/CartPage.component.js
+++ b/packages/scandipwa/src/route/CartPage/CartPage.component.js
@@ -269,12 +269,15 @@ export class CartPage extends PureComponent {
     }
 
     renderMobile() {
+        const { totals: { items = [] } } = this.props;
+        const isShowTotals = items.length > 0;
+
         return (
             <div block="CartPage" elem="Static">
                 { this.renderHeading() }
                 { this.renderCartItems() }
                 <div block="CartPage" elem="Floating">
-                    { this.renderTotals() }
+                    { isShowTotals && this.renderTotals() }
                 </div>
                 { this.renderDiscountCode() }
                 { this.renderPromo() }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4922

**Problem:**
* 0 tax and 0 subtotal are shown in Cart if there are no products

**In this PR:**
* 0 tax and 0 subtotal are absent in Cart if there are no products
