### PR TITLE
#3455 - Disable customizable options for out of stock product

### DIFF
--- a/packages/scandipwa/src/component/DateSelect/DateSelect.component.js
+++ b/packages/scandipwa/src/component/DateSelect/DateSelect.component.js
@@ -55,7 +55,8 @@ export class DateSelectComponent extends PureComponent {
         showDateSelect: PropTypes.bool.isRequired,
         showTimeSelect: PropTypes.bool.isRequired,
         dateFieldsOrder: PropTypes.string.isRequired,
-        timeFormat: PropTypes.string.isRequired
+        timeFormat: PropTypes.string.isRequired,
+        isDisabled: PropTypes.bool.isRequired
     };
 
     dateMap = {
@@ -125,7 +126,8 @@ export class DateSelectComponent extends PureComponent {
             isRequired,
             type,
             selectedYear,
-            onSetYear
+            onSetYear,
+            isDisabled
         } = this.props;
 
         return (
@@ -150,6 +152,7 @@ export class DateSelectComponent extends PureComponent {
                   isRequired
               } }
               validateOn={ ['onChange'] }
+              isDisabled={ isDisabled }
             />
         );
     }
@@ -160,7 +163,8 @@ export class DateSelectComponent extends PureComponent {
             isRequired,
             type,
             selectedMonth,
-            onSetMonth
+            onSetMonth,
+            isDisabled
         } = this.props;
 
         return (
@@ -185,6 +189,7 @@ export class DateSelectComponent extends PureComponent {
                   isRequired
               } }
               validateOn={ ['onChange'] }
+              isDisabled={ isDisabled }
             />
         );
     }
@@ -195,7 +200,8 @@ export class DateSelectComponent extends PureComponent {
             uid,
             isRequired,
             type,
-            selectedDay
+            selectedDay,
+            isDisabled
         } = this.props;
 
         return (
@@ -220,6 +226,7 @@ export class DateSelectComponent extends PureComponent {
                   isRequired
               } }
               validateOn={ ['onChange'] }
+              isDisabled={ isDisabled }
             />
         );
     }
@@ -230,7 +237,8 @@ export class DateSelectComponent extends PureComponent {
             uid,
             isRequired,
             type,
-            selectedHours
+            selectedHours,
+            isDisabled
         } = this.props;
 
         return (
@@ -255,6 +263,7 @@ export class DateSelectComponent extends PureComponent {
                   isRequired
               } }
               validateOn={ ['onChange'] }
+              isDisabled={ isDisabled }
             />
         );
     }
@@ -265,7 +274,8 @@ export class DateSelectComponent extends PureComponent {
             uid,
             isRequired,
             type,
-            selectedMinutes
+            selectedMinutes,
+            isDisabled
         } = this.props;
 
         return (
@@ -290,6 +300,7 @@ export class DateSelectComponent extends PureComponent {
                   isRequired
               } }
               validateOn={ ['onChange'] }
+              isDisabled={ isDisabled }
             />
         );
     }
@@ -301,7 +312,8 @@ export class DateSelectComponent extends PureComponent {
             isRequired,
             type,
             selectedAMPM,
-            timeFormat
+            timeFormat,
+            isDisabled
         } = this.props;
 
         if (timeFormat !== TIME_FORMAT.H12) {
@@ -329,6 +341,7 @@ export class DateSelectComponent extends PureComponent {
                   isRequired
               } }
               validateOn={ ['onChange'] }
+              isDisabled={ isDisabled }
             />
         );
     }

--- a/packages/scandipwa/src/component/DateSelect/DateSelect.container.js
+++ b/packages/scandipwa/src/component/DateSelect/DateSelect.container.js
@@ -37,11 +37,13 @@ export class DateSelectContainer extends PureComponent {
         yearRange: PropTypes.string.isRequired,
         uid: PropTypes.string.isRequired,
         isRequired: PropTypes.bool,
-        updateSelectedValues: PropTypes.func.isRequired
+        updateSelectedValues: PropTypes.func.isRequired,
+        isDisabled: PropTypes.bool
     };
 
     static defaultProps = {
-        isRequired: false
+        isRequired: false,
+        isDisabled: false
     };
 
     containerFunctions = {
@@ -97,7 +99,8 @@ export class DateSelectContainer extends PureComponent {
             timeFormat,
             dateFieldsOrder,
             uid,
-            isRequired
+            isRequired,
+            isDisabled
         } = this.props;
 
         const showTimeSelect = type === FIELD_DATE_TYPE.dateTime || type === FIELD_DATE_TYPE.time;
@@ -118,7 +121,8 @@ export class DateSelectContainer extends PureComponent {
             timeFormat,
             uid,
             isRequired,
-            type
+            type,
+            isDisabled
         };
     }
 

--- a/packages/scandipwa/src/component/Field/Field.component.js
+++ b/packages/scandipwa/src/component/Field/Field.component.js
@@ -132,6 +132,7 @@ export class Field extends PureComponent {
             events,
             setRef,
             validate,
+            isDisabled,
             resetFieldValue
         } = this.props;
 
