### PR TITLE
fixed issue #5432 using combining carrier_code and method_code

### DIFF
--- a/packages/scandipwa/package.json
+++ b/packages/scandipwa/package.json
@@ -18,7 +18,7 @@
         "@scandipwa/service-worker": "0.0.18",
         "@scandipwa/stylelint-config": "0.0.8",
         "@scandipwa/webpack-i18n-runtime": "0.0.36",
-        "@tilework/opus": "^0.0.12",
+        "@tilework/opus": "0.0.12",
         "@types/react": "18.0.17",
         "@types/react-datepicker": "^4.4.1",
         "@types/react-dom": "18.0.6",


### PR DESCRIPTION
**Related issue(s):**
* Fixes [link](https://github.com/scandipwa/scandipwa/issues/5432)

**Problem:**
* Earlier the CheckoutDeliveryOptions was giving error of same key found of multiple components. The reason was 'ups' which is a carrier_code and can be present multiple times.

**In this PR:**
* In this PR i used a combination of carrier_code and method_code to resolve the conflict
