### PR TITLE
#3777 - Don`t send not selected subscribition status when sign up

### DIFF
--- a/packages/scandipwa/src/component/MyAccountCreateAccount/MyAccountCreateAccount.container.js
+++ b/packages/scandipwa/src/component/MyAccountCreateAccount/MyAccountCreateAccount.container.js
@@ -137,12 +137,15 @@ export class MyAccountCreateAccountContainer extends PureComponent {
                 firstname,
                 lastname,
                 email,
-                is_subscribed,
                 taxvat
             },
             password,
             orderID: sessionStorage.getItem(ORDER_ID)
         };
+
+        if (is_subscribed) {
+            customerData.customer.is_subscribed = is_subscribed;
+        }
 
         if (isLoading) {
             return;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3777

**Problem:**
* Subscribed guest automatically unsubscribes when creating an account

**In this PR:**
* User stays subscribed after sign up as in default Magenta
