### PR TITLE
See #5124 Hid footer navigation on mobile view for the order print page

### DIFF
--- a/packages/scandipwa/src/route/OrderPrintPage/OrderPrintPage.style.scss
+++ b/packages/scandipwa/src/route/OrderPrintPage/OrderPrintPage.style.scss
@@ -41,7 +41,8 @@
         .NotificationList,
         .DemoNotice,
         .Header-Wrapper,
-        .Breadcrumbs {
+        .Breadcrumbs,
+        .NavigationTabs {
             display: none;
         }
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes #5124

**Problem:**
* The navigation appeared in the mobile layout.

**In this PR:**
* Hid the navigation.
