### PR TITLE
#4994 - Fixed overflowing content in checkout address table on mobile

### DIFF
--- a/packages/scandipwa/src/component/CheckoutAddressTable/CheckoutAddressTable.style.scss
+++ b/packages/scandipwa/src/component/CheckoutAddressTable/CheckoutAddressTable.style.scss
@@ -79,4 +79,8 @@
     th {
         width: auto;
     }
+
+    td {
+        overflow-wrap: anywhere;
+    }
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4994

**Problem:**
* Long text content added to any field that appears in the checkout address book would make the table scroll horizontally.

**In this PR:**
* Added `overflow-wrap: anywhere` to break the text as it fills the container.
