### PR TITLE
#5099 - Add wrap for category description

### DIFF
--- a/packages/scandipwa/src/component/CategoryDetails/CategoryDetails.style.scss
+++ b/packages/scandipwa/src/component/CategoryDetails/CategoryDetails.style.scss
@@ -49,6 +49,7 @@
         justify-content: center;
         font-size: 14px;
         font-weight: 400;
+        word-break: break-word;
 
         li {
             &::before {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5099

**Problem:**
* PLP layout is broken if description contain long word without spaces

**In this PR:**
* PLP layout is not broken if description contain long word without spaces