### PR TITLE
#4890 - Change condition for max salable qty is 1

### DIFF
--- a/packages/scandipwa/src/component/FieldNumberWithControls/FieldNumberWithControls.component.js
+++ b/packages/scandipwa/src/component/FieldNumberWithControls/FieldNumberWithControls.component.js
@@ -63,7 +63,7 @@ export class FieldNumberWithControls extends PureComponent {
                   disabled={ isDisabled }
                 />
                 <button
-                  disabled={ max === 1 || numberValue >= max || isDisabled }
+                  disabled={ (max === 1 && min !== 0) || numberValue >= max || isDisabled }
                   // eslint-disable-next-line react/jsx-no-bind
                   onClick={ () => handleValueChange(numberValue + 1) }
                   aria-label={ __('Add') }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4890

**Problem:**
* Plus button is disabled for child of grouped product if Qty of child product in stock is 1 and user clicked 'minus' button

**In this PR:**
* User can increase Qty from 0 to 1
