### PR TITLE
#4805 - Use error message from admin panel for shipping

### DIFF
--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
@@ -29,7 +29,8 @@ export class CheckoutDeliveryOption extends PureComponent {
         isSelected: PropTypes.bool,
         optionPrice: PropTypes.number,
         optionSubPrice: PropTypes.number,
-        onOptionClick: PropTypes.func.isRequired
+        onOptionClick: PropTypes.func.isRequired,
+        errorMessage: PropTypes.string.isRequired
     };
 
     static defaultProps = {
@@ -108,6 +109,7 @@ export class CheckoutDeliveryOption extends PureComponent {
 
     renderAvailabilityMessage() {
         const {
+            errorMessage,
             option: {
                 available
             } = {}
@@ -122,7 +124,7 @@ export class CheckoutDeliveryOption extends PureComponent {
               block="CheckoutDeliveryOption"
               elem="Message"
             >
-                { DELIVERY_METHOD_UNAVAILABLE_MESSAGE }
+                { errorMessage || DELIVERY_METHOD_UNAVAILABLE_MESSAGE }
             </div>
         );
     }

--- a/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.container.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOption/CheckoutDeliveryOption.container.js
@@ -38,7 +38,8 @@ export class CheckoutDeliveryOptionContainer extends PureComponent {
         getCartShippingItemSubPrice: PropTypes.func.isRequired,
         option: ShippingMethodType.isRequired,
         onClick: PropTypes.func.isRequired,
-        isSelected: PropTypes.bool.isRequired
+        isSelected: PropTypes.bool.isRequired,
+        errorMessage: PropTypes.string.isRequired
     };
 
     containerFunctions = {
@@ -51,6 +52,7 @@ export class CheckoutDeliveryOptionContainer extends PureComponent {
             getCartShippingItemPrice,
             getCartShippingItemSubPrice,
             option = {},
+            errorMessage,
             totals: {
                 prices: {
                     quote_currency_code = null
@@ -61,6 +63,7 @@ export class CheckoutDeliveryOptionContainer extends PureComponent {
         return {
             isSelected,
             option,
+            errorMessage,
             optionPrice: getCartShippingItemPrice(option),
             optionSubPrice: getCartShippingItemSubPrice(option),
             currency: quote_currency_code

--- a/packages/scandipwa/src/component/CheckoutDeliveryOptions/CheckoutDeliveryOptions.component.js
+++ b/packages/scandipwa/src/component/CheckoutDeliveryOptions/CheckoutDeliveryOptions.component.js
@@ -40,10 +40,12 @@ export class CheckoutDeliveryOptions extends PureComponent {
     renderDeliveryOption(option) {
         const {
             selectShippingMethod,
-            selectedShippingMethod: { method_code: selectedMethodCode }
+            selectedShippingMethod: {
+                method_code: selectedMethodCode
+            }
         } = this.props;
 
-        const { carrier_code, method_code } = option;
+        const { carrier_code, error_message, method_code } = option;
         const isSelected = selectedMethodCode === method_code;
 
         return (
@@ -52,6 +54,7 @@ export class CheckoutDeliveryOptions extends PureComponent {
               isSelected={ isSelected }
               option={ option }
               onClick={ selectShippingMethod }
+              errorMessage={ error_message }
             />
         );
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4805

**Problem:**
* Error Message for unavailable shipping - static value on FE

**In this PR:**
* Error Message for unavailable shipping taken from the admin panel, and if empty - static value on FE
