### PR TITLE
Fix typo in README template

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Data-integrity and simple server setup. Changes from Magento 2 admin are reflect
 
 > Powered by [Create ScandiPWA App](https://github.com/scandipwa/create-scandipwa-app).
 
-:gift: **BONUS!** You will get ESLins rules covering:
+:gift: **BONUS!** You will get ESLint rules covering:
 
 - Well-thought file-structure
 - Naming-convention

--- a/build-packages/csa-generator-blank/template/README.md
+++ b/build-packages/csa-generator-blank/template/README.md
@@ -10,7 +10,7 @@ To do this, use `yarn` or `npm i` command.
 
 ### Recommended packages
 
-For the best expirience, install `scandipwa-cli` package globally. To do this, run:
+For the best experience, install `scandipwa-cli` package globally. To do this, run:
 
 ```bash
 npm i -g scandipwa-cli

--- a/build-packages/csa-generator-cra/template/README.md
+++ b/build-packages/csa-generator-cra/template/README.md
@@ -12,7 +12,7 @@ To do this, use `yarn` or `npm i` command.
 
 ### Recommended packages
 
-For the best expirience, install `scandipwa-cli` package globally. To do this, run:
+For the best experience, install `scandipwa-cli` package globally. To do this, run:
 
 ```bash
 npm i -g scandipwa-cli

--- a/build-packages/csa-generator-theme/template/README.md
+++ b/build-packages/csa-generator-theme/template/README.md
@@ -10,7 +10,7 @@ To do this, use `yarn` or `npm i` command.
 
 ### Recommended packages
 
-For the best expirience, install `scandipwa-cli` package globally. To do this, run:
+For the best experience, install `scandipwa-cli` package globally. To do this, run:
 
 ```bash
 npm i -g scandipwa-cli


### PR DESCRIPTION
**Related issue(s):**
* Fixes #5176

**Problem:**
* There is a typo in README.md

**In this PR:**
* Change 'expirience' to 'experience'.
* Change 'Exlins' to 'Eslint'.
