### PR TITLE
#5032 - Hide tier price if higher than regular price

### DIFF
--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.js
@@ -15,7 +15,7 @@ import { PureComponent } from 'react';
 import PRODUCT_TYPE from 'Component/Product/Product.config';
 import TextPlaceholder from 'Component/TextPlaceholder';
 import { MixType } from 'Type/Common.type';
-import { OriginalPriceType, ProductPriceType } from 'Type/Price.type';
+import { OriginalPriceType, ProductPriceType, TierPriceType } from 'Type/Price.type';
 import { PriceConfiguration } from 'Type/ProductList.type';
 
 import {
@@ -35,7 +35,7 @@ export class ProductPrice extends PureComponent {
         price: ProductPriceType,
         priceType: PropTypes.oneOf(Object.values(PRODUCT_TYPE)),
         originalPrice: OriginalPriceType,
-        tierPrice: PropTypes.string,
+        tierPrice: TierPriceType,
         configuration: PriceConfiguration,
         priceCurrency: PropTypes.string,
         discountPercentage: PropTypes.number,
@@ -57,7 +57,7 @@ export class ProductPrice extends PureComponent {
         isSchemaRequired: false,
         variantsCount: 0,
         mix: {},
-        tierPrice: '',
+        tierPrice: {},
         label: '',
         configuration: {},
         displayTaxInPrice: DISPLAY_PRODUCT_PRICES_IN_CATALOG_INCL_TAX
@@ -393,22 +393,25 @@ export class ProductPrice extends PureComponent {
 
     renderTierPrice() {
         const {
-            tierPrice,
+            tierPrice: {
+                valueFormatted: tierPriceFormatted,
+                value: tierPriceValue
+            },
             price: {
                 finalPrice: {
-                    valueFormatted = 0
+                    value
                 } = {}
             } = {}
         } = this.props;
 
-        if (!tierPrice || tierPrice === valueFormatted) {
+        if (!tierPriceFormatted || tierPriceValue >= value) {
             return null;
         }
 
         return (
             <p block="ProductPrice" elem="TierPrice">
                 { __('As low as') }
-                <strong>{ ` ${tierPrice}` }</strong>
+                <strong>{ ` ${tierPriceFormatted}` }</strong>
             </p>
         );
     }

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.container.js
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.container.js
@@ -115,10 +115,18 @@ export class ProductPriceContainer extends PureComponent {
             const prices = tierPrices.map(({ final_price: { value = 0 } = {} }) => value);
             const minPrice = Math.min(...prices);
 
-            return formatPrice(minPrice, currency);
+            return {
+                currency,
+                value: minPrice,
+                valueFormatted: formatPrice(minPrice, currency)
+            };
         }
 
-        return '';
+        return {
+            currency,
+            value: '',
+            valueFormatted: ''
+        };
     }
 
     render() {

--- a/packages/scandipwa/src/type/Price.type.js
+++ b/packages/scandipwa/src/type/Price.type.js
@@ -66,3 +66,9 @@ export const TierPricesType = PropTypes.arrayOf(PropTypes.shape({
     }),
     quantity: PropTypes.number
 }));
+
+export const TierPriceType = PropTypes.shape({
+    currency: PropTypes.string,
+    value: PropTypes.number,
+    valueFormatted: PropTypes.string
+});


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5032

**Problem:**
* The tier price is displayed on PDP and PLP when the tier price is higher than the regular price

**In this PR:**
* Updated how the tier price is passed to the price component from just a string to an object containing the currency, value and formatted value
* Added a tier price type for props validation
