### PR TITLE
fixed the issue by adding validationEmail to checkout container and c…

### DIFF
--- a/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.tsx
+++ b/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.tsx
@@ -30,6 +30,7 @@ import { noopFn } from 'Util/Common';
 import scrollToError from 'Util/Form/Form';
 import { debounce, getErrorMessage } from 'Util/Request';
 import { RootState } from 'Util/Store/Store.type';
+import { validateEmail } from 'Util/Validator';
 import { ValidationDOMOutput } from 'Util/Validator/Validator.type';
 
 import CheckoutGuestForm from './CheckoutGuestForm.component';
@@ -207,12 +208,14 @@ CheckoutGuestFormContainerState
         const { onEmailChange } = this.props;
         const { value: email = '' } = field || {};
 
-        this.checkEmailAvailability(email);
+        if (validateEmail(email)){
+            this.checkEmailAvailability(email);
+        }
         onEmailChange(email);
 
         const { updateEmail, isEmailAvailable } = this.props;
 
-        if (isEmailAvailable) {
+        if (isEmailAvailable && validateEmail(email)) {
             updateEmail(email);
         }
     }

--- a/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.tsx
+++ b/packages/scandipwa/src/component/CheckoutGuestForm/CheckoutGuestForm.container.tsx
@@ -71,7 +71,7 @@ export const mapDispatchToProps = (dispatch: Dispatch): CheckoutGuestFormContain
     showErrorNotification: (error) => dispatch(showNotification(NotificationType.ERROR, getErrorMessage(error))),
     clearEmailStatus: () => dispatch(updateEmailAvailable(true)),
     checkEmailAvailability: (email) => CheckoutDispatcher.then(
-        ({ default: dispatcher }) => dispatcher.handleData(dispatch, email),
+        ({ default: dispatcher }) => dispatcher.requestEmailValidation(dispatch, email),
     ),
     updateEmail: (email) => dispatch(updateEmail(email)),
 });

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.tsx
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.tsx
@@ -47,6 +47,7 @@ import {
 import { ONE_MONTH_IN_SECONDS } from 'Util/Request/QueryDispatcher';
 import { RootState } from 'Util/Store/Store.type';
 import { appendWithStoreCode } from 'Util/Url';
+import { validateEmail } from 'Util/Validator';
 
 import Checkout from './Checkout.component';
 import {
@@ -254,7 +255,9 @@ export class CheckoutContainer extends PureComponent<CheckoutContainerProps, Che
         }
 
         if (email) {
-            this.checkEmailAvailability(email);
+            if (validateEmail(email)){
+                this.checkEmailAvailability(email);
+            }
         }
 
         updateMeta({ title: __('Checkout') });
@@ -350,7 +353,9 @@ export class CheckoutContainer extends PureComponent<CheckoutContainerProps, Che
         }
 
         if (email !== prevEmail) {
-            this.checkEmailAvailability(email);
+            if (validateEmail(email)){
+                this.checkEmailAvailability(email);
+            }
 
             if (email && isVisibleEmailRequired !== prevIsVisibleEmailRequired) {
                 this.onChangeEmailRequired();
@@ -358,7 +363,9 @@ export class CheckoutContainer extends PureComponent<CheckoutContainerProps, Che
         }
 
         if (!isEmailAvailable) {
-            updateEmail(email);
+            if (validateEmail(email)){
+                updateEmail(email);
+            }
         }
     }
 

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.tsx
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.tsx
@@ -131,7 +131,7 @@ export const mapDispatchToProps = (dispatch: Dispatch): CheckoutContainerDispatc
     updateShippingFields: (fields) => dispatch(updateShippingFields(fields)),
     updateEmail: (email) => dispatch(updateEmail(email)),
     checkEmailAvailability: (email) => CheckoutDispatcher.then(
-        ({ default: dispatcher }) => dispatcher.handleData(dispatch, email),
+        ({ default: dispatcher }) => dispatcher.requestEmailValidation(dispatch, email),
     ),
     updateShippingPrice: (data) => dispatch(updateShippingPrice(data)),
 });

--- a/packages/scandipwa/src/util/Validator/Validator.ts
+++ b/packages/scandipwa/src/util/Validator/Validator.ts
@@ -266,3 +266,6 @@ export const validatePassword = (
 
     return true;
 };
+
+/** @namespace Util/Validator/validateEmail */
+export const validateEmail = (email: string) => /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(email);


### PR DESCRIPTION
…heckoutGuestForm container

**Related issue(s):**
* https://github.com/scandipwa/scandipwa/issues/5010

**Problem:**
* 1- the problem was for the validation of email we were sending many requests to BE while we could first validate on FE and then send a validation request to BE.
* 2-the problem related to unnecessary caching in varnish.

**In this PR:**
* 1- I added a function named `validateEmail` to Util/Validator and used it in Route/checkout.container and Component/checkoutGuestForm.container. I put it as a condition to proceed for `checkEmailAvailability` and `updateEmail`. Still, we send 2 requests for each valid email address because we call `checkEmailAvailability ` both in the `checkout.container` and in the `checkoutGuestForm.container`. I don't know how to solve this problem safely. so I just leave it. now we don't send many requests on each email (valid or invalid) to BE.
* 2- for solving the cache problem I changed the checkout.dispatcher to use `executePost` function. I also changed parts of the code where the checkout.dispatcher was used. (it affects only two file `checkout.container` and `CheckoutGuestForm.container`.
