### PR TITLE
#4989 - Removed image borders that display when image is loading

### DIFF
--- a/packages/scandipwa/src/component/ProductGallery/ProductGallery.style.scss
+++ b/packages/scandipwa/src/component/ProductGallery/ProductGallery.style.scss
@@ -79,6 +79,10 @@
         &_isZoomInCursor {
             cursor: zoom-in;
         }
+
+        .Image-Image {
+            border: none;
+        }
     }
 
     .react-transform-component,

--- a/packages/scandipwa/src/component/ProductGallery/ProductGallery.style.scss
+++ b/packages/scandipwa/src/component/ProductGallery/ProductGallery.style.scss
@@ -80,7 +80,7 @@
             cursor: zoom-in;
         }
 
-        .Image-Image {
+        img {
             border: none;
         }
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4989

**Problem:**
* Image borders display on safari when the image is loading. I believe this is due to the loading attribute being set to `lazy`.

**In this PR:**
* Removes image borders.
