### PR TITLE
issue-5164 - Fix typo for passing match to routes

### DIFF
--- a/packages/scandipwa/src/component/Router/Router.component.js
+++ b/packages/scandipwa/src/component/Router/Router.component.js
@@ -161,12 +161,12 @@ export class Router extends PureComponent {
 
     [SWITCH_ITEMS_TYPE] = [
         {
-            component: <Route path={ withStoreRegex('/') } exact render={ ({ currentUrl }) => <HomePage currentUrl={ currentUrl } /> } />,
+            component: <Route path={ withStoreRegex('/') } exact render={ ({ currentUrl, match }) => <HomePage currentUrl={ currentUrl } match={ match } /> } />,
             position: 10,
             name: HOME
         },
         {
-            component: <Route path={ withStoreRegex('/search/:query/') } render={ () => <SearchPage /> } />,
+            component: <Route path={ withStoreRegex('/search/:query/') } render={ ({ match }) => <SearchPage match={ match } /> } />,
             position: 25,
             name: SEARCH
         },


### PR DESCRIPTION
**Related issue(s):**
* Fixes #5164 

**Problem:**
* Shows 404 pages and some time oops page. Overall just typo on passing match from react router to routes.

**In this PR:**
* Fix typo for passing match to routes
