### PR TITLE
#4923 - Made the same indent for product placeholder on widget

### DIFF
--- a/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
+++ b/packages/scandipwa/src/component/ProductCard/ProductCard.style.scss
@@ -143,6 +143,10 @@
         @include desktop {
             line-height: 20px;
         }
+
+        .TextPlaceholder {
+            margin-block-end: 0;
+        }
     }
 
     &-Brand {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4923

**Problem:**
* Different indent between two placeholders for product card in widget and on PLP

**In this PR:**
* The same indent between two placeholders for product card in widget as on PLP
