### PR TITLE
Virtual Product Customizable Options

### DIFF
--- a/packages/scandipwa/src/query/Cart.query.js
+++ b/packages/scandipwa/src/query/Cart.query.js
@@ -146,6 +146,7 @@ export class CartQuery {
             this._getCartDownloadableProductLinkField(),
             this._getCartBundleProductFragment(),
             this._getCartConfigurableProductFragment(),
+            this._getCartVirtualProductFragments(),
             this._getCartSimpleProductFragments()
         ];
     }
@@ -251,6 +252,13 @@ export class CartQuery {
         return new Fragment('SimpleCartItem')
             .addFieldList([
                 this._getCustomizableOptionsField('simple_customizable_options')
+            ]);
+    }
+
+    _getCartVirtualProductFragments() {
+        return new Fragment('VirtualCartItem')
+            .addFieldList([
+                this._getCustomizableOptionsField('virtual_customizable_options')
             ]);
     }
 

--- a/packages/scandipwa/src/store/Cart/Cart.reducer.js
+++ b/packages/scandipwa/src/store/Cart/Cart.reducer.js
@@ -33,6 +33,7 @@ export const updateCartTotals = (action) => {
                 bundle_customizable_options,
                 configurable_customizable_options,
                 downloadable_customizable_options,
+                virtual_customizable_options,
                 simple_customizable_options,
                 ...normalizedItem
             } = item;
@@ -42,6 +43,7 @@ export const updateCartTotals = (action) => {
             normalizedItem.customizable_options = bundle_customizable_options
                 || configurable_customizable_options
                 || downloadable_customizable_options
+                || virtual_customizable_options
                 || simple_customizable_options
                 || [];
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #5112

**Problem:**
* The virtual product graphql fragment was missing, thus the request didn't get virtual product specific fields.

**In this PR:**
* Added necessary fields to the request.
