### PR TITLE
#5089 - Include product tier price on compare page

### DIFF
--- a/packages/scandipwa/src/component/ProductCompare/ProductCompare.component.js
+++ b/packages/scandipwa/src/component/ProductCompare/ProductCompare.component.js
@@ -146,7 +146,8 @@ export class ProductCompare extends Component {
             price_range,
             dynamic_price,
             type_id,
-            id
+            id,
+            price_tiers
         } = product;
 
         const price = getPrice(price_range, dynamic_price, {}, type_id);
@@ -156,6 +157,7 @@ export class ProductCompare extends Component {
               price={ price }
               key={ id }
               priceType={ type_id }
+              tierPrices={ price_tiers }
               isPreview
             />
         );


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5089

**Problem:**
* The product tier price was not shown on the products on the compare page.

**In this PR:**
* Added the tier price by passing `price_tiers` from the product to the `ProductPrice` component.
