### PR TITLE
same as billing address by default if they are the same or guest or no address

### DIFF
--- a/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/packages/scandipwa/src/component/CheckoutBilling/CheckoutBilling.container.js
@@ -38,6 +38,7 @@ import CheckoutBilling from './CheckoutBilling.component';
 /** @namespace Component/CheckoutBilling/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
     customer: state.MyAccountReducer.customer,
+    isSignedIn: state.MyAccountReducer.isSignedIn,
     totals: state.CartReducer.cartTotals,
     termsAreEnabled: state.ConfigReducer.terms_are_enabled,
     termsAndConditions: state.ConfigReducer.checkoutAgreements,
@@ -76,7 +77,8 @@ export class CheckoutBillingContainer extends PureComponent {
         termsAreEnabled: PropTypes.bool,
         newShippingId: PropTypes.number,
         newShippingStreet: PropTypes.arrayOf(PropTypes.string).isRequired,
-        onChangeEmailRequired: PropTypes.func.isRequired
+        onChangeEmailRequired: PropTypes.func.isRequired,
+        isSignedIn: PropTypes.bool.isRequired
     };
 
     static defaultProps = {
@@ -123,6 +125,14 @@ export class CheckoutBillingContainer extends PureComponent {
             prevPaymentMethods: paymentMethods,
             paymentMethod: ''
         };
+    }
+
+    componentDidMount() {
+        const { isSignedIn, customer: { addresses } } = this.props;
+
+        if ((isSignedIn && addresses.length === 0) || !isSignedIn) {
+            this.setState({ isSameAsShipping: true });
+        }
     }
 
     componentDidUpdate(prevState) {

--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
@@ -78,6 +78,10 @@ export const RecentlyViewedProductsReducer = (
         recentProductsFromStorage[storeCode] = recentProductsFromStorage[storeCode]
             .filter((storageItem) => !indexedProducts.every((indexedItem) => indexedItem.id !== storageItem.id));
 
+        // Removing previous version of products that just changed the sku
+        recentProductsFromStorage[storeCode] = recentProductsFromStorage[storeCode]
+            .filter((val, idx, arr) => arr.findIndex((itm) => (itm.id === val.id)) === idx);
+
         BrowserDatabase.setItem(recentProductsFromStorage, RECENTLY_VIEWED_PRODUCTS);
 
         // Sort products same as it is localstorage recentlyViewedProducts

--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
@@ -78,10 +78,6 @@ export const RecentlyViewedProductsReducer = (
         recentProductsFromStorage[storeCode] = recentProductsFromStorage[storeCode]
             .filter((storageItem) => !indexedProducts.every((indexedItem) => indexedItem.id !== storageItem.id));
 
-        // Removing previous version of products that just changed the sku
-        recentProductsFromStorage[storeCode] = recentProductsFromStorage[storeCode]
-            .filter((val, idx, arr) => arr.findIndex((itm) => (itm.id === val.id)) === idx);
-
         BrowserDatabase.setItem(recentProductsFromStorage, RECENTLY_VIEWED_PRODUCTS);
 
         // Sort products same as it is localstorage recentlyViewedProducts


### PR DESCRIPTION

**Related issue(s):**
* Fixes #4974 

**Problem:**
* The same as shipping checkbox wasn't checked by default in cases when user didn't have configured any adresses, and if guest is going to billing from shipping

**In this PR:**
* The checkbox is checked for necessary cases
