### PR TITLE
#4744 - Return value if grouped product out of stock

### DIFF
--- a/packages/scandipwa/src/util/Product/Transform.js
+++ b/packages/scandipwa/src/util/Product/Transform.js
@@ -293,10 +293,6 @@ export const magentoProductTransform = (
     const productData = [];
 
     if (typeId === PRODUCT_TYPE.grouped && action === ADD_TO_CART) {
-        if (Object.keys(quantity).length === 0) {
-            return productData;
-        }
-
         const { items } = product;
         const groupedProducts = [];
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4744

**Problem:**
* Wishlist icon is missing for out of stock grouped product on PDP and PLP

**In this PR:**
* Wishlist icon is displayed and can add product to Wishlist

**Important:**
* Need to check that adding to the group products cart is not broken