### PR TITLE
5197 Added redirect to order history

### DIFF
--- a/packages/scandipwa/src/component/MyAccountOrder/MyAccountOrder.container.tsx
+++ b/packages/scandipwa/src/component/MyAccountOrder/MyAccountOrder.container.tsx
@@ -93,6 +93,8 @@ State extends MyAccountOrderContainerState = MyAccountOrderContainerState,
 
         if (orderId) {
             this.requestOrderDetails(orderId);
+        } else {
+            history.replace(appendWithStoreCode(`${AccountPageUrl.ORDER_HISTORY}`));
         }
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes [5197 Never-ending loader appears when opening order page without order id](https://github.com/scandipwa/scandipwa/issues/5197)

**In this PR:**
* Added redirect to order history when opening order page without order ID.
