### PR TITLE
5142 added check for items availibility

### DIFF
--- a/packages/scandipwa/src/util/Product/Transform.js
+++ b/packages/scandipwa/src/util/Product/Transform.js
@@ -296,11 +296,13 @@ export const magentoProductTransform = (
         const { items } = product;
         const groupedProducts = [];
 
-        items.forEach(({ product: { id } }) => {
-            const { [id]: groupedQuantity = 0 } = quantity;
+        if (items) {
+            items.forEach(({ product: { id } }) => {
+                const { [id]: groupedQuantity = 0 } = quantity;
 
-            groupedProducts.push(btoa(`grouped/${id}/${groupedQuantity}`));
-        });
+                groupedProducts.push(btoa(`grouped/${id}/${groupedQuantity}`));
+            });
+        }
 
         productData.push({
             sku,


### PR DESCRIPTION
**Related issue(s):**
* Fixes #5142 

**Problem:**
* Grouped products with out of stock status or out of stock items in it don't have items param instantly from first render

**In this PR:**
* Added check for items param in the product, because they appear in next renders
