### PR TITLE
#3025 - Add support for hideOnDesktop class

### DIFF
--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -135,6 +135,14 @@
             }
         }
 
+        &Figure {
+            &_type_hideOnDesktop {
+                @include desktop {
+                    display: none;
+                }
+            }
+        }
+
         &List {
             @include desktop {
                 display: flex;

--- a/packages/scandipwa/src/component/MenuItem/MenuItem.component.js
+++ b/packages/scandipwa/src/component/MenuItem/MenuItem.component.js
@@ -66,13 +66,14 @@ export class MenuItem extends PureComponent {
     }
 
     renderItemContent(item, itemMods) {
-        const { title } = item;
+        const { item_class = '', title } = item;
 
         return (
             <figcaption
               block="Menu"
               elem="ItemCaption"
               mods={ itemMods }
+              mix={ { block: item_class } }
             >
                 { title }
                 { this.renderExpandButton() }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3025

**Problem:**
* Menu Item CSS Class - Menu-ItemFigure_type_hideOnDesktop doesn't work

**In this PR:**
* This menu item is displayed only on mobile layout

**Support for 'Available CSS classes' section:**
* https://manual.scandipwa.com/progressive-web-app/menu-manager
