### PR TITLE
issue-5245 - Adjust description text break for category description

### DIFF
--- a/packages/scandipwa/src/component/CategoryDetails/CategoryDetails.style.scss
+++ b/packages/scandipwa/src/component/CategoryDetails/CategoryDetails.style.scss
@@ -49,6 +49,7 @@
         justify-content: center;
         font-size: 14px;
         font-weight: 400;
+        word-break: break-all;
 
         ul,
         ol {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #5245 

