### PR TITLE
#4996 - Fix overflowing content in Address book on mobile

### DIFF
--- a/packages/scandipwa/src/component/MyAccountAddressTable/MyAccountAddressTable.style.scss
+++ b/packages/scandipwa/src/component/MyAccountAddressTable/MyAccountAddressTable.style.scss
@@ -18,4 +18,8 @@
             width: 50%;
         }
     }
+
+    td {
+        overflow-wrap: anywhere;
+    }
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4996

**Problem:**
* Long text content added to any field that appears in the address book would make the table scroll horizontally.

**In this PR:**
* Added `overflow-wrap: anywhere` to break the text as it fills the container.
