### PR TITLE
#4987 - Fixed overlapping downloadable orders table cell content when resized in safari  

### DIFF
--- a/packages/scandipwa/src/component/MyAccountMyOrders/MyAccountMyOrders.style.scss
+++ b/packages/scandipwa/src/component/MyAccountMyOrders/MyAccountMyOrders.style.scss
@@ -10,12 +10,7 @@
  */
 
 .MyAccountMyOrders {
-    display: grid;
-    grid-gap: 24px;
-    grid-template-columns: 1fr;
-
     @include mobile {
-        grid-gap: 10px;
         margin-block-end: 20px;
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4987

**Problem:**
* Content under the status column in the downloadable orders table overlapped once you resized the safari browser.

**In this PR:**
* Removes the `display: grid` and its related properties from the `MyAccountMyOrders` css class which seems redundant. 
