### PR TITLE
#5040 - Fix infinity loading on cart page after checkout/logout

### DIFF
--- a/packages/scandipwa/src/route/Checkout/Checkout.container.js
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.js
@@ -101,7 +101,7 @@ export const mapDispatchToProps = (dispatch) => ({
     resetGuestCart: () => CartDispatcher.then(
         ({ default: dispatcher }) => {
             dispatcher.resetGuestCart(dispatch);
-            dispatcher.createGuestEmptyCart(dispatch);
+            dispatcher.createGuestEmptyCart(dispatch, true);
         }
     ),
     toggleBreadcrumbs: (state) => dispatch(toggleBreadcrumbs(state)),

--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.js
@@ -123,9 +123,11 @@ export class CartDispatcher {
         };
     }
 
-    async createGuestEmptyCart(dispatch) {
+    async createGuestEmptyCart(dispatch, disableLoader = false) {
         try {
-            dispatch(updateIsLoadingCart(true));
+            if (!disableLoader) {
+                dispatch(updateIsLoadingCart(true));
+            }
 
             const quoteId = await this._getNewQuoteId(dispatch);
 

--- a/packages/scandipwa/src/store/MyAccount/MyAccount.dispatcher.js
+++ b/packages/scandipwa/src/store/MyAccount/MyAccount.dispatcher.js
@@ -133,7 +133,7 @@ export class MyAccountDispatcher {
         CartDispatcher.then(
             ({ default: dispatcher }) => {
                 dispatcher.resetGuestCart(dispatch);
-                dispatcher.createGuestEmptyCart(dispatch);
+                dispatcher.createGuestEmptyCart(dispatch, true);
             }
         );
         WishlistDispatcher.then(


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5040

**Problem:**
* After checkout/logout the cart is cleared, however, this introduces a loader on the cart page infinitely. 

**In this PR:**
* Updates the `createGuestEmptyCart` method to optionally take a `disableLoader` argument to determine whether to show the loader or not.
