### PR TITLE
#4870 - Add missing clickOutside props

### DIFF
--- a/packages/scandipwa/src/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.component.js
+++ b/packages/scandipwa/src/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.component.js
@@ -39,7 +39,7 @@ export class CheckoutTermsAndConditionsPopup extends PureComponent {
         return (
             <Popup
               id={ TERMS_AND_CONDITIONS_POPUP_ID }
-              clickOutside={ false }
+              allowClickOutside={ false }
               mix={ { block: 'CheckoutTermsAndConditionsPopup' } }
             >
                 { this.renderContent() }

--- a/packages/scandipwa/src/component/ImageZoomPopup/ImageZoomPopup.container.js
+++ b/packages/scandipwa/src/component/ImageZoomPopup/ImageZoomPopup.container.js
@@ -89,7 +89,7 @@ export class ImageZoomPopupContainer extends PureComponent {
         return (
             <Popup
               id={ popupId }
-              clickOutside={ false }
+              allowClickOutside={ false }
               mix={ { block: 'ImageZoomPopup', mix } }
               contentMix={ { block: 'ImageZoomPopup', elem: 'PopupContent' } }
               onClose={ onClose }

--- a/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.component.js
+++ b/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.component.js
@@ -87,7 +87,7 @@ export class MyAccountAddressPopup extends PureComponent {
         return (
             <Popup
               id={ ADDRESS_POPUP_ID }
-              clickOutside={ false }
+              allowClickOutside={ false }
               mix={ { block: 'MyAccountAddressPopup' } }
             >
                 <div>

--- a/packages/scandipwa/src/component/MyAccountCustomerPopup/MyAccountCustomerPopup.component.js
+++ b/packages/scandipwa/src/component/MyAccountCustomerPopup/MyAccountCustomerPopup.component.js
@@ -77,7 +77,7 @@ export class MyAccountCustomerPopup extends PureComponent {
         return (
             <Popup
               id={ CUSTOMER_POPUP_ID }
-              clickOutside={ false }
+              allowClickOutside={ false }
               mix={ { block: 'MyAccountCustomerPopup' } }
             >
                 <Loader isLoading={ isLoading } />

--- a/packages/scandipwa/src/component/NewVersionPopup/NewVersionPopup.component.js
+++ b/packages/scandipwa/src/component/NewVersionPopup/NewVersionPopup.component.js
@@ -97,7 +97,7 @@ export class NewVersionPopup extends PureComponent {
         return (
             <Popup
               id={ NEW_VERSION_POPUP_ID }
-              clickOutside={ false }
+              allowClickOutside={ false }
               mix={ { block: 'NewVersionPopup' } }
             >
                 { this.renderContent() }

--- a/packages/scandipwa/src/component/Popup/Popup.component.js
+++ b/packages/scandipwa/src/component/Popup/Popup.component.js
@@ -26,13 +26,12 @@ import './Popup.style';
 export class Popup extends Overlay {
     static propTypes = {
         ...Overlay.propTypes,
-        clickOutside: PropTypes.bool,
+        allowClickOutside: PropTypes.bool.isRequired,
         title: PropTypes.string
     };
 
     static defaultProps = {
         ...Overlay.defaultProps,
-        clickOutside: true,
         title: ''
     };
 
@@ -110,9 +109,9 @@ export class Popup extends Overlay {
 
     // Same with click outside
     handleClickOutside() {
-        const { clickOutside, isMobile } = this.props;
+        const { allowClickOutside, isMobile } = this.props;
 
-        if (!clickOutside) {
+        if (allowClickOutside) {
             return;
         }
 

--- a/packages/scandipwa/src/component/Popup/Popup.container.js
+++ b/packages/scandipwa/src/component/Popup/Popup.container.js
@@ -74,7 +74,7 @@ export class PopupContainer extends PureComponent {
         contentMix: {},
         children: [],
         isStatic: false,
-        allowClickOutside: true
+        allowClickOutside: false
     };
 
     containerFunctions = {

--- a/packages/scandipwa/src/component/Popup/Popup.container.js
+++ b/packages/scandipwa/src/component/Popup/Popup.container.js
@@ -62,7 +62,8 @@ export class PopupContainer extends PureComponent {
         shouldPopupClose: PropTypes.bool.isRequired,
         isMobile: PropTypes.bool.isRequired,
         hideActiveOverlay: PropTypes.func.isRequired,
-        resetHideActivePopup: PropTypes.func.isRequired
+        resetHideActivePopup: PropTypes.func.isRequired,
+        clickOutside: PropTypes.bool
     };
 
     static defaultProps = {
@@ -72,7 +73,8 @@ export class PopupContainer extends PureComponent {
         mix: {},
         contentMix: {},
         children: [],
-        isStatic: false
+        isStatic: false,
+        clickOutside: true
     };
 
     containerFunctions = {
@@ -110,7 +112,8 @@ export class PopupContainer extends PureComponent {
             shouldPopupClose,
             hideActiveOverlay,
             resetHideActivePopup,
-            goToPreviousNavigationState
+            goToPreviousNavigationState,
+            clickOutside
         } = this.props;
 
         return {
@@ -130,6 +133,7 @@ export class PopupContainer extends PureComponent {
             hideActiveOverlay,
             resetHideActivePopup,
             goToPreviousNavigationState,
+            clickOutside,
             title: this._getPopupTitle()
         };
     }

--- a/packages/scandipwa/src/component/Popup/Popup.container.js
+++ b/packages/scandipwa/src/component/Popup/Popup.container.js
@@ -63,7 +63,7 @@ export class PopupContainer extends PureComponent {
         isMobile: PropTypes.bool.isRequired,
         hideActiveOverlay: PropTypes.func.isRequired,
         resetHideActivePopup: PropTypes.func.isRequired,
-        clickOutside: PropTypes.bool
+        allowClickOutside: PropTypes.bool
     };
 
     static defaultProps = {
@@ -74,7 +74,7 @@ export class PopupContainer extends PureComponent {
         contentMix: {},
         children: [],
         isStatic: false,
-        clickOutside: true
+        allowClickOutside: true
     };
 
     containerFunctions = {
@@ -113,7 +113,7 @@ export class PopupContainer extends PureComponent {
             hideActiveOverlay,
             resetHideActivePopup,
             goToPreviousNavigationState,
-            clickOutside
+            allowClickOutside
         } = this.props;
 
         return {
@@ -133,7 +133,7 @@ export class PopupContainer extends PureComponent {
             hideActiveOverlay,
             resetHideActivePopup,
             goToPreviousNavigationState,
-            clickOutside,
+            allowClickOutside,
             title: this._getPopupTitle()
         };
     }

--- a/packages/scandipwa/src/component/ShareWishlistPopup/ShareWishlistPopup.component.js
+++ b/packages/scandipwa/src/component/ShareWishlistPopup/ShareWishlistPopup.component.js
@@ -43,7 +43,7 @@ export class ShareWishlistPopup extends PureComponent {
         return (
             <Popup
               id={ SHARE_WISHLIST_POPUP_ID }
-              clickOutside={ false }
+              allowClickOutside={ false }
               mix={ { block: 'ShareWishlistPopup' } }
             >
                 { this.renderContent() }

--- a/packages/scandipwa/src/component/StoreInPickUpPopup/StoreInPickUpPopup.component.js
+++ b/packages/scandipwa/src/component/StoreInPickUpPopup/StoreInPickUpPopup.component.js
@@ -153,7 +153,7 @@ export class StoreInPickUpPopupComponent extends PureComponent {
         return (
             <Popup
               id={ STORE_IN_PICK_UP_POPUP_ID }
-              clickOutside={ false }
+              allowClickOutside={ false }
               mix={ { block: 'StoreInPickUpPopup' } }
             >
                 { this.renderContent() }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4870

**Problem:**
* clickOutside prop false not working, because it didn't exist on `Popup.container.js`.

**In this PR:**
* clickOutside a configurable prop(for example false set for share wishlist popup)
* Renamed `clickOutside` to `allowClickOutside` for better meaning of its role. If `allowClickOutside` is set to `true`, it means popup won't close if click outside happens, if its `false`, popup will close if click outside happens.