### PR TITLE
Checkout empty shipping fields fix

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -127,6 +127,6 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://scandipwapmrev.indvp.com/",
+    "proxy": "https://demo100-ors-1588667385-csa-hcx.scandipwa.cloud/",
     "gitHead": "187276597fcf17521bcccdac1238b4e0061e5418"
 }

--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -127,6 +127,6 @@
     "publishConfig": {
         "access": "public"
     },
-    "proxy": "https://demo100-ors-1588667385-csa-hcx.scandipwa.cloud/",
+    "proxy": "https://scandipwapmrev.indvp.com/",
     "gitHead": "187276597fcf17521bcccdac1238b4e0061e5418"
 }

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.tsx
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.tsx
@@ -20,7 +20,7 @@ import {
 import { StoreWithCountryId } from 'Component/StoreInPickUpPopup/StoreInPickUpPopup.type';
 import { ShippingMethod } from 'Query/Checkout.type';
 import { CheckoutAddress } from 'Route/Checkout/Checkout.type';
-import { updateShippingFields } from 'Store/Checkout/Checkout.action';
+import { updateShippingAddress, updateShippingFields } from 'Store/Checkout/Checkout.action';
 import { ReactElement } from 'Type/Common.type';
 import {
     trimCheckoutAddress,
@@ -283,9 +283,11 @@ CheckoutShippingContainerState
         };
 
         saveAddressInformation(data);
+
         const shipping_method = `${shipping_carrier_code}_${shipping_method_code}`;
         const { street = [] } = formattedFields;
 
+        updateShippingAddress(data);
         updateShippingFields({
             ...(
                 street.length

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.tsx
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.tsx
@@ -57,6 +57,7 @@ export const mapStateToProps = (state: RootState): CheckoutShippingContainerMapS
 /** @namespace Component/CheckoutShipping/Container/mapDispatchToProps */
 export const mapDispatchToProps = (dispatch: Dispatch): CheckoutShippingContainerMapDispatchProps => ({
     updateShippingFields: (fields) => dispatch(updateShippingFields(fields)),
+    updateShippingAddress: (fields) => dispatch(updateShippingAddress(fields)),
 });
 
 /** @namespace Component/CheckoutShipping/Container */
@@ -233,6 +234,7 @@ CheckoutShippingContainerState
         const {
             saveAddressInformation,
             updateShippingFields,
+            updateShippingAddress,
             addressLinesQty,
             selectedStoreAddress,
             customer: { default_shipping },
@@ -287,7 +289,7 @@ CheckoutShippingContainerState
         const shipping_method = `${shipping_carrier_code}_${shipping_method_code}`;
         const { street = [] } = formattedFields;
 
-        updateShippingAddress(data);
+        updateShippingAddress({ ...data.shipping_address });
         updateShippingFields({
             ...(
                 street.length

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.type.ts
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.type.ts
@@ -29,6 +29,7 @@ export interface CheckoutShippingContainerMapStateProps {
 
 export interface CheckoutShippingContainerMapDispatchProps {
     updateShippingFields: (fields: Record<string, unknown>) => void;
+    updateShippingAddress: (fields: Record<string, unknown>) => void;
 }
 
 export interface CheckoutShippingContainerFunctions {

--- a/packages/scandipwa/src/route/Checkout/Checkout.config.ts
+++ b/packages/scandipwa/src/route/Checkout/Checkout.config.ts
@@ -35,3 +35,4 @@ export const PAYMENT_TOTALS = 'PAYMENT_TOTALS';
 
 export const UPDATE_EMAIL_CHECK_FREQUENCY = 1500; // ms
 export const UPDATE_SHIPPING_COST_ESTIMATES_FREQUENCY = 800; // ms
+export const SHIPPING_ADDRESS = 'shippingAddress';

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.tsx
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.tsx
@@ -292,7 +292,12 @@ export class CheckoutContainer extends PureComponent<CheckoutContainerProps, Che
             isCartLoading: prevIsCartLoading,
         } = prevProps;
 
-        const { email, checkoutStep, isVisibleEmailRequired } = this.state;
+        const {
+            email,
+            checkoutStep,
+            isVisibleEmailRequired,
+            shippingAddress,
+        } = this.state;
         const { email: prevEmail, isVisibleEmailRequired: prevIsVisibleEmailRequired } = prevState;
         const { location: { pathname = '' } } = history;
 
@@ -347,6 +352,14 @@ export class CheckoutContainer extends PureComponent<CheckoutContainerProps, Che
         )) {
             BrowserDatabase.deleteItem(PAYMENT_TOTALS);
             history.push(appendWithStoreCode(CART_URL));
+        }
+
+        if (
+            urlStep.includes(CheckoutUrlSteps.BILLING_URL_STEP)
+            && prevUrlStep.includes(CheckoutUrlSteps.BILLING_URL_STEP)
+            && !shippingAddress
+        ) {
+            this.saveShippingFieldsAsShippingAddress(shippingFields, !!is_virtual);
         }
 
         if (email !== prevEmail) {

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.tsx
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.tsx
@@ -55,6 +55,7 @@ import {
     CheckoutStepUrl,
     CheckoutUrlSteps,
     PAYMENT_TOTALS,
+    SHIPPING_ADDRESS,
     UPDATE_EMAIL_CHECK_FREQUENCY,
     UPDATE_SHIPPING_COST_ESTIMATES_FREQUENCY,
 } from './Checkout.config';
@@ -100,7 +101,7 @@ export const mapStateToProps = (state: RootState): CheckoutContainerMapStateProp
     savedEmail: state.CheckoutReducer.email,
     isSignedIn: state.MyAccountReducer.isSignedIn,
     shippingFields: state.CheckoutReducer.shippingFields,
-    shippingAddress: state.CheckoutReducer.shippingAddress,
+    formattedShippingAddress: state.CheckoutReducer.shippingAddress,
     minimumOrderAmount: state.CartReducer.cartTotals.minimum_order_amount,
 });
 
@@ -274,7 +275,7 @@ export class CheckoutContainer extends PureComponent<CheckoutContainerProps, Che
             isEmailAvailable,
             updateEmail,
             isCartLoading,
-            shippingAddress: formatedShippingFields,
+            formattedShippingAddress,
             shippingFields: {
                 shipping_method,
             },
@@ -329,7 +330,7 @@ export class CheckoutContainer extends PureComponent<CheckoutContainerProps, Che
                 this.setState({ checkoutStep: CheckoutSteps.SHIPPING_STEP });
             }
 
-            this.saveShippingFieldsAsShippingAddress(formatedShippingFields, !!is_virtual);
+            this.saveShippingFieldsAsShippingAddress(formattedShippingAddress, !!is_virtual);
         }
 
         // Handle going back from billing to shipping
@@ -356,11 +357,18 @@ export class CheckoutContainer extends PureComponent<CheckoutContainerProps, Che
         }
 
         if (
+            urlStep.includes(CheckoutUrlSteps.DETAILS_URL_STEP)
+            && prevUrlStep.includes(CheckoutUrlSteps.BILLING_URL_STEP)
+        ) {
+            BrowserDatabase.deleteItem(SHIPPING_ADDRESS);
+        }
+
+        if (
             urlStep.includes(CheckoutUrlSteps.BILLING_URL_STEP)
             && prevUrlStep.includes(CheckoutUrlSteps.BILLING_URL_STEP)
             && !shippingAddress
         ) {
-            this.saveShippingFieldsAsShippingAddress(formatedShippingFields, !!is_virtual);
+            this.saveShippingFieldsAsShippingAddress(formattedShippingAddress, !!is_virtual);
         }
 
         if (email !== prevEmail) {

--- a/packages/scandipwa/src/route/Checkout/Checkout.container.tsx
+++ b/packages/scandipwa/src/route/Checkout/Checkout.container.tsx
@@ -100,6 +100,7 @@ export const mapStateToProps = (state: RootState): CheckoutContainerMapStateProp
     savedEmail: state.CheckoutReducer.email,
     isSignedIn: state.MyAccountReducer.isSignedIn,
     shippingFields: state.CheckoutReducer.shippingFields,
+    shippingAddress: state.CheckoutReducer.shippingAddress,
     minimumOrderAmount: state.CartReducer.cartTotals.minimum_order_amount,
 });
 
@@ -273,7 +274,7 @@ export class CheckoutContainer extends PureComponent<CheckoutContainerProps, Che
             isEmailAvailable,
             updateEmail,
             isCartLoading,
-            shippingFields,
+            shippingAddress: formatedShippingFields,
             shippingFields: {
                 shipping_method,
             },
@@ -328,7 +329,7 @@ export class CheckoutContainer extends PureComponent<CheckoutContainerProps, Che
                 this.setState({ checkoutStep: CheckoutSteps.SHIPPING_STEP });
             }
 
-            this.saveShippingFieldsAsShippingAddress(shippingFields, !!is_virtual);
+            this.saveShippingFieldsAsShippingAddress(formatedShippingFields, !!is_virtual);
         }
 
         // Handle going back from billing to shipping
