### PR TITLE
ISSUE-5405 - solve image is not shown on pop-up

### DIFF
--- a/packages/scandipwa/src/component/TranslateOnCursorMove/TranslateOnCursorMove.component.tsx
+++ b/packages/scandipwa/src/component/TranslateOnCursorMove/TranslateOnCursorMove.component.tsx
@@ -31,6 +31,8 @@ export class TranslateOnCursorMoveComponent extends PureComponent<TranslateOnCur
 
     componentDidMount(): void {
         window.addEventListener('resize', this.handleLoad);
+
+        this.handleLoad();
     }
 
     componentDidUpdate(prevProps: TranslateOnCursorMoveComponentProps): void {
@@ -119,9 +121,6 @@ export class TranslateOnCursorMoveComponent extends PureComponent<TranslateOnCur
         return (
             <div
               block="TranslateOnCursorMove"
-              // TODO: investigate why does this work ???
-              // eslint-disable-next-line react/no-unknown-property
-              onLoad={ this.handleLoad }
               onMouseMove={ this.handleMouseMove }
               ref={ this.ref }
             >


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5405

**Problem:**
* Zoomed image is not shown in popup

**In this PR:**
* Moved `handleLoad` usage from `onLoad` attribute value of `.TranslateOnCursorMove` element to `componentDidMount` method because `componentDidMount` is called after the component is mounted (inserted into the tree) which is similar to `onLoad` behavior.