### PR TITLE
remove the outdated copy of a product that changed the sku

### DIFF
--- a/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
+++ b/packages/scandipwa/src/store/RecentlyViewedProducts/RecentlyViewedProducts.reducer.js
@@ -78,6 +78,10 @@ export const RecentlyViewedProductsReducer = (
         recentProductsFromStorage[storeCode] = recentProductsFromStorage[storeCode]
             .filter((storageItem) => !indexedProducts.every((indexedItem) => indexedItem.id !== storageItem.id));
 
+        // Removing previous version of products that just changed the sku
+        recentProductsFromStorage[storeCode] = recentProductsFromStorage[storeCode]
+            .filter((val, idx, arr) => arr.findIndex((itm) => (itm.id === val.id)) === idx);
+
         BrowserDatabase.setItem(recentProductsFromStorage, RECENTLY_VIEWED_PRODUCTS);
 
         // Sort products same as it is localstorage recentlyViewedProducts


### PR DESCRIPTION
**Related issue(s):**
* Fixes #5116 

**Problem:**
* Outdated copy of a product that changed sku was left in localstorage

**In this PR:**
* Filtering the array of products and removing the outdated duplicate
