### PR TITLE
See #5072 Added additional check if JWT is expired

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -20,6 +20,7 @@
         "history": "^4.9.0",
         "html-react-parser": "^0.13.0",
         "intersection-observer": "^0.12.0",
+        "jwt-decode": "^3.1.2",
         "postcss": "8.4.5",
         "prop-types": "^15.6.2",
         "react": "^16.13.1",

--- a/packages/scandipwa/src/util/Auth/Token.js
+++ b/packages/scandipwa/src/util/Auth/Token.js
@@ -9,6 +9,8 @@
  * @link https://github.com/scandipwa/scandipwa
  */
 
+import jwtDecode from 'jwt-decode';
+
 import { updateCustomerSignInStatus } from 'Store/MyAccount/MyAccount.action';
 import BrowserDatabase from 'Util/BrowserDatabase';
 import { deleteCartId } from 'Util/Cart';
@@ -21,6 +23,7 @@ export const AUTH_TOKEN = 'auth_token';
 export const ONE_HOUR_IN_SECONDS = 3600;
 export const ONE_HOUR = 1;
 export const TOKEN_REFRESH_DELAY = 2000;
+export const MILLISECONDS_IN_SECOND = 1000;
 
 /** @namespace Util/Auth/Token/setAuthorizationToken */
 export const setAuthorizationToken = (token) => {
@@ -33,8 +36,9 @@ export const setAuthorizationToken = (token) => {
         } = state.ConfigReducer;
 
         const tokens = BrowserDatabase.getItem(AUTH_TOKEN) || {};
+        const { exp } = jwtDecode(token) || {};
 
-        tokens[website_code] = token;
+        tokens[ website_code ] = { token, exp: exp * MILLISECONDS_IN_SECOND };
         BrowserDatabase.setItem(tokens, AUTH_TOKEN, access_token_lifetime * ONE_HOUR_IN_SECONDS);
     }
 };
@@ -45,7 +49,7 @@ export const deleteAuthorizationToken = () => {
 
     const tokens = BrowserDatabase.getItem(AUTH_TOKEN);
 
-    tokens[website_code] = undefined;
+    tokens[ website_code ] = undefined;
     BrowserDatabase.setItem(tokens, AUTH_TOKEN);
 };
 
@@ -54,9 +58,13 @@ export const getAuthorizationToken = () => {
     const { website_code } = window;
     const tokens = BrowserDatabase.getItem(AUTH_TOKEN) || {};
 
-    const token = tokens[website_code];
+    const { token, exp } = tokens[ website_code ] || {};
 
-    if (token) {
+    // Magento now has two parameters to affect the auth token lifetime
+    // 1. access_token_lifetime affects the session liftime, that can be prolonged every time you make an action to the backend
+    // 2. JWT exp field affects JWT liftime and cannot be prolonged
+    // Thus if you set access_token_lifetime 2h and JWT expires after the 1h, then you will get the "The current customer isn't authorized." error.
+    if (token && Date.now() < exp) {
         return token;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10571,6 +10571,11 @@ jsprim@^1.2.2:
     array-includes "^3.1.4"
     object.assign "^4.1.2"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 keymirror@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/keymirror/-/keymirror-0.1.1.tgz#918889ea13f8d0a42e7c557250eee713adc95c35"


### PR DESCRIPTION
**Related issue(s):**
* Fixes #5072

**Problem:**
* Magento is using JWT for auth tokens now. JWT has it's own expiration mechanism, and the token lifetime cannot be prolonged, like it's done for the session.

**In this PR:**
* Added the additional check of the JWT expiration field in order to trigger logout action once the token becomes invalid.
