### PR TITLE
WIP testing: removed encoding for searchOverlay

### DIFF
--- a/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.container.js
+++ b/packages/scandipwa/src/component/SearchOverlay/SearchOverlay.container.js
@@ -86,7 +86,7 @@ export class SearchOverlayContainer extends PureComponent {
 
         if (searchCriteria) {
             clearSearchResults();
-            const search = encodeURIComponent(searchCriteria.trim().replace(/%/g, '%25'));
+            const search = searchCriteria.trim();
 
             makeSearchRequest({
                 args: {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #3972 

**Problem:**
* The search functionality is broken if search query contains special symbols like "/", '&'

**In this PR:**
* Removed encoding