### PR TITLE
5324 Changed configurable product PDP image logic

### DIFF
--- a/packages/scandipwa/src/component/Product/Product.container.tsx
+++ b/packages/scandipwa/src/component/Product/Product.container.tsx
@@ -511,13 +511,10 @@ S extends ProductContainerState = ProductContainerState,
 
         this.setState({ parameters });
 
-        const { product: { variants = [], configurable_options = {} } } = this.props;
+        const { product: { variants = [] } } = this.props;
         const { selectedProduct } = this.state;
 
-        const newIndex = Object.keys(parameters).length === Object.keys(configurable_options).length
-            ? getVariantIndex(variants, parameters)
-            // Not all parameters are selected yet, therefore variantIndex must be invalid
-            : -1;
+        const newIndex = getVariantIndex(variants, parameters);
 
         const newProduct = newIndex === -1 ? null : variants[ newIndex ];
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #5324 

**Problem:**
* Configurable product image updating logic was different from Luma theme.

**In this PR:**
* Changed logic so now image is updated when any configurable option changes, the image also changes (before you had to set all options).
