### PR TITLE
Fixed incorrect `shippingMethod` reference in `CheckoutShipping.container`

### DIFF
--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.tsx
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.tsx
@@ -283,7 +283,7 @@ CheckoutShippingContainerState
         };
 
         saveAddressInformation(data);
-        const shippingMethod = `${shipping_carrier_code}_${shipping_method_code}`;
+        const shipping_method = `${shipping_carrier_code}_${shipping_method_code}`;
         const { street = [] } = formattedFields;
 
         updateShippingFields({
@@ -294,7 +294,7 @@ CheckoutShippingContainerState
                     && parseInt(default_shipping, 10) === data.shipping_address.id)
                     ? formattedFields : data.shipping_address
             ),
-            shippingMethod,
+            shipping_method,
         });
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5359

**Problem:**
* `shippingMethod` was saved instead of `shipping_method`, so `shipping_method` would always be undefined in `Checkout.container`

**In this PR:**
* renamed variable
