### PR TITLE
#5090 - Set swipe background color transparent

### DIFF
--- a/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.style.scss
+++ b/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.style.scss
@@ -26,7 +26,7 @@
     }
 
     &-RightSideContentWrapper {
-        background-color: var(--imported_secondary_light_color, white);
+        background-color: none;
         position: absolute;
         inset-block-start: 0;
         inset-inline-end: 0;

--- a/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.style.scss
+++ b/packages/scandipwa/src/component/SwipeToDelete/SwipeToDelete.style.scss
@@ -26,7 +26,6 @@
     }
 
     &-RightSideContentWrapper {
-        background-color: none;
         position: absolute;
         inset-block-start: 0;
         inset-inline-end: 0;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5090

**Problem:**
* Area colored in secondary color is displayed in the cart and Wishlist

**In this PR:**
* Area is white