@@ -359,7 +360,7 @@ export class CheckoutContainer extends PureComponent<CheckoutContainerProps, Che
             && prevUrlStep.includes(CheckoutUrlSteps.BILLING_URL_STEP)
             && !shippingAddress
         ) {
-            this.saveShippingFieldsAsShippingAddress(shippingFields, !!is_virtual);
+            this.saveShippingFieldsAsShippingAddress(formatedShippingFields, !!is_virtual);
         }
 
         if (email !== prevEmail) {

--- a/packages/scandipwa/src/route/Checkout/Checkout.type.ts
+++ b/packages/scandipwa/src/route/Checkout/Checkout.type.ts
@@ -40,6 +40,7 @@ export interface CheckoutContainerMapStateProps {
     isSignedIn: boolean;
     isCartLoading: boolean;
     shippingFields: Record<string, unknown>;
+    shippingAddress: Record<string, unknown>;
     minimumOrderAmount: MinimumOrderAmount | undefined;
 }
 

--- a/packages/scandipwa/src/route/Checkout/Checkout.type.ts
+++ b/packages/scandipwa/src/route/Checkout/Checkout.type.ts
@@ -40,7 +40,7 @@ export interface CheckoutContainerMapStateProps {
     isSignedIn: boolean;
     isCartLoading: boolean;
     shippingFields: Record<string, unknown>;
-    shippingAddress: Record<string, unknown>;
+    formattedShippingAddress: Record<string, unknown>;
     minimumOrderAmount: MinimumOrderAmount | undefined;
 }
 

--- a/packages/scandipwa/src/store/Checkout/Checkout.action.ts
+++ b/packages/scandipwa/src/store/Checkout/Checkout.action.ts
@@ -12,6 +12,7 @@ import {
     CheckoutActionType,
     UpdateEmailAction,
     UpdateEmailAvailableAction,
+    UpdateShippingAddressAction,
     UpdateShippingFieldsAction,
 } from './Checkout.type';
 
@@ -19,6 +20,12 @@ import {
 export const updateShippingFields = (shippingFields: Record<string, unknown>): UpdateShippingFieldsAction => ({
     type: CheckoutActionType.UPDATE_SHIPPING_FIELDS,
     shippingFields,
+});
+
+/** @namespace Store/Checkout/Action/updateShippingAddress */
+export const updateShippingAddress = (shippingAddress: Record<string, unknown>): UpdateShippingAddressAction => ({
+    type: CheckoutActionType.UPDATE_SHIPPING_ADDRESS,
+    shippingAddress,
 });
 
 /** @namespace Store/Checkout/Action/updateEmail */

--- a/packages/scandipwa/src/store/Checkout/Checkout.reducer.ts
+++ b/packages/scandipwa/src/store/Checkout/Checkout.reducer.ts
@@ -11,15 +11,19 @@
 
 import { Reducer } from 'redux';
 
+import BrowserDatabase from 'Util/BrowserDatabase';
+
 import {
     CheckoutAction,
     CheckoutActionType,
     CheckoutStore,
 } from './Checkout.type';
 
+export const SHIPPING_FIELDS = 'shipping_fields';
+
 /** @namespace Store/Checkout/Reducer/getInitialState */
 export const getInitialState = (): CheckoutStore => ({
-    shippingFields: {},
+    shippingFields: BrowserDatabase.getItem(SHIPPING_FIELDS) || {},
     email: '',
     isEmailAvailable: true,
 });
@@ -35,6 +39,11 @@ CheckoutAction
     switch (action.type) {
     case CheckoutActionType.UPDATE_SHIPPING_FIELDS:
         const { shippingFields } = action;
+
+        BrowserDatabase.setItem(
+            shippingFields,
+            SHIPPING_FIELDS,
+        );
 
         return {
             ...state,

--- a/packages/scandipwa/src/store/Checkout/Checkout.reducer.ts
+++ b/packages/scandipwa/src/store/Checkout/Checkout.reducer.ts
@@ -20,10 +20,12 @@ import {
 } from './Checkout.type';
 
 export const SHIPPING_FIELDS = 'shipping_fields';
+export const SHIPPING_ADDRESS = 'shippingAddress';
 
 /** @namespace Store/Checkout/Reducer/getInitialState */
 export const getInitialState = (): CheckoutStore => ({
     shippingFields: BrowserDatabase.getItem(SHIPPING_FIELDS) || {},
+    shippingAddress: BrowserDatabase.getItem(SHIPPING_ADDRESS) || {},
     email: '',
     isEmailAvailable: true,
 });
@@ -48,6 +50,19 @@ CheckoutAction
         return {
             ...state,
             shippingFields,
+        };
+
+    case CheckoutActionType.UPDATE_SHIPPING_ADDRESS:
+        const { shippingAddress } = action;
+
+        BrowserDatabase.setItem(
+            shippingAddress,
+            SHIPPING_ADDRESS,
+        );
+
+        return {
+            ...state,
+            shippingAddress,
         };
 
     case CheckoutActionType.UPDATE_EMAIL:

--- a/packages/scandipwa/src/store/Checkout/Checkout.reducer.ts
+++ b/packages/scandipwa/src/store/Checkout/Checkout.reducer.ts
@@ -11,6 +11,7 @@
 
 import { Reducer } from 'redux';
 
+import { SHIPPING_ADDRESS } from 'Route/Checkout/Checkout.config';
 import BrowserDatabase from 'Util/BrowserDatabase';
 
 import {
@@ -19,12 +20,9 @@ import {
     CheckoutStore,
 } from './Checkout.type';
 
-export const SHIPPING_FIELDS = 'shipping_fields';
-export const SHIPPING_ADDRESS = 'shippingAddress';
-
 /** @namespace Store/Checkout/Reducer/getInitialState */
 export const getInitialState = (): CheckoutStore => ({
-    shippingFields: BrowserDatabase.getItem(SHIPPING_FIELDS) || {},
+    shippingFields: {},
     shippingAddress: BrowserDatabase.getItem(SHIPPING_ADDRESS) || {},
     email: '',
     isEmailAvailable: true,
@@ -41,11 +39,6 @@ CheckoutAction
     switch (action.type) {
     case CheckoutActionType.UPDATE_SHIPPING_FIELDS:
         const { shippingFields } = action;
-
-        BrowserDatabase.setItem(
-            shippingFields,
-            SHIPPING_FIELDS,
-        );
 
         return {
             ...state,

--- a/packages/scandipwa/src/store/Checkout/Checkout.type.ts
+++ b/packages/scandipwa/src/store/Checkout/Checkout.type.ts
@@ -12,6 +12,7 @@ import { AnyAction } from 'redux';
 
 export enum CheckoutActionType {
     UPDATE_SHIPPING_FIELDS = 'UPDATE_SHIPPING_FIELDS',
+    UPDATE_SHIPPING_ADDRESS = 'UPDATE_SHIPPING_ADDRESS',
     UPDATE_EMAIL = 'UPDATE_EMAIL',
     UPDATE_EMAIL_AVAILABLE = 'UPDATE_EMAIL_AVAILABLE',
 }
@@ -19,6 +20,11 @@ export enum CheckoutActionType {
 export interface UpdateShippingFieldsAction extends AnyAction {
     type: CheckoutActionType.UPDATE_SHIPPING_FIELDS;
     shippingFields: Record<string, unknown>;
+}
+
+export interface UpdateShippingAddressAction extends AnyAction {
+    type: CheckoutActionType.UPDATE_SHIPPING_ADDRESS;
+    shippingAddress: Record<string, unknown>;
 }
 export interface UpdateEmailAction extends AnyAction {
     type: CheckoutActionType.UPDATE_EMAIL;
@@ -30,11 +36,13 @@ export interface UpdateEmailAvailableAction extends AnyAction {
 }
 
 export type CheckoutAction = UpdateShippingFieldsAction
+| UpdateShippingAddressAction
 | UpdateEmailAction
 | UpdateEmailAvailableAction;
 
 export interface CheckoutStore {
     shippingFields: Record<string, unknown>;
+    shippingAddress: Record<string, unknown>;
     email: string;
     isEmailAvailable: boolean;
 }


### PR DESCRIPTION
**ScandiPWA contribution**
* Fixes [Unable to Place Order after refreshing on the Checkout page.](https://github.com/scandipwa/scandipwa/issues/5399)

**Problem:**
* An error occurs when clicking "Place Order" after refreshing the checkout billing step. The only resolution is to return to the shipping step.
* **The issue stems from the fact that after a refresh, `CheckoutReducer` is empty of any data required for placing an order.**

**In this PR:**
* A new persistent state called `formattedShippingAddress` has been added to CheckoutReducer with the help of localStorage. This state was created because it differs from the `shippingFields` state, which may contain many irrelevant fields and obstruct the process of placing an order. It made sense to add the `shippingAddress` state to CheckoutReducer as it is already present in Checkout.container.
* A condition was added in Checkout.container to determine if the customer reloaded the page and, if so, then restore the shippingAddress state in Checkout.container with: `this.saveShippingFieldsAsShippingAddress(formattedShippingAddress, !!is_virtual);`