### PR TITLE
[4870] Added missing clickOutside prop

### DIFF
--- a/packages/scandipwa/src/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.component.js
+++ b/packages/scandipwa/src/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.component.js
@@ -39,7 +39,7 @@ export class CheckoutTermsAndConditionsPopup extends PureComponent {
         return (
             <Popup
               id={ TERMS_AND_CONDITIONS_POPUP_ID }
-              clickOutside={ false }
+              isCloseOnOutsideClick={ false }
               mix={ { block: 'CheckoutTermsAndConditionsPopup' } }
             >
                 { this.renderContent() }

--- a/packages/scandipwa/src/component/ImageZoomPopup/ImageZoomPopup.container.js
+++ b/packages/scandipwa/src/component/ImageZoomPopup/ImageZoomPopup.container.js
@@ -89,7 +89,7 @@ export class ImageZoomPopupContainer extends PureComponent {
         return (
             <Popup
               id={ popupId }
-              clickOutside={ false }
+              isCloseOnOutsideClick={ false }
               mix={ { block: 'ImageZoomPopup', mix } }
               contentMix={ { block: 'ImageZoomPopup', elem: 'PopupContent' } }
               onClose={ onClose }

--- a/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.component.js
+++ b/packages/scandipwa/src/component/MyAccountAddressPopup/MyAccountAddressPopup.component.js
@@ -87,7 +87,7 @@ export class MyAccountAddressPopup extends PureComponent {
         return (
             <Popup
               id={ ADDRESS_POPUP_ID }
-              clickOutside={ false }
+              isCloseOnOutsideClick={ false }
               mix={ { block: 'MyAccountAddressPopup' } }
             >
                 <div>

--- a/packages/scandipwa/src/component/MyAccountCustomerPopup/MyAccountCustomerPopup.component.js
+++ b/packages/scandipwa/src/component/MyAccountCustomerPopup/MyAccountCustomerPopup.component.js
@@ -77,7 +77,7 @@ export class MyAccountCustomerPopup extends PureComponent {
         return (
             <Popup
               id={ CUSTOMER_POPUP_ID }
-              clickOutside={ false }
+              isCloseOnOutsideClick={ false }
               mix={ { block: 'MyAccountCustomerPopup' } }
             >
                 <Loader isLoading={ isLoading } />

--- a/packages/scandipwa/src/component/NewVersionPopup/NewVersionPopup.component.js
+++ b/packages/scandipwa/src/component/NewVersionPopup/NewVersionPopup.component.js
@@ -97,7 +97,7 @@ export class NewVersionPopup extends PureComponent {
         return (
             <Popup
               id={ NEW_VERSION_POPUP_ID }
-              clickOutside={ false }
+              isCloseOnOutsideClick={ false }
               mix={ { block: 'NewVersionPopup' } }
             >
                 { this.renderContent() }

--- a/packages/scandipwa/src/component/Popup/Popup.component.js
+++ b/packages/scandipwa/src/component/Popup/Popup.component.js
@@ -26,13 +26,12 @@ import './Popup.style';
 export class Popup extends Overlay {
     static propTypes = {
         ...Overlay.propTypes,
-        clickOutside: PropTypes.bool,
+        clickOutside: PropTypes.bool.isRequired,
         title: PropTypes.string
     };
 
     static defaultProps = {
         ...Overlay.defaultProps,
-        clickOutside: true,
         title: ''
     };
 

--- a/packages/scandipwa/src/component/Popup/Popup.component.js
+++ b/packages/scandipwa/src/component/Popup/Popup.component.js
@@ -26,7 +26,7 @@ import './Popup.style';
 export class Popup extends Overlay {
     static propTypes = {
         ...Overlay.propTypes,
-        clickOutside: PropTypes.bool.isRequired,
+        isCloseOnOutsideClick: PropTypes.bool.isRequired,
         title: PropTypes.string
     };
 
@@ -109,9 +109,9 @@ export class Popup extends Overlay {
 
     // Same with click outside
     handleClickOutside() {
-        const { clickOutside, isMobile } = this.props;
+        const { isCloseOnOutsideClick, isMobile } = this.props;
 
-        if (!clickOutside) {
+        if (!isCloseOnOutsideClick) {
             return;
         }
 

--- a/packages/scandipwa/src/component/Popup/Popup.container.js
+++ b/packages/scandipwa/src/component/Popup/Popup.container.js
@@ -49,7 +49,7 @@ export class PopupContainer extends PureComponent {
                 title: PropTypes.string
             })
         ).isRequired,
-        clickOutside: PropTypes.bool,
+        isCloseOnOutsideClick: PropTypes.bool,
         activeOverlay: PropTypes.string.isRequired,
         goToPreviousNavigationState: PropTypes.func.isRequired,
         areOtherOverlaysOpen: PropTypes.bool.isRequired,
@@ -74,7 +74,7 @@ export class PopupContainer extends PureComponent {
         contentMix: {},
         children: [],
         isStatic: false,
-        clickOutside: true
+        isCloseOnOutsideClick: true
     };
 
     containerFunctions = {
@@ -97,7 +97,7 @@ export class PopupContainer extends PureComponent {
 
     containerProps() {
         const {
-            clickOutside,
+            isCloseOnOutsideClick,
             activeOverlay,
             areOtherOverlaysOpen,
             changeHeaderState,
@@ -117,7 +117,7 @@ export class PopupContainer extends PureComponent {
         } = this.props;
 
         return {
-            clickOutside,
+            isCloseOnOutsideClick,
             activeOverlay,
             areOtherOverlaysOpen,
             changeHeaderState,

--- a/packages/scandipwa/src/component/Popup/Popup.container.js
+++ b/packages/scandipwa/src/component/Popup/Popup.container.js
@@ -49,6 +49,7 @@ export class PopupContainer extends PureComponent {
                 title: PropTypes.string
             })
         ).isRequired,
+        clickOutside: PropTypes.bool,
         activeOverlay: PropTypes.string.isRequired,
         goToPreviousNavigationState: PropTypes.func.isRequired,
         areOtherOverlaysOpen: PropTypes.bool.isRequired,
@@ -72,7 +73,8 @@ export class PopupContainer extends PureComponent {
         mix: {},
         contentMix: {},
         children: [],
-        isStatic: false
+        isStatic: false,
+        clickOutside: true
     };
 
     containerFunctions = {
@@ -95,6 +97,7 @@ export class PopupContainer extends PureComponent {
 
     containerProps() {
         const {
+            clickOutside,
             activeOverlay,
             areOtherOverlaysOpen,
             changeHeaderState,
@@ -114,6 +117,7 @@ export class PopupContainer extends PureComponent {
         } = this.props;
 
         return {
+            clickOutside,
             activeOverlay,
             areOtherOverlaysOpen,
             changeHeaderState,

--- a/packages/scandipwa/src/component/ShareWishlistPopup/ShareWishlistPopup.component.js
+++ b/packages/scandipwa/src/component/ShareWishlistPopup/ShareWishlistPopup.component.js
@@ -43,7 +43,7 @@ export class ShareWishlistPopup extends PureComponent {
         return (
             <Popup
               id={ SHARE_WISHLIST_POPUP_ID }
-              clickOutside={ false }
+              isCloseOnOutsideClick={ false }
               mix={ { block: 'ShareWishlistPopup' } }
             >
                 { this.renderContent() }

--- a/packages/scandipwa/src/component/StoreInPickUpPopup/StoreInPickUpPopup.component.js
+++ b/packages/scandipwa/src/component/StoreInPickUpPopup/StoreInPickUpPopup.component.js
@@ -153,7 +153,7 @@ export class StoreInPickUpPopupComponent extends PureComponent {
         return (
             <Popup
               id={ STORE_IN_PICK_UP_POPUP_ID }
-              clickOutside={ false }
+              isCloseOnOutsideClick={ false }
               mix={ { block: 'StoreInPickUpPopup' } }
             >
                 { this.renderContent() }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4870

**Problem:**
* `clickOutside` prop not working, because it was missing in `containerProps`

**In this PR:**
* Added missing prop
