### PR TITLE
Added storeCurrency to window

### DIFF
--- a/packages/m2-theme/public/index.php
+++ b/packages/m2-theme/public/index.php
@@ -39,6 +39,7 @@ $icons = $this->getAppIconData();
             type: `<?= $this->getAction(); ?>`
         };
         window.contentConfiguration = <?= json_encode($contentConfig) ?> || {};
+        window.storeCurrency = '<?= $this->getStoreCurrency() ?>';
 
         // Multistore
         // do reverse sort in order prevent an issue like store code `en` replaces store code `en_us`

--- a/packages/scandipwa/src/type/Global.type.ts
+++ b/packages/scandipwa/src/type/Global.type.ts
@@ -30,6 +30,7 @@ declare global {
         contentConfiguration?: ContentConfiguration;
         prompt_event?: BeforeInstallPromptEvent;
         website_code: string;
+        storeCurrency: string;
     }
 
     interface BeforeInstallPromptEvent extends Event {

--- a/packages/scandipwa/src/util/Currency/Currency.ts
+++ b/packages/scandipwa/src/util/Currency/Currency.ts
@@ -10,7 +10,6 @@
  */
 
 import { Currencies, CurrencyData } from 'Query/Config.type';
-import { GQLCurrencyEnum } from 'Type/Graphql.type';
 import BrowserDatabase from 'Util/BrowserDatabase';
 import getStore from 'Util/Store';
 import { RootState } from 'Util/Store/Store.type';
@@ -46,7 +45,7 @@ export const getCurrency = (): string => {
 
     const {
         ConfigReducer: {
-            default_display_currency_code = GQLCurrencyEnum.USD,
+            default_display_currency_code = window.storeCurrency,
         } = {},
     } = store.getState() as RootState;
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes #5355.

**Problem:**
* If USD was removed from allowed store currencies, user could see an error on the first website load.

**In this PR:**
* [Added current store currency to window variables](https://github.com/scandipwa/customization/pull/34).
* Used default currency from window variables.