### PR TITLE
5354 Added option to use global default sort by on PLP

### DIFF
--- a/packages/scandipwa/src/query/Config.query.ts
+++ b/packages/scandipwa/src/query/Config.query.ts
@@ -214,6 +214,7 @@ export class ConfigQuery {
             new Field<'downloadable_disable_guest_checkout', boolean>('downloadable_disable_guest_checkout'),
             new Field<'minimun_password_length', number>('minimun_password_length'),
             new Field<'required_character_classes_number', string>('required_character_classes_number'),
+            new Field<'catalog_default_sort_by', string>('catalog_default_sort_by'),
             ...this._getTimeDateFormatFields(),
             this._getPriceDisplayTypeField(),
         ];

--- a/packages/scandipwa/src/query/Config.type.ts
+++ b/packages/scandipwa/src/query/Config.type.ts
@@ -81,6 +81,7 @@ Field<'code', string>
 | Field<'date_fields_order', string>
 | Field<'time_format', string>
 | Field<'priceTaxDisplay', PriceTaxDisplay>
+| Field<'catalog_default_sort_by', string>
 >;
 
 export interface StoreConfig {
@@ -146,6 +147,7 @@ export interface StoreConfig {
     date_fields_order: string;
     time_format: string;
     priceTaxDisplay: PriceTaxDisplay;
+    catalog_default_sort_by: string;
 }
 
 export interface StoreItem {

--- a/packages/scandipwa/src/query/ProductList.query.ts
+++ b/packages/scandipwa/src/query/ProductList.query.ts
@@ -200,7 +200,7 @@ export class ProductListQuery {
                 handler: <SortKey extends string>(
                     { sortKey, sortDirection }: { sortKey: SortKey; sortDirection: SortDirections },
                 ): Partial<Record<SortKey, SortDirections>> => {
-                    if (sortKey === NONE_SORT_OPTION_VALUE) {
+                    if (!sortKey || sortKey === NONE_SORT_OPTION_VALUE) {
                         return {};
                     }
 

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.tsx
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.tsx
@@ -98,6 +98,7 @@ export const mapStateToProps = (state: RootState): CategoryPageContainerMapState
     totalItems: state.ProductListReducer.totalItems,
     plpType: state.ConfigReducer.plp_list_mode,
     isMobile: state.ConfigReducer.device.isMobile,
+    defaultSortKey: state.ConfigReducer.catalog_default_sort_by,
 });
 
 /** @namespace Route/CategoryPage/Container/mapDispatchToProps */
@@ -494,11 +495,15 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
             category: {
                 default_sort_by,
             },
+            sortFields: {
+                options = [],
+            },
+            defaultSortKey: globalDefaultSortKey,
         } = this.props;
         const { location } = history;
 
         const {
-            sortKey: globalDefaultSortKey,
+            sortKey: classDefaultSortKey,
             sortDirection: defaultSortDirection,
         } = this.config;
 
@@ -506,7 +511,7 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
          * Default SORT DIRECTION is taken from (sequentially):
          * - URL param "sortDirection"
          * - CategoryPage class property "config"
-         * */
+         */
         const sortDirection: SortDirections = (getQueryParam('sortDirection', location) as SortDirections)
             || defaultSortDirection;
 
@@ -514,10 +519,20 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
          * Default SORT KEY is taken from (sequentially):
          * - URL param "sortKey"
          * - Category default sort key (Magento 2 configuration)
+         * - Product Listing Sort By (Magento 2 configuration)
          * - CategoryPage class property "config"
-         * */
-        const defaultSortKey = default_sort_by || globalDefaultSortKey;
-        const sortKey = getQueryParam('sortKey', location) || defaultSortKey;
+         * (used when global default sort key does not exist for current category)
+         */
+        const isGlobalSortKeyAvailable = !!options.find(
+            (sortOption) => sortOption.value === globalDefaultSortKey,
+        );
+        const isClassSortKeyAvailable = !!options.find(
+            (sortOption) => sortOption.value === classDefaultSortKey,
+        );
+        const fallbackSortKey = isClassSortKeyAvailable ? classDefaultSortKey : options[0]?.value;
+        const defaultSortKey = isGlobalSortKeyAvailable ? globalDefaultSortKey : fallbackSortKey;
+        const configSortKey = default_sort_by || defaultSortKey;
+        const sortKey = getQueryParam('sortKey', location) || configSortKey;
 
         return {
             sortDirection,

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.type.ts
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.type.ts
@@ -32,7 +32,6 @@ export interface CategoryPageContainerMapStateProps {
     isOffline: boolean;
     filters: Record<string, ProductListFilter>;
     sortFields: Partial<SortFields>;
-
     currentArgs: ProductListOptionArgs;
     selectedInfoFilter: Partial<ProductAttributeFilterOptions>;
     isInfoLoading: boolean;
@@ -40,6 +39,7 @@ export interface CategoryPageContainerMapStateProps {
     totalItems: number;
     plpType: string;
     isMobile: boolean;
+    defaultSortKey: string;
 }
 
 export interface CategoryPageContainerMapDispatchProps {


### PR DESCRIPTION
**Related issue(s):**
* Fixes #5354.

**Problem:**
* PLP didn't use default global sort by if category default sort was not defined.

**In this PR:**
* Used global default sort by for categories without defined sort by.
