### PR TITLE
Fixed category page placeholders

### DIFF
--- a/packages/scandipwa/src/query/Menu.query.ts
+++ b/packages/scandipwa/src/query/Menu.query.ts
@@ -11,6 +11,8 @@
 
 import { Field, Query } from '@tilework/opus';
 
+import { CategoryDisplayMode } from 'Route/CategoryPage/CategoryPage.config';
+
 import { MenuItem } from './Menu.type';
 /**
  * Menu Query
@@ -35,6 +37,7 @@ export class MenuQuery {
     | Field<'position', number>
     | Field<'parent_id', number>
     | Field<'category_id', number>
+    | Field<'display_mode', CategoryDisplayMode>
     > {
         return [
             new Field<'url', string>('url'),
@@ -43,6 +46,7 @@ export class MenuQuery {
             new Field<'position', number>('position'),
             new Field<'parent_id', number>('parent_id'),
             new Field<'category_id', number>('category_id'),
+            new Field<'display_mode', CategoryDisplayMode>('display_mode'),
         ];
     }
 }

--- a/packages/scandipwa/src/query/Menu.type.ts
+++ b/packages/scandipwa/src/query/Menu.type.ts
@@ -9,6 +9,8 @@
  * @link https://github.com/scandipwa/scandipwa
  */
 
