### PR TITLE
4999 Hide vertical scroll bars on wishlist tab when screen is resized 

### DIFF
--- a/packages/scandipwa/src/route/MyAccount/MyAccount.style.scss
+++ b/packages/scandipwa/src/route/MyAccount/MyAccount.style.scss
@@ -77,6 +77,7 @@
             grid-row: span 2;
             padding: 24px;
             overflow-x: auto;
+            overflow-y: hidden;
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4999

**Problem:**
* Vertical scrollbars appear when the screen is resized in the wishlist tab on the account page

**In this PR:**
* Included `overflow-y: hidden` to stop it from appearing on desktop.
