### PR TITLE
#5101 - Show cart items quantity on mobile minicart

### DIFF
--- a/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.component.js
+++ b/packages/scandipwa/src/component/NavigationTabs/NavigationTabs.component.js
@@ -124,9 +124,9 @@ export class NavigationTabs extends NavigationAbstract {
     }
 
     renderMinicartItemsQty() {
-        const { cartTotals: { items_qty } } = this.props;
+        const { cartTotals: { total_quantity } } = this.props;
 
-        if (!items_qty) {
+        if (!total_quantity) {
             return null;
         }
 
@@ -136,7 +136,7 @@ export class NavigationTabs extends NavigationAbstract {
               block="Header"
               elem="MinicartItemCount"
             >
-                { items_qty }
+                { total_quantity }
             </span>
         );
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5101

**Problem:**
* The cart items quantity was not displaying on the mobile minicart when products are added to the cart.

**In this PR:**
* Updated the `renderMinicartItemsQty` method to use the `total_quantity` which contains the total quantity of items in the cart
