### PR TITLE
Performance jumping header and breadcrumbs fix

### DIFF
--- a/packages/scandipwa/src/component/Breadcrumbs/Breadcrumbs.style.scss
+++ b/packages/scandipwa/src/component/Breadcrumbs/Breadcrumbs.style.scss
@@ -10,7 +10,6 @@
  */
 
 :root {
-    --breadcrumbs-height: 40px;
     --breadcrumbs-active-color: #0a0903;
     --breadcrumbs-color: #888;
 }
@@ -19,10 +18,13 @@
     $crumb-padding: 11px;
     $arrow-size: 4px;
 
+    height: var(--breadcrumbs-height);
+
     @include mobile {
         --breadcrumbs-background: #fff;
 
         display: none;
+        height: 0;
     }
 
     &-List {

--- a/packages/scandipwa/src/component/DemoNotice/DemoNotice.style.scss
+++ b/packages/scandipwa/src/component/DemoNotice/DemoNotice.style.scss
@@ -9,11 +9,6 @@
  * @link https://github.com/scandipwa/scandipwa
  */
 
-:root {
-    /* stylelint-disable-next-line length-zero-no-unit */
-    --demo-notice-height: 0px;
-}
-
 .DemoNotice {
     padding-block-start: env(safe-area-inset-top);
     align-items: center;

--- a/packages/scandipwa/src/component/Header/Header.style.scss
+++ b/packages/scandipwa/src/component/Header/Header.style.scss
@@ -12,15 +12,6 @@
 :root {
     --header-logo-width: 194px;
     --header-logo-height: 24px;
-
-    --header-height: 60px;
-    --header-nav-height: 60px;
-    --header-total-height: calc(var(--header-height) + var(--offline-notice-height) + var(--demo-notice-height) + env(safe-area-inset-top));
-
-    @include desktop {
-        --header-top-menu-height: 32px;
-        --header-height: calc(var(--header-nav-height) + var(--header-top-menu-height) + var(--menu-total-height));
-    }
 }
 
 @mixin button-invisible {

--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -11,7 +11,6 @@
 
 :root {
     --menu-item-height: 20px;
-    --menu-total-height: 53px;
 }
 
 @mixin subcategory-visible {

--- a/packages/scandipwa/src/component/OfflineNotice/OfflineNotice.style.scss
+++ b/packages/scandipwa/src/component/OfflineNotice/OfflineNotice.style.scss
@@ -11,8 +11,6 @@
 
 :root {
     --diameter: 1;
-    /* stylelint-disable-next-line length-zero-no-unit */
-    --offline-notice-height: 0px;
     --offline-notice-display: none;
 }
 
@@ -141,7 +139,7 @@
                 width: calc(22px * var(--diameter));
                 height: calc(3px * var(--diameter));
                 inset-inline-start: calc(-1px * var(--diameter));
-            
+
                 [dir="rtl"] & {
                     // stylelint-disable-next-line csstools/use-logical
                     right: calc(-5px * var(--diameter));

--- a/packages/scandipwa/src/component/Router/Router.component.tsx
+++ b/packages/scandipwa/src/component/Router/Router.component.tsx
@@ -330,6 +330,15 @@ export class RouterComponent extends PureComponent<RouterComponentProps, RouterC
         this.setState({ hasError: false });
     }
 
+    renderBeforeItemsFallback(): ReactElement {
+        return (
+            <div block="Router">
+                <section block="Router" elem="HeaderFallback" />
+                <section block="Router" elem="BreadcrumbsFallback" />
+            </div>
+        );
+    }
+
     renderComponentsOfType(type: RouterItemType): ReactElement {
         return this.getSortedItems(type)
             .map(({ position, component }: RouterItem) => cloneElement(component, { key: position }));
@@ -337,7 +346,7 @@ export class RouterComponent extends PureComponent<RouterComponentProps, RouterC
 
     renderSectionOfType(type: RouterItemType): ReactElement {
         return (
-            <Suspense fallback={ this.renderFallbackPage() }>
+            <Suspense fallback={ this.renderBeforeItemsFallback() }>
                 { this.renderComponentsOfType(type) }
             </Suspense>
         );

--- a/packages/scandipwa/src/component/Router/Router.style.scss
+++ b/packages/scandipwa/src/component/Router/Router.style.scss
@@ -26,4 +26,17 @@
             inset-block-start: calc(var(--header-total-height) + 10px);
         }
     }
+
+    &-HeaderFallback {
+        height: var(--header-total-height);
+    }
+
+    &-BreadcrumbsFallback {
+        height: var(--breadcrumbs-height);
+
+        @include mobile {
+            height: 0;
+            display: none;
+        }
+    }
 }

--- a/packages/scandipwa/src/style/base/_root.scss
+++ b/packages/scandipwa/src/style/base/_root.scss
@@ -42,4 +42,20 @@
     --secondary-base-color: var(--imported_secondary_base_color, #{$default-secondary-base-color});
     --secondary-dark-color: var(--imported_secondary_dark_color, #{$default-secondary-dark-color});
     --secondary-light-color: var(--imported_secondary_light_color, #{$default-secondary-light-color});
+
+    // initial heights for the Header, it's elements, and Breadcrumbs
+    --breadcrumbs-height: 66px;
+
+    --offline-notice-height: 0px;
+    --demo-notice-height: 0px;
+    --menu-total-height: 54px;
+
+    --header-height: 60px;
+    --header-nav-height: 60px;
+    --header-total-height: calc(var(--header-height) + var(--offline-notice-height) + var(--demo-notice-height) + env(safe-area-inset-top));
+
+    @include desktop {
+        --header-top-menu-height: 32px;
+        --header-height: calc(var(--header-nav-height) + var(--header-top-menu-height) + var(--menu-total-height));
+    }
 }


### PR DESCRIPTION

**Problem:**
* Fixed jumping header on initial load

**In this PR:**
* Fallback for the BEFORE_ITEMS, which include a placeholder for the header and breadcrumbs, based on their total height
* Moved root variables to the root.scss to have them available initially
* Removed duplicates of root variables
* Fixes for breadcrumbs height
