### PR TITLE
TypeScript issue with cart price rounding

### DIFF
--- a/packages/scandipwa/src/component/CartItem/CartItem.component.tsx
+++ b/packages/scandipwa/src/component/CartItem/CartItem.component.tsx
@@ -349,7 +349,7 @@ export class CartItem extends PureComponent<CartItemComponentProps> {
 
         return (
             <CartItemPrice
-              row_total={ Number(row_total || 0).toFixed(2) }
+              row_total={ row_total }
               row_total_incl_tax={ row_total_incl_tax }
               currency_code={ currency_code }
               mix={ {


### PR DESCRIPTION
**Problem:**
* Error appears on cart item when trying to make `toFixed()` on string. It happens because in higher component price prop is parsed to string by `toFixed()`. 

**In this PR:**
* Remove redundant usage of `toFixed()` in parent component for CartItemPrice
