### PR TITLE
#5098 - Removed character validation for first and last name inputs on registration

### DIFF
--- a/packages/scandipwa/src/component/MyAccountCreateAccount/MyAccountCreateAccount.component.js
+++ b/packages/scandipwa/src/component/MyAccountCreateAccount/MyAccountCreateAccount.component.js
@@ -95,7 +95,6 @@ export class MyAccountCreateAccount extends PureComponent {
                   } }
                   validateOn={ ['onChange'] }
                   validationRule={ {
-                      inputType: VALIDATION_INPUT_TYPE.alphaSpace,
                       isRequired: true
                   } }
                   addRequiredTag
@@ -112,7 +111,6 @@ export class MyAccountCreateAccount extends PureComponent {
                   } }
                   validateOn={ ['onChange'] }
                   validationRule={ {
-                      inputType: VALIDATION_INPUT_TYPE.alphaSpace,
                       isRequired: true
                   } }
                   addRequiredTag


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5098

**Problem:**
* The first and last name inputs on registration were invalidating names written in some languages such as Cyrillic and Mandarin.

**In this PR:**
* Removed character validation on the first and last name input fields, as validation rules vary from region to region.
