### PR TITLE
 [5152] Fixed infinite scroll on PLP

### DIFF
--- a/packages/scandipwa/src/component/ProductList/ProductList.container.js
+++ b/packages/scandipwa/src/component/ProductList/ProductList.container.js
@@ -331,6 +331,8 @@ export class ProductListContainer extends PureComponent {
         setQueryParams({
             page: pageNumber === 1 ? '' : pageNumber
         }, location, history);
+
+        scrollToTop();
     }
 
     render() {


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/5152

**Problem:**
* After updating the page with infinite scrollbar, the scrollbar's thumb element's position wasn't updated. which also caused the page not to update it's state correctly

**In this PR:**
* After updating the page, we should scroll to the top. this will fix both issues
