### PR TITLE
#5041 - Set link for out of stock product in cart

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.component.js
+++ b/packages/scandipwa/src/component/CartItem/CartItem.component.js
@@ -162,10 +162,10 @@ export class CartItem extends PureComponent {
     }
 
     renderContent() {
-        const { linkTo = {}, isProductInStock, isMobile } = this.props;
+        const { linkTo = {}, isMobile } = this.props;
 
-        if (!isProductInStock || Object.keys(linkTo).length === 0 || isMobile) {
-            // If product is out of stock, or link is not set
+        if (Object.keys(linkTo).length === 0 || isMobile) {
+            // If link is not set
             return (
                 <span block="CartItem" elem="Link">
                     { this.renderWrapperContent() }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5041

**Problem:**
* Product card isn’t clickable for out of stock product in the cart

**In this PR:**
* Product card is clickable for out of stock product in the cart

**Notice:**
* The work of the fix can be checked after fixing [issue-5087](https://github.com/scandipwa/scandipwa/issues/5087)