### PR TITLE
#4826 - Added height to the warning container displayed in the cart for mobile

### DIFF
--- a/packages/scandipwa/src/route/CartPage/CartPage.style.scss
+++ b/packages/scandipwa/src/route/CartPage/CartPage.style.scss
@@ -112,7 +112,10 @@
         color: var(--color-white);
         inset-inline-start: -16px;
         width: calc(100% + 32px);
-        height: var(--button-height);
+        
+        @include mobile {
+            height: var(--button-height);
+        }
     }
 
     &-CheckoutButton {

--- a/packages/scandipwa/src/route/CartPage/CartPage.style.scss
+++ b/packages/scandipwa/src/route/CartPage/CartPage.style.scss
@@ -105,12 +105,14 @@
         padding: 10px;
         display: flex;
         justify-content: center;
+        align-items: center;
         background-color: var(--primary-error-color, red);
         font-size: 14px;
         font-weight: 600;
         color: var(--color-white);
         inset-inline-start: -16px;
         width: calc(100% + 32px);
+        height: var(--button-height);
     }
 
     &-CheckoutButton {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4826

**Problem:**
* The warning container had a height lesser than that of the checkout button.

**In this PR:**
* Adds the same height used by the button to the warning container and also aligns the text horizontally.
