### PR TITLE
5381 - Added alt tags to PDP images

### DIFF
--- a/packages/scandipwa/src/component/ProductGallery/ProductGallery.component.tsx
+++ b/packages/scandipwa/src/component/ProductGallery/ProductGallery.component.tsx
@@ -176,10 +176,13 @@ export class ProductGalleryComponent extends PureComponent<ProductGalleryCompone
     }
 
     renderAdditionalPicture(media: MediaGalleryEntry, index = 0): ReactElement {
+        const { productName } = this.props;
+
         return (
             <ProductGalleryThumbnailImage
               key={ index }
               media={ media }
+              productName={ productName }
             />
         );
     }
@@ -259,6 +262,7 @@ export class ProductGalleryComponent extends PureComponent<ProductGalleryCompone
             isMobile,
             isImageZoomPopupActive,
             showLoader,
+            productName,
         } = this.props;
         const { scrollEnabled } = this.state;
 
@@ -275,6 +279,7 @@ export class ProductGalleryComponent extends PureComponent<ProductGalleryCompone
                 <Image
                   key={ index }
                   src={ src }
+                  alt={ productName }
                   ratio={ ImageRatio.IMG_CUSTOM }
                   mix={ {
                       block: 'ProductGallery',

--- a/packages/scandipwa/src/component/ProductGalleryThumbnailImage/ProductGalleryThumbnailImage.component.tsx
+++ b/packages/scandipwa/src/component/ProductGalleryThumbnailImage/ProductGalleryThumbnailImage.component.tsx
@@ -74,6 +74,7 @@ export class ProductGalleryThumbnailImageComponent extends PureComponent<Product
                 thumbnail: { url: thumbnailUrl } = {},
                 id,
             },
+            productName,
         } = this.props;
 
         // !FIXME: Possible dead code. Id is number and cannot be comparable to the 'thumbnail' value.
@@ -88,7 +89,7 @@ export class ProductGalleryThumbnailImageComponent extends PureComponent<Product
         return (
             <Image
               src={ src }
-              alt={ alt }
+              alt={ alt || productName }
               ratio={ ImageRatio.IMG_CUSTOM }
               mix={ { block: 'ProductGalleryThumbnailImage' } }
             />

--- a/packages/scandipwa/src/component/ProductGalleryThumbnailImage/ProductGalleryThumbnailImage.type.ts
+++ b/packages/scandipwa/src/component/ProductGalleryThumbnailImage/ProductGalleryThumbnailImage.type.ts
@@ -13,4 +13,5 @@ import { MediaGalleryEntry } from 'Query/ProductList.type';
 
 export interface ProductGalleryThumbnailImageComponentProps {
     media: MediaGalleryEntry;
+    productName: string;
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/5381

**Problem:**
* All product images have empty alt tags. From an SEO standpoint. All images should have alt tags,

**In this PR:**
* Added product name as a value for alt tag. 