+import { CategoryDisplayMode } from 'Route/CategoryPage/CategoryPage.config';
+
 export interface MenuItem {
     url: string;
     title: string;
@@ -16,4 +18,5 @@ export interface MenuItem {
     position: number;
     parent_id: number;
     category_id: number;
+    display_mode: CategoryDisplayMode;
 }

--- a/packages/scandipwa/src/query/UrlRewrites.query.ts
+++ b/packages/scandipwa/src/query/UrlRewrites.query.ts
@@ -10,6 +10,7 @@
  */
 import { Field, Query } from '@tilework/opus';
 
+import { CategoryDisplayMode } from 'Route/CategoryPage/CategoryPage.config';
 import { GQLUrlRewriteEntityTypeEnum } from 'Type/Graphql.type';
 
 import {
@@ -26,6 +27,7 @@ export class UrlRewritesQuery {
         sku: string;
         type: GQLUrlRewriteEntityTypeEnum;
         id: number;
+        display_mode: CategoryDisplayMode;
     }> {
         return new Query<'urlResolver', UrlRewritesOutput>('urlResolver')
             .addArgument('url', 'String!', urlParam)
@@ -36,11 +38,13 @@ export class UrlRewritesQuery {
     Field<'sku', string>
     | Field<'type', GQLUrlRewriteEntityTypeEnum>
     | Field<'id', number>
+    | Field<'display_mode', CategoryDisplayMode>
     > {
         return [
             new Field<'sku', string>('sku'),
             new Field<'type', GQLUrlRewriteEntityTypeEnum>('type'),
             new Field<'id', number>('id'),
+            new Field<'display_mode', CategoryDisplayMode>('display_mode'),
         ];
     }
 }

--- a/packages/scandipwa/src/query/UrlRewrites.type.ts
+++ b/packages/scandipwa/src/query/UrlRewrites.type.ts
@@ -9,12 +9,14 @@
  * @link https://github.com/scandipwa/scandipwa
  */
 
+import { CategoryDisplayMode } from 'Route/CategoryPage/CategoryPage.config';
 import { GQLUrlRewriteEntityTypeEnum } from 'Type/Graphql.type';
 
 export interface UrlRewritesOutput {
     sku: string;
     type: GQLUrlRewriteEntityTypeEnum;
     id: number;
+    display_mode: CategoryDisplayMode;
 }
 
 export interface UrlRewritesQueryOptions {

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.tsx
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.component.tsx
@@ -93,15 +93,11 @@ S extends CategoryPageComponentState = CategoryPageComponentState,
     }
 
     displayProducts() {
-        const {
-            category: {
-                display_mode = CategoryDisplayMode.PRODUCTS,
-            } = {},
-        } = this.props;
+        const { displayMode } = this.props;
 
-        return display_mode === null
-            || display_mode === CategoryDisplayMode.PRODUCTS
-            || display_mode === CategoryDisplayMode.BOTH;
+        return displayMode === null
+            || displayMode === CategoryDisplayMode.PRODUCTS
+            || displayMode === CategoryDisplayMode.BOTH;
     }
 
     displayCmsBlock(): boolean {

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.tsx
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.tsx
@@ -20,11 +20,6 @@ import {
     FilterPriceRange,
     ProductAttributeFilterOptions,
 } from 'Query/ProductList.type';
-import {
-    CategoryPageLayout,
-    LAYOUT_KEY,
-    SortDirections,
-} from 'Route/CategoryPage/CategoryPage.config';
 import { updateCurrentCategory } from 'Store/Category/Category.action';
 import CategoryReducer from 'Store/Category/Category.reducer';
 import { changeNavigationState } from 'Store/Navigation/Navigation.action';
@@ -47,7 +42,13 @@ import {
 } from 'Util/Url';
 
 import CategoryPage from './CategoryPage.component';
-import { LOADING_TIME } from './CategoryPage.config';
+import {
+    CategoryDisplayMode,
+    CategoryPageLayout,
+    LAYOUT_KEY,
+    LOADING_TIME,
+    SortDirections,
+} from './CategoryPage.config';
 import {
     CategoryPageComponentProps,
     CategoryPageContainerFunctions,
@@ -141,6 +142,7 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
         currentArgs: {},
         selectedInfoFilter: {},
         plpType: '',
+        displayMode: CategoryDisplayMode.PRODUCTS,
     };
 
     config = {
@@ -425,6 +427,7 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
             totalPages,
             totalItems,
             isSearchPage,
+            displayMode,
         } = this.props;
 
         const {
@@ -452,6 +455,7 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
             totalItems,
             selectedLayoutType,
             activeLayoutType,
+            displayMode,
         };
     }
 

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.type.ts
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.type.ts
@@ -25,7 +25,11 @@ import { NavigationState } from 'Store/Navigation/Navigation.type';
 import { ProductListFilter } from 'Store/ProductListInfo/ProductListInfo.type';
 import { HistoryState } from 'Util/History/History.type';
 
-import { CategoryPageLayout, SortDirections } from './CategoryPage.config';
+import {
+    CategoryDisplayMode,
+    CategoryPageLayout,
+    SortDirections,
+} from './CategoryPage.config';
 
 export interface CategoryPageContainerMapStateProps {
     category: Partial<Category>;
@@ -69,6 +73,7 @@ export interface CategoryPageContainerBaseProps {
     match: Match;
     categoryIds: number;
     isSearchPage: boolean;
+    displayMode: CategoryDisplayMode;
 }
 
 export type CategoryPageContainerProps = CategoryPageContainerMapStateProps
@@ -105,6 +110,7 @@ export interface CategoryPageComponentProps extends CategoryPageContainerFunctio
     totalItems: number;
     selectedLayoutType?: CategoryPageLayout;
     activeLayoutType?: CategoryPageLayout;
+    displayMode: CategoryDisplayMode;
 }
 
 export interface CategoryPageComponentState {
@@ -130,7 +136,8 @@ export type CategoryPageContainerPropsKeys =
     | 'totalPages'
     | 'totalItems'
     | 'selectedLayoutType'
-    | 'activeLayoutType';
+    | 'activeLayoutType'
+    | 'displayMode';
 
 export interface CategoryUrlParams {
     customFilters: string;

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.tsx
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.tsx
@@ -87,12 +87,14 @@ export class UrlRewritesComponent extends PureComponent<UrlRewritesComponentProp
         const {
             match,
             categoryIds,
+            displayMode,
         } = props;
 
         return (
             <CategoryPage
               match={ match }
               categoryIds={ categoryIds }
+              displayMode={ displayMode }
             />
         );
     }

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.tsx
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.tsx
@@ -162,14 +162,22 @@ export class UrlRewritesContainer extends PureComponent<UrlRewritesContainerProp
                  */
             if (isLoading) {
                 // TODO: history.state.state looks like undefined all the time.
-                const category = history?.location?.state?.category;
-                const displayMode = history?.location?.state?.displayMode;
+                if (history) {
+                    const {
+                        location: {
+                            state: {
+                                category,
+                                displayMode,
+                            } = {},
+                        } = {},
+                    } = history;
 
-                if (category && category !== true) {
-                    return {
-                        categoryIds: category,
-                        displayMode,
-                    };
+                    if (category && category !== true) {
+                        return {
+                            categoryIds: category,
+                            displayMode,
+                        };
+                    }
                 }
 
                 return {};

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.tsx
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.tsx
@@ -121,6 +121,7 @@ export class UrlRewritesContainer extends PureComponent<UrlRewritesContainerProp
             urlRewrite: {
                 id,
                 sku,
+                display_mode,
             },
         } = this.props;
 
@@ -162,15 +163,22 @@ export class UrlRewritesContainer extends PureComponent<UrlRewritesContainerProp
             if (isLoading) {
                 // TODO: history.state.state looks like undefined all the time.
                 const category = history?.location?.state?.category;
+                const displayMode = history?.location?.state?.displayMode;
 
                 if (category && category !== true) {
-                    return { categoryIds: category };
+                    return {
+                        categoryIds: category,
+                        displayMode,
+                    };
                 }
 
                 return {};
             }
 
-            return { categoryIds: id };
+            return {
+                categoryIds: id,
+                displayMode: display_mode,
+            };
         case UrlRewritePageType.NOTFOUND:
         default:
             return {};

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.type.ts
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.type.ts
@@ -11,6 +11,7 @@
 
 import { match as Match } from 'react-router';
 
+import { CategoryDisplayMode } from 'Route/CategoryPage/CategoryPage.config';
 import { UrlRewrite } from 'Store/UrlRewrites/UrlRewrites.type';
 
 export interface UrlRewritesContainerMapStateProps {
@@ -47,4 +48,5 @@ export interface UrlRewriteTypeSpecificProps {
     isOnlyPlaceholder: boolean;
     pageIds: number;
     categoryIds: number;
+    displayMode: CategoryDisplayMode;
 }

--- a/packages/scandipwa/src/util/History/History.type.ts
+++ b/packages/scandipwa/src/util/History/History.type.ts
@@ -9,6 +9,7 @@
  * @link https://github.com/scandipwa/scandipwa
  */
 
+import { CategoryDisplayMode } from 'Route/CategoryPage/CategoryPage.config';
 import { IndexedProduct } from 'Util/Product/Product.type';
 
 export interface HistoryState {
@@ -26,4 +27,5 @@ export interface HistoryState {
     lastName?: string;
     email?: string;
     overlayOpen?: boolean;
+    displayMode?: CategoryDisplayMode;
 }

--- a/packages/scandipwa/src/util/Menu/Menu.ts
+++ b/packages/scandipwa/src/util/Menu/Menu.ts
@@ -35,23 +35,31 @@ export class Menu {
     menuPositionReference: Record<string, number[]> = {};
 
     getMenuUrl(
-        { url, category_id }: Pick<MenuItem, 'url' | 'category_id'>,
+        { url, category_id, display_mode }: Pick<
+        MenuItem,
+        'url'
+        | 'category_id'
+        | 'display_mode'>,
     ): MenuLocation | string {
         return {
             pathname: getUrlPathname(url),
             search: '',
-            state: { category: category_id },
+            state: {
+                category: category_id,
+                displayMode: display_mode,
+            },
         };
     }
 
     getMenuData({
         url,
         category_id,
+        display_mode,
         ...item
     }: MenuItem): FormattedMenuItem {
         return {
             ...item,
-            url: this.getMenuUrl({ url, category_id }),
+            url: this.getMenuUrl({ url, category_id, display_mode }),
             children: {},
         };
     }

--- a/packages/scandipwa/src/util/Menu/Menu.type.ts
+++ b/packages/scandipwa/src/util/Menu/Menu.type.ts
@@ -10,6 +10,7 @@
  */
 
 import { MenuItem } from 'Query/Menu.type';
+import { CategoryDisplayMode } from 'Route/CategoryPage/CategoryPage.config';
 import { Merge } from 'Type/Common.type';
 
 export interface MenuLocation {
@@ -18,11 +19,12 @@ export interface MenuLocation {
     state: {
         category?: number;
         page?: boolean;
+        displayMode?: CategoryDisplayMode;
     };
 }
 
 export type FormattedMenuItem = Merge<
-Omit<MenuItem, 'cms_page_identifier' | 'url_type' | 'category_id' >,
+Omit<MenuItem, 'cms_page_identifier' | 'url_type' | 'category_id' | 'display_mode'>,
 {
     url: MenuLocation | string;
     children: Record<string, FormattedMenuItem>;


### PR DESCRIPTION
Fixes #5334.

Issue: category page was showing incorrect placeholders for static content only.

In this PR: added displayMode to menu items to load correct placeholders.