### PR TITLE
#3654 - Hide qty for grouped product in wishlist

### DIFF
--- a/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
+++ b/packages/scandipwa/src/component/WishlistItem/WishlistItem.component.js
@@ -88,13 +88,17 @@ export class WishlistItem extends PureComponent {
 
     renderQuantityFieldInput() {
         const {
-            product: { wishlist: { quantity } },
+            product: { type_id, wishlist: { quantity } },
             changeQuantity,
             setQuantity,
             minSaleQuantity,
             maxSaleQuantity,
             inStock
         } = this.props;
+
+        if (type_id === PRODUCT_TYPE.grouped) {
+            return null;
+        }
 
         return (
             <Field


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3654

**Problem:**
* Counter of Qty of grouped product present in Wishlist

**In this PR:**
* Counter of Qty of grouped product absent in Wishlist
