### PR TITLE
5301 Added required options check to compare page

### DIFF
--- a/packages/scandipwa/i18n/da_DK.json
+++ b/packages/scandipwa/i18n/da_DK.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/de_DE.json
+++ b/packages/scandipwa/i18n/de_DE.json
@@ -136,7 +136,6 @@
     "Play video": null,
     "Play video %s": null,
     "Please, select product options!": null,
-    "Please, select required options!": null,
     "Please sign in first!": null,
     "Please sign-in to complete checkout!": null,
     "Please, try removing selected filters and try again!": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/en_US.json
+++ b/packages/scandipwa/i18n/en_US.json
@@ -173,7 +173,6 @@
     "Got it": null,
     "Incorrect data! Please resolve all field validation errors.": null,
     "Please, select product options!": null,
-    "Please, select required options!": null,
     "You must login or register to review products.": null,
     "Edit address": null,
     "Confirm delete": null,

--- a/packages/scandipwa/i18n/es_ES.json
+++ b/packages/scandipwa/i18n/es_ES.json
@@ -137,7 +137,6 @@
     "Play video": null,
     "Play video %s": null,
     "Please, select product options!": null,
-    "Please, select required options!": null,
     "Please sign in first!": null,
     "Please sign-in to complete checkout!": null,
     "Please, try removing selected filters and try again!": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/fa_IR.json
+++ b/packages/scandipwa/i18n/fa_IR.json
@@ -377,7 +377,6 @@
     "We could not preselect pickup location based on available information, please select it manually.": null,
     "Store": null,
     "Select store": null,
-    "Please, select required options!": null,
     "In stock": null,
     "SKU: %s": null,
     "Sorry! The product %s is out of stock!": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/fi_FI.json
+++ b/packages/scandipwa/i18n/fi_FI.json
@@ -172,7 +172,6 @@
     "Got it": "Selkis",
     "Incorrect data! Please resolve all field validation errors.": "Väärät tiedot! Korjaa kaikki kentän vahvistus virheet.",
     "Please, select product options!": "Valitse tuotevaihtoehdot!",
-    "Please, select required options!": "Valitse vaadittu vaihtoehto!",
     "You must login or register to review products.": "Sinun on kirjauduttava sisään tai rekisteröidyttävä tarkistamaan tuotteita.",
     "Edit address": "Muokkaa osoitetta",
     "Confirm delete": "Vahvista poistaminen",
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/fr_FR.json
+++ b/packages/scandipwa/i18n/fr_FR.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/it_IT.json
+++ b/packages/scandipwa/i18n/it_IT.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/lv_LV.json
+++ b/packages/scandipwa/i18n/lv_LV.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/nb_NO.json
+++ b/packages/scandipwa/i18n/nb_NO.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/nl_NL.json
+++ b/packages/scandipwa/i18n/nl_NL.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/pl_PL.json
+++ b/packages/scandipwa/i18n/pl_PL.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/pt_BR.json
+++ b/packages/scandipwa/i18n/pt_BR.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/ru_RU.json
+++ b/packages/scandipwa/i18n/ru_RU.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/sl_SI.json
+++ b/packages/scandipwa/i18n/sl_SI.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/sv_SE.json
+++ b/packages/scandipwa/i18n/sv_SE.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/tr_TR.json
+++ b/packages/scandipwa/i18n/tr_TR.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/i18n/zh_TW.json
+++ b/packages/scandipwa/i18n/zh_TW.json
@@ -390,7 +390,6 @@
     "1 filter selected": null,
     "Thank you for your subscription.": null,
     "Excl. tax:": null,
-    "Please, select required options!": null,
     "Product compare": null,
     "Enter your password": null,
     "Your Tax/VAT Number": null,
@@ -609,5 +608,6 @@
     "County": null,
     "State/Province": null,
     "Region": null,
-    "You %s the address": null
+    "You %s the address": null,
+    "You need to choose options for your item.": null
 }

--- a/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.type.ts
+++ b/packages/scandipwa/src/component/ProductCompareItem/ProductCompareItem.type.ts
@@ -46,7 +46,7 @@ export type ProductCompareItemContainerProps = ProductCompareItemContainerMapSta
 
 export interface ProductCompareItemContainerState {
     isLoading: boolean;
-    currentQty: number | Record<number, number>;
+    overrideAddToCartBtnBehavior: boolean;
 }
 
 export interface ProductCompareItemComponentProps extends ProductCompareItemContainerFunctions {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5301

**Problem:**
* User could not add products with required config options to cart from compare page and the error notification was popping up.

**In this PR:**
* Added check for required config and downloadable links options.
* Also fixed zero product quantity on compare page.