@@ -141,6 +142,7 @@ export class Field extends PureComponent {
               events={ events }
               setRef={ setRef }
               validate={ validate }
+              isDisabled={ isDisabled }
               resetFieldValue={ resetFieldValue }
             />
         );

--- a/packages/scandipwa/src/component/Field/Field.component.js
+++ b/packages/scandipwa/src/component/Field/Field.component.js
@@ -220,21 +220,20 @@ export class Field extends PureComponent {
             isDisabled,
             label
         } = this.props;
-        const { id = '', checked, value = '' } = newAttr;
+        const { id = '', checked } = newAttr;
         const elem = type.charAt(0).toUpperCase() + type.slice(1);
         const inputEvents = {
             ...events,
             onChange: onChange || noopFn
         };
-        // if button value is "none" do not disable
-        const isButtonDisabled = (!value.match('none') && isDisabled);
-        const isChecked = checked || (isButtonDisabled || defaultChecked ? !isDisabled : null);
+
+        const isChecked = checked || (isDisabled || defaultChecked ? !isDisabled : null);
 
         return (
             <label htmlFor={ id } block="Field" elem={ `${elem}Label` } mods={ { isDisabled } }>
                 <input
                   ref={ (elem) => setRef(elem) }
-                  disabled={ isButtonDisabled ? isDisabled : false }
+                  disabled={ isDisabled }
                   type={ type }
                   { ...newAttr }
                   { ...inputEvents }
@@ -328,7 +327,9 @@ export class Field extends PureComponent {
 
     // Renders fields label under field
     renderSubLabel() {
-        const { subLabel } = this.props;
+        const {
+            subLabel
+        } = this.props;
 
         if (!subLabel) {
             return null;

--- a/packages/scandipwa/src/component/Field/Field.style.scss
+++ b/packages/scandipwa/src/component/Field/Field.style.scss
@@ -458,6 +458,26 @@
                 margin-block-end: 0;
             }
         }
+
+        &:disabled {
+            cursor: default;
+
+            + label {
+                cursor: default;
+
+                p, span, button {
+                    color: var(--color-dark-gray);
+                }
+
+                .Field-SelectFileBtn {
+                    cursor: default;
+
+                    &:hover {
+                        color: var(--color-dark-gray);
+                    }
+                }
+            }
+        }
     }
 
     &-Labels {

--- a/packages/scandipwa/src/component/FieldDate/FieldDate.container.js
+++ b/packages/scandipwa/src/component/FieldDate/FieldDate.container.js
@@ -33,11 +33,13 @@ export class FieldDateContainer extends PureComponent {
         uid: PropTypes.string.isRequired,
         isRequired: PropTypes.bool,
         updateSelectedValues: PropTypes.func.isRequired,
-        useCalendar: PropTypes.bool.isRequired
+        useCalendar: PropTypes.bool.isRequired,
+        isDisabled: PropTypes.bool
     };
 
     static defaultProps = {
-        isRequired: false
+        isRequired: false,
+        isDisabled: false
     };
 
     containerProps() {
@@ -45,14 +47,16 @@ export class FieldDateContainer extends PureComponent {
             type,
             uid,
             isRequired,
-            updateSelectedValues
+            updateSelectedValues,
+            isDisabled
         } = this.props;
 
         return {
             type,
             uid,
             isRequired,
-            updateSelectedValues
+            updateSelectedValues,
+            isDisabled
         };
     }
 

--- a/packages/scandipwa/src/component/FieldFile/FieldFile.component.js
+++ b/packages/scandipwa/src/component/FieldFile/FieldFile.component.js
@@ -28,6 +28,7 @@ export class FieldFile extends PureComponent {
         setRef: PropTypes.func.isRequired,
         fileName: PropTypes.string.isRequired,
         isLoading: PropTypes.bool.isRequired,
+        isDisabled: PropTypes.bool.isRequired,
         resetFieldValue: PropTypes.func.isRequired
     };
 
@@ -45,7 +46,8 @@ export class FieldFile extends PureComponent {
             attr: { id = '', multiple = false } = {},
             fileName = '',
             isLoading = false,
-            resetFieldValue
+            resetFieldValue,
+            isDisabled
         } = this.props;
 
         if (isLoading) {
@@ -54,7 +56,7 @@ export class FieldFile extends PureComponent {
 
         if (fileName) {
             return (
-                <label htmlFor={ id }>
+                <label htmlFor={ id } block="FieldFile" elem="Label" mods={ { disabled: isDisabled } }>
                     <p>{ fileName }</p>
                     <button onClick={ resetFieldValue }>{ __('Remove file') }</button>
                 </label>
@@ -65,7 +67,7 @@ export class FieldFile extends PureComponent {
         const selectLabel = multiple ? __('Select files') : __('Select file');
 
         return (
-            <label htmlFor={ id }>
+            <label htmlFor={ id } block="FieldFile" elem="Label" mods={ { disabled: isDisabled } }>
                 <UploadIcon />
                 <p>{ dropLabel }</p>
                 <span block="Field" elem="SelectFileBtn">{ selectLabel }</span>
@@ -78,6 +80,7 @@ export class FieldFile extends PureComponent {
             attr = {},
             attr: { accept = '' } = {},
             events = {},
+            isDisabled,
             setRef
         } = this.props;
 
@@ -91,6 +94,7 @@ export class FieldFile extends PureComponent {
                 <input
                   ref={ (elem) => setRef(elem) }
                   type={ FIELD_TYPE.file }
+                  disabled={ isDisabled }
                   // eslint-disable-next-line @scandipwa/scandipwa-guidelines/jsx-no-props-destruction
                   { ...attr }
                   // eslint-disable-next-line @scandipwa/scandipwa-guidelines/jsx-no-props-destruction

--- a/packages/scandipwa/src/component/FieldFile/FieldFile.component.js
+++ b/packages/scandipwa/src/component/FieldFile/FieldFile.component.js
@@ -46,8 +46,7 @@ export class FieldFile extends PureComponent {
             attr: { id = '', multiple = false } = {},
             fileName = '',
             isLoading = false,
-            resetFieldValue,
-            isDisabled
+            resetFieldValue
         } = this.props;
 
         if (isLoading) {
@@ -56,7 +55,7 @@ export class FieldFile extends PureComponent {
 
         if (fileName) {
             return (
-                <label htmlFor={ id } block="FieldFile" elem="Label" mods={ { disabled: isDisabled } }>
+                <label htmlFor={ id }>
                     <p>{ fileName }</p>
                     <button onClick={ resetFieldValue }>{ __('Remove file') }</button>
                 </label>
@@ -67,7 +66,7 @@ export class FieldFile extends PureComponent {
         const selectLabel = multiple ? __('Select files') : __('Select file');
 
         return (
-            <label htmlFor={ id } block="FieldFile" elem="Label" mods={ { disabled: isDisabled } }>
+            <label htmlFor={ id }>
                 <UploadIcon />
                 <p>{ dropLabel }</p>
                 <span block="Field" elem="SelectFileBtn">{ selectLabel }</span>

--- a/packages/scandipwa/src/component/FieldFile/FieldFile.component.js
+++ b/packages/scandipwa/src/component/FieldFile/FieldFile.component.js
@@ -33,8 +33,12 @@ export class FieldFile extends PureComponent {
     };
 
     renderSubLabel(allowedTypes) {
+        const {
+            isDisabled
+        } = this.props;
+
         return (
-            <p block="FieldFile" elem="AllowedTypes">
+            <p block="FieldFile" elem="AllowedTypes" mods={ { isDisabled } }>
                 { __('Compatible file extensions to upload:') }
                 <strong>{ ` ${allowedTypes}` }</strong>
             </p>

--- a/packages/scandipwa/src/component/FieldFile/FieldFile.container.js
+++ b/packages/scandipwa/src/component/FieldFile/FieldFile.container.js
@@ -27,6 +27,7 @@ export class FieldFileContainer extends PureComponent {
         events: EventsType.isRequired,
         setRef: PropTypes.func.isRequired,
         validate: PropTypes.func.isRequired,
+        isDisabled: PropTypes.bool.isRequired,
         resetFieldValue: PropTypes.func.isRequired
     };
 
@@ -110,6 +111,7 @@ export class FieldFileContainer extends PureComponent {
                 ...attr
             } = {},
             setRef,
+            isDisabled,
             resetFieldValue
         } = this.props;
         const { fileName, isLoading, value } = this.state;
@@ -127,6 +129,7 @@ export class FieldFileContainer extends PureComponent {
             resetFieldValue: resetFieldValue.bind(this, { setState: (val) => this.setState(val) }),
             fileName,
             isLoading,
+            isDisabled,
             value
         };
     }

--- a/packages/scandipwa/src/component/GroupedProductList/GroupedProductList.component.js
+++ b/packages/scandipwa/src/component/GroupedProductList/GroupedProductList.component.js
@@ -24,13 +24,15 @@ export class GroupedProductList extends PureComponent {
     static propTypes = {
         product: ProductType.isRequired,
         quantity: PropTypes.objectOf(PropTypes.number).isRequired,
-        setQuantity: PropTypes.func.isRequired
+        setQuantity: PropTypes.func.isRequired,
+        isParentProductInStock: PropTypes.bool.isRequired
     };
 
     renderProductList(items) {
         const {
             quantity,
-            setQuantity
+            setQuantity,
+            isParentProductInStock
         } = this.props;
 
         const sortedItems = items.sort(({ position }, { position: cmpPosition }) => position - cmpPosition);
@@ -44,6 +46,7 @@ export class GroupedProductList extends PureComponent {
                       defaultQuantity={ qty }
                       quantity={ quantity }
                       setQuantity={ setQuantity }
+                      isParentProductInStock={ isParentProductInStock }
                     />
                 )) }
             </ul>

--- a/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.component.js
+++ b/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.component.js
@@ -35,7 +35,8 @@ export class GroupedProductsItem extends PureComponent {
     static propTypes = {
         product: ProductType.isRequired,
         setQuantity: PropTypes.func.isRequired,
-        itemCount: PropTypes.number.isRequired
+        itemCount: PropTypes.number.isRequired,
+        isParentProductInStock: PropTypes.bool.isRequired
     };
 
     renderTitle() {
@@ -92,8 +93,13 @@ export class GroupedProductsItem extends PureComponent {
             product = {},
             product: { id } = {},
             setQuantity,
-            itemCount = 0
+            itemCount = 0,
+            isParentProductInStock
         } = this.props;
+
+        if (!isParentProductInStock) {
+            return null;
+        }
 
         if (!getProductInStock(product)) {
             return (

--- a/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.container.js
+++ b/packages/scandipwa/src/component/GroupedProductsItem/GroupedProductsItem.container.js
@@ -23,7 +23,8 @@ export class GroupedProductsItemContainer extends PureComponent {
         product: ProductType.isRequired,
         quantity: PropTypes.objectOf(PropTypes.number).isRequired,
         setQuantity: PropTypes.func.isRequired,
-        defaultQuantity: PropTypes.number.isRequired
+        defaultQuantity: PropTypes.number.isRequired,
+        isParentProductInStock: PropTypes.bool.isRequired
     };
 
     containerFunctions = {
@@ -39,10 +40,14 @@ export class GroupedProductsItemContainer extends PureComponent {
     }
 
     containerProps() {
-        const { product } = this.props;
+        const {
+            product,
+            isParentProductInStock
+        } = this.props;
 
         return {
             itemCount: this._getCurrentQuantity(),
+            isParentProductInStock,
             product
         };
     }

--- a/packages/scandipwa/src/component/Product/Product.component.js
+++ b/packages/scandipwa/src/component/Product/Product.component.js
@@ -94,6 +94,7 @@ export class Product extends PureComponent {
     //#region PRODUCT OPTIONS
     renderBundleOptions() {
         const {
+            product,
             product: {
                 items
             } = {},
@@ -104,6 +105,7 @@ export class Product extends PureComponent {
             <ProductBundleOptions
               options={ items }
               updateSelectedValues={ updateSelectedValues }
+              isParentProductInStock={ getProductInStock(product) }
             />
         );
     }
@@ -245,6 +247,7 @@ export class Product extends PureComponent {
                   product={ product }
                   quantity={ quantity }
                   setQuantity={ setQuantity }
+                  isParentProductInStock={ getProductInStock(product) }
                 />
             </div>
         );

--- a/packages/scandipwa/src/component/Product/Product.component.js
+++ b/packages/scandipwa/src/component/Product/Product.component.js
@@ -34,6 +34,7 @@ import { RefType } from 'Type/Common.type';
 import { PriceType } from 'Type/Price.type';
 import { MagentoProductType, ProductType, QuantityType } from 'Type/ProductList.type';
 import { filterConfigurableOptions } from 'Util/Product';
+import { getProductInStock } from 'Util/Product/Extract';
 import { VALIDATION_INPUT_TYPE_NUMBER } from 'Util/Validator/Config';
 
 /**
@@ -109,6 +110,7 @@ export class Product extends PureComponent {
 
     renderCustomizableOptions() {
         const {
+            product,
             product: {
                 options
             },
@@ -120,7 +122,7 @@ export class Product extends PureComponent {
             <ProductCustomizableOptions
               options={ options }
               updateSelectedValues={ updateSelectedValues }
-
+              isProductInStock={ getProductInStock(product) }
             />
         );
     }

--- a/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.component.js
+++ b/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.component.js
@@ -284,10 +284,6 @@ export class ProductBundleOption extends PureComponent {
         const min = getMinQuantity(product);
         const max = getMaxQuantity(product);
 
-        console.log(stock);
-        console.log(min);
-        console.log(max);
-
         return (
             <div block="ProductBundleItem" elem="DropdownWrapper" mods={ { customQuantity: canChangeQuantity } }>
                 <Field
@@ -304,8 +300,8 @@ export class ProductBundleOption extends PureComponent {
                       onChange: this.updateSelect.bind(this)
                   } }
                   validationRule={ {
-                      isRequired
-                      // match: this.getError.bind(this, quantity, stock, min, max)
+                      isRequired,
+                      match: this.getError.bind(this, quantity, stock, min, max)
                   } }
                   validateOn={ ['onChange'] }
                 />

--- a/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.component.js
+++ b/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.component.js
@@ -284,6 +284,10 @@ export class ProductBundleOption extends PureComponent {
         const min = getMinQuantity(product);
         const max = getMaxQuantity(product);
 
+        console.log(stock);
+        console.log(min);
+        console.log(max);
+
         return (
             <div block="ProductBundleItem" elem="DropdownWrapper" mods={ { customQuantity: canChangeQuantity } }>
                 <Field
@@ -300,8 +304,8 @@ export class ProductBundleOption extends PureComponent {
                       onChange: this.updateSelect.bind(this)
                   } }
                   validationRule={ {
-                      isRequired,
-                      match: this.getError.bind(this, quantity, stock, min, max)
+                      isRequired
+                      // match: this.getError.bind(this, quantity, stock, min, max)
                   } }
                   validateOn={ ['onChange'] }
                 />

--- a/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.component.js
+++ b/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.component.js
@@ -42,7 +42,8 @@ export class ProductBundleOption extends PureComponent {
         activeSelectUid: PropTypes.string,
         setActiveSelectUid: PropTypes.func.isRequired,
         getDropdownOptions: PropTypes.func.isRequired,
-        updateSelectedValues: PropTypes.func.isRequired
+        updateSelectedValues: PropTypes.func.isRequired,
+        isParentProductInStock: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -62,7 +63,7 @@ export class ProductBundleOption extends PureComponent {
         updateSelectedValues();
     }
 
-    //#refion ERROR
+    //#region ERROR
     getError(quantity, stock, min = -1, max = DEFAULT_MAX_PRODUCTS, value) {
         if (!value) {
             return true;
@@ -92,6 +93,8 @@ export class ProductBundleOption extends PureComponent {
     }
 
     renderQuantityChange(uid, quantity, product = null) {
+        const { isParentProductInStock } = this.props;
+
         const min = !product ? DEFAULT_MIN_PRODUCTS : getMinQuantity(product);
         const max = !product ? DEFAULT_MAX_PRODUCTS : getMaxQuantity(product);
         // eslint-disable-next-line no-nested-ternary
@@ -122,6 +125,7 @@ export class ProductBundleOption extends PureComponent {
               } }
               events={ { onChange: this.setQuantity.bind(this, uid) } }
               validateOn={ ['onChange'] }
+              isDisabled={ !isParentProductInStock }
             />
         );
     }
@@ -139,13 +143,16 @@ export class ProductBundleOption extends PureComponent {
 
         const {
             updateSelectedValues,
-            quantity: { [uid]: quantity = defaultQuantity }
+            quantity: { [uid]: quantity = defaultQuantity },
+            isParentProductInStock
         } = this.props;
 
         const label = this.getLabel(option);
         const min = getMinQuantity(product);
         const max = getMaxQuantity(product);
         const stock = getProductInStock(product);
+
+        const isDisabled = !isParentProductInStock || !stock;
 
         return (
             <div block="ProductBundleItem" elem="Checkbox" mods={ { customQuantity: canChangeQuantity } } key={ uid }>
@@ -165,7 +172,7 @@ export class ProductBundleOption extends PureComponent {
                       match: this.getError.bind(this, quantity, stock, min, max)
                   } }
                   validateOn={ ['onChange'] }
-                  isDisabled={ !stock }
+                  isDisabled={ isDisabled }
                 />
                 { canChangeQuantity && this.renderQuantityChange(uid, quantity, product) }
             </div>
@@ -201,11 +208,14 @@ export class ProductBundleOption extends PureComponent {
 
         const {
             updateSelectedValues,
-            quantity: { [uid]: quantity = defaultQuantity }
+            quantity: { [uid]: quantity = defaultQuantity },
+            isParentProductInStock
         } = this.props;
 
         const label = this.getLabel(option);
         const stock = (product && uid !== FIELD_RADIO_NONE) ? getProductInStock(product) : 'true';
+
+        const isDisabled = !isParentProductInStock || !stock;
 
         return (
             <div block="ProductBundleItem" elem="Radio" mods={ { customQuantity: canChangeQuantity } } key={ uid }>
@@ -225,7 +235,7 @@ export class ProductBundleOption extends PureComponent {
                       match: this.getError.bind(this, quantity, stock)
                   } }
                   validateOn={ ['onChange'] }
-                  isDisabled={ !stock }
+                  isDisabled={ isDisabled }
                 />
                 { canChangeQuantity && this.renderQuantityChange(uid, quantity, product) }
             </div>
@@ -264,7 +274,8 @@ export class ProductBundleOption extends PureComponent {
             isRequired,
             uid,
             activeSelectUid,
-            options
+            options,
+            isParentProductInStock
         } = this.props;
 
         const activeOption = getBundleOption(activeSelectUid, options);
@@ -283,6 +294,8 @@ export class ProductBundleOption extends PureComponent {
         const stock = !Object.keys(product).length ? true : getProductInStock(product);
         const min = getMinQuantity(product);
         const max = getMaxQuantity(product);
+
+        const isDisabled = !isParentProductInStock;
 
         return (
             <div block="ProductBundleItem" elem="DropdownWrapper" mods={ { customQuantity: canChangeQuantity } }>
@@ -304,6 +317,7 @@ export class ProductBundleOption extends PureComponent {
                       match: this.getError.bind(this, quantity, stock, min, max)
                   } }
                   validateOn={ ['onChange'] }
+                  isDisabled={ { isDisabled } }
                 />
                 { canChangeQuantity && this.renderQuantityChange(optionUid, quantity, product) }
             </div>
@@ -342,15 +356,23 @@ export class ProductBundleOption extends PureComponent {
     //#endregion
 
     render() {
-        const { title, options, type } = this.props;
+        const {
+            title,
+            options,
+            type,
+            isParentProductInStock
+        } = this.props;
+
         const render = this.renderMap[type];
 
         if (!render) {
             return null;
         }
 
+        const isDisabled = !isParentProductInStock;
+
         return (
-            <div block="ProductBundleItem" elem="Wrapper">
+            <div block="ProductBundleItem" elem="Wrapper" mods={ { isDisabled } }>
                 { title && this.renderOptionGroupTitle(title) }
                 { options && render(options) }
             </div>

--- a/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.container.js
+++ b/packages/scandipwa/src/component/ProductBundleOption/ProductBundleOption.container.js
@@ -45,7 +45,8 @@ export class ProductBundleOptionContainer extends PureComponent {
         type: PropTypes.string.isRequired,
         options: ItemOptionsType.isRequired,
         updateSelectedValues: PropTypes.func.isRequired,
-        currencyCode: PropTypes.string.isRequired
+        currencyCode: PropTypes.string.isRequired,
+        isParentProductInStock: PropTypes.bool.isRequired
     };
 
     state = {
@@ -136,7 +137,8 @@ export class ProductBundleOptionContainer extends PureComponent {
             isRequired,
             type,
             updateSelectedValues,
-            currencyCode
+            currencyCode,
+            isParentProductInStock
         } = this.props;
 
         const {
@@ -153,7 +155,8 @@ export class ProductBundleOptionContainer extends PureComponent {
             updateSelectedValues,
             currencyCode,
             activeSelectUid,
-            quantity
+            quantity,
+            isParentProductInStock
         };
     }
 

--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.component.js
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.component.js
@@ -25,7 +25,8 @@ import './ProductBundleOptions.style';
 export class ProductBundleOptions extends PureComponent {
     static propTypes = {
         options: ProductItemsType.isRequired,
-        updateSelectedValues: PropTypes.func.isRequired
+        updateSelectedValues: PropTypes.func.isRequired,
+        isParentProductInStock: PropTypes.bool.isRequired
     };
 
     renderOptionGroup(group) {
@@ -38,7 +39,10 @@ export class ProductBundleOptions extends PureComponent {
             option_id
         } = group;
 
-        const { updateSelectedValues } = this.props;
+        const {
+            updateSelectedValues,
+            isParentProductInStock
+        } = this.props;
 
         return (
             <ProductBundleOption
@@ -50,6 +54,7 @@ export class ProductBundleOptions extends PureComponent {
               required={ required }
               updateSelectedValues={ updateSelectedValues }
               uid={ uid }
+              isParentProductInStock={ isParentProductInStock }
             />
         );
     }

--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.container.js
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.container.js
@@ -24,7 +24,8 @@ import ProductBundleOptions from './ProductBundleOptions.component';
 export class ProductBundleOptionsContainer extends PureComponent {
     static propTypes = {
         options: ProductItemsType,
-        updateSelectedValues: PropTypes.func.isRequired
+        updateSelectedValues: PropTypes.func.isRequired,
+        isParentProductInStock: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -32,11 +33,16 @@ export class ProductBundleOptionsContainer extends PureComponent {
     };
 
     containerProps() {
-        const { options, updateSelectedValues } = this.props;
+        const {
+            options,
+            updateSelectedValues,
+            isParentProductInStock
+        } = this.props;
 
         return {
             options,
-            updateSelectedValues
+            updateSelectedValues,
+            isParentProductInStock
         };
     }
 

--- a/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductBundleOptions/ProductBundleOptions.style.scss
@@ -57,6 +57,22 @@
                 }
             }
         }
+
+        &_isDisabled {
+            .ProductBundleItem-Heading, 
+            .Field-SubLabelContainer,
+            .Field-LabelContainer {
+                color: var(--customizable-options-disabled-label-color);
+            }
+
+            .ChevronIcon {
+                fill: var(--customizable-options-disabled-label-color);
+            }
+
+            .FieldSelect-Clickable {
+                cursor: default;
+            }
+        }
     }
 
     &-PriceLabel {

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
@@ -166,7 +166,6 @@ export class ProductCustomizableOption extends PureComponent {
         return (
             <>
                 { this.renderOptionGroupTitle(label) }
-                &&&
                 <Field
                   type={ FIELD_TYPE.file }
                   validationRule={ {
@@ -238,7 +237,7 @@ export class ProductCustomizableOption extends PureComponent {
             uid,
             is_default
         } = option;
-        const { updateSelectedValues } = this.props;
+        const { isProductInStock, updateSelectedValues } = this.props;
         const label = this.getLabel(option);
 
         return (
@@ -255,6 +254,7 @@ export class ProductCustomizableOption extends PureComponent {
                   events={ {
                       onChange: updateSelectedValues
                   } }
+                  isDisabled={ !isProductInStock }
                 />
             </div>
         );

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
@@ -138,7 +138,8 @@ export class ProductCustomizableOption extends PureComponent {
             title,
             uid,
             isRequired,
-            updateSelectedValues
+            updateSelectedValues,
+            isProductInStock
         } = this.props;
 
         const label = this.getLabel(option, title);
@@ -151,6 +152,7 @@ export class ProductCustomizableOption extends PureComponent {
                   uid={ uid }
                   isRequired={ isRequired }
                   updateSelectedValues={ updateSelectedValues }
+                  isDisabled={ !isProductInStock }
                 />
             </>
         );
@@ -280,7 +282,8 @@ export class ProductCustomizableOption extends PureComponent {
             getDropdownOptions,
             updateSelectedValues,
             isRequired,
-            uid
+            uid,
+            isProductInStock
         } = this.props;
 
         return (
@@ -301,13 +304,16 @@ export class ProductCustomizableOption extends PureComponent {
                       isRequired
                   } }
                   validateOn={ ['onChange'] }
+                  isDisabled={ !isProductInStock }
                 />
             </div>
         );
     }
 
     renderOptionGroupTitle(title) {
-        const { isRequired } = this.props;
+        const {
+            isRequired
+        } = this.props;
 
         return (
             <div block="ProductCustomizableItem" elem="HeadingBold">
@@ -318,7 +324,12 @@ export class ProductCustomizableOption extends PureComponent {
     }
 
     render() {
-        const { options, type, title } = this.props;
+        const {
+            options,
+            type,
+            title,
+            isProductInStock
+        } = this.props;
         const render = this.renderMap[type];
 
         if (!render) {
@@ -331,8 +342,10 @@ export class ProductCustomizableOption extends PureComponent {
             || type === CONFIG_FIELD_TYPE.checkbox
             || type === CONFIG_FIELD_TYPE.multi);
 
+        const isDisabled = !isProductInStock;
+
         return (
-            <div block="ProductCustomizableItem" elem="Wrapper">
+            <div block="ProductCustomizableItem" elem="Wrapper" mods={ { isDisabled } }>
                 { renderTitle && this.renderOptionGroupTitle(title) }
                 { options && render(options) }
             </div>

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.component.js
@@ -39,11 +39,13 @@ export class ProductCustomizableOption extends PureComponent {
         getDropdownOptions: PropTypes.func.isRequired,
         isRequired: PropTypes.bool.isRequired,
         currencyCode: PropTypes.string.isRequired,
-        options: CustomizableOptionsType
+        options: CustomizableOptionsType,
+        isProductInStock: PropTypes.bool
     };
 
     static defaultProps = {
-        options: []
+        options: [],
+        isProductInStock: true
     };
 
     renderMap = {
@@ -99,7 +101,7 @@ export class ProductCustomizableOption extends PureComponent {
 
     renderDefaultValue(option) {
         const {
-            title, fieldType, isRequired, uid
+            title, fieldType, isRequired, uid, isProductInStock
         } = this.props;
         const { value } = this.state;
         const { max_characters } = option;
@@ -125,6 +127,7 @@ export class ProductCustomizableOption extends PureComponent {
                       onChange: this.updateValues.bind(this)
                   } }
                   validateOn={ ['onBlur', 'onChange'] }
+                  isDisabled={ !isProductInStock }
                 />
             </>
         );
@@ -155,7 +158,7 @@ export class ProductCustomizableOption extends PureComponent {
 
     renderFileValue(option) {
         const {
-            title, uid, isRequired, updateSelectedValues
+            title, uid, isRequired, updateSelectedValues, isProductInStock
         } = this.props;
         const { file_extension: fileExtensions = '' } = option;
         const label = this.getLabel(option, title);
@@ -163,6 +166,7 @@ export class ProductCustomizableOption extends PureComponent {
         return (
             <>
                 { this.renderOptionGroupTitle(label) }
+                &&&
                 <Field
                   type={ FIELD_TYPE.file }
                   validationRule={ {
@@ -180,6 +184,7 @@ export class ProductCustomizableOption extends PureComponent {
                   events={ {
                       onChange: updateSelectedValues
                   } }
+                  isDisabled={ !isProductInStock }
                 />
             </>
         );
@@ -190,7 +195,7 @@ export class ProductCustomizableOption extends PureComponent {
             uid,
             is_default: isDefault = false
         } = option;
-        const { updateSelectedValues } = this.props;
+        const { isProductInStock, updateSelectedValues } = this.props;
         const label = this.getLabel(option);
 
         return (
@@ -207,6 +212,7 @@ export class ProductCustomizableOption extends PureComponent {
                   events={ {
                       onChange: updateSelectedValues
                   } }
+                  isDisabled={ !isProductInStock }
                 />
             </div>
         );

--- a/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.container.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOption/ProductCustomizableOption.container.js
@@ -42,11 +42,13 @@ export class ProductCustomizableOptionContainer extends PureComponent {
         type: PropTypes.string.isRequired,
         options: CustomizableOptionsType,
         updateSelectedValues: PropTypes.func.isRequired,
-        currencyCode: PropTypes.string.isRequired
+        currencyCode: PropTypes.string.isRequired,
+        isProductInStock: PropTypes.bool
     };
 
     static defaultProps = {
-        options: []
+        options: [],
+        isProductInStock: true
     };
 
     containerFunctions = {
@@ -61,13 +63,15 @@ export class ProductCustomizableOptionContainer extends PureComponent {
     }
 
     getDropdownOptions() {
-        const { options, currencyCode, type } = this.props;
+        const {
+            options, currencyCode, type, isProductInStock
+        } = this.props;
 
         if (type !== CONFIG_FIELD_TYPE.select) {
             return null;
         }
 
-        return sortBySortOrder(customizableOptionsToSelectTransform(options, currencyCode));
+        return sortBySortOrder(customizableOptionsToSelectTransform(options, currencyCode, isProductInStock));
     }
 
     getSortedOptions() {
@@ -87,7 +91,8 @@ export class ProductCustomizableOptionContainer extends PureComponent {
             isRequired,
             type,
             updateSelectedValues,
-            currencyCode
+            currencyCode,
+            isProductInStock
         } = this.props;
 
         return {
@@ -98,6 +103,7 @@ export class ProductCustomizableOptionContainer extends PureComponent {
             options: nonRequiredRadioOptions(this.getSortedOptions(), isRequired, type),
             updateSelectedValues,
             currencyCode,
+            isProductInStock,
             fieldType: this.getFieldType()
         };
     }

--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.component.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.component.js
@@ -25,11 +25,13 @@ import './ProductCustomizableOptions.style';
 export class ProductCustomizableOptions extends PureComponent {
     static propTypes = {
         options: OptionsListType,
+        isProductInStock: PropTypes.bool,
         updateSelectedValues: PropTypes.func.isRequired
     };
 
     static defaultProps = {
-        options: []
+        options: [],
+        isProductInStock: true
     };
 
     renderOptionGroup(group) {
@@ -41,7 +43,7 @@ export class ProductCustomizableOptions extends PureComponent {
             uid
         } = group;
 
-        const { updateSelectedValues } = this.props;
+        const { isProductInStock, updateSelectedValues } = this.props;
 
         return (
             <ProductCustomizableOption
@@ -51,6 +53,7 @@ export class ProductCustomizableOptions extends PureComponent {
               options={ value }
               isRequired={ required }
               type={ type }
+              isProductInStock={ isProductInStock }
               updateSelectedValues={ updateSelectedValues }
             />
         );

--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.container.js
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.container.js
@@ -24,18 +24,21 @@ import ProductCustomizableOptions from './ProductCustomizableOptions.component';
 export class ProductCustomizableOptionsContainer extends PureComponent {
     static propTypes = {
         options: OptionsListType,
+        isProductInStock: PropTypes.bool,
         updateSelectedValues: PropTypes.func.isRequired
     };
 
     static defaultProps = {
-        options: []
+        options: [],
+        isProductInStock: true
     };
 
     containerProps() {
-        const { options, updateSelectedValues } = this.props;
+        const { options, isProductInStock, updateSelectedValues } = this.props;
 
         return {
             options,
+            isProductInStock,
             updateSelectedValues
         };
     }

--- a/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
+++ b/packages/scandipwa/src/component/ProductCustomizableOptions/ProductCustomizableOptions.style.scss
@@ -12,6 +12,7 @@
 :root {
     --customizable-options-additional-information-color: #2c2c2c;
     --customizable-options-required-text-color: #dc6d6d;
+    --customizable-options-disabled-label-color: #858481;
 }
 
 .ProductCustomizableItem {
@@ -81,6 +82,30 @@
                         height: 45px;
                     }
                 }
+            }
+        }
+
+        .FieldFile {
+            &-AllowedTypes {
+                &_isDisabled {
+                    color: var(--customizable-options-disabled-label-color);
+                }
+            }
+        }
+
+        &_isDisabled {
+            .ProductCustomizableItem-HeadingBold, 
+            .Field-SubLabelContainer,
+            .Field-LabelContainer {
+                color: var(--customizable-options-disabled-label-color);
+            }
+
+            .ChevronIcon {
+                fill: var(--customizable-options-disabled-label-color);
+            }
+
+            .FieldSelect-Clickable {
+                cursor: default;
             }
         }
     }

--- a/packages/scandipwa/src/util/Product/Transform.js
+++ b/packages/scandipwa/src/util/Product/Transform.js
@@ -244,7 +244,7 @@ export const customizableOptionToLabel = (option, currencyCode = 'USD') => {
  * @param options
  * @namespace Util/Product/Transform/customizableOptionsToSelectTransform
  */
-export const customizableOptionsToSelectTransform = (options, currencyCode = 'USD') => (
+export const customizableOptionsToSelectTransform = (options, currencyCode = 'USD', isProductInStock = true) => (
     options.reduce((result = [], option) => {
         const {
             uid,
@@ -264,6 +264,7 @@ export const customizableOptionsToSelectTransform = (options, currencyCode = 'US
             value: uid,
             label: baseLabel,
             subLabel: priceLabel,
+            isAvailable: isProductInStock,
             sort_order: position || sort_order
         });
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3455

**Problem:**
* Customizable options are not disabled if products with options is 'Out of stock'

**In this PR:**
* Customizable options are disabled if products with options is 'Out of stock'
