### PR TITLE
Fixed - Endless loader on Checkout and user redirection to shipping step when billing step is refreshed

### DIFF
--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.tsx
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.container.tsx
@@ -20,7 +20,7 @@ import {
 import { StoreWithCountryId } from 'Component/StoreInPickUpPopup/StoreInPickUpPopup.type';
 import { ShippingMethod } from 'Query/Checkout.type';
 import { CheckoutAddress } from 'Route/Checkout/Checkout.type';
-import { updateShippingFields } from 'Store/Checkout/Checkout.action';
+import { updateShippingAddress, updateShippingFields } from 'Store/Checkout/Checkout.action';
 import { ReactElement } from 'Type/Common.type';
 import {
     trimCheckoutAddress,
@@ -57,6 +57,7 @@ export const mapStateToProps = (state: RootState): CheckoutShippingContainerMapS
 /** @namespace Component/CheckoutShipping/Container/mapDispatchToProps */
 export const mapDispatchToProps = (dispatch: Dispatch): CheckoutShippingContainerMapDispatchProps => ({
     updateShippingFields: (fields) => dispatch(updateShippingFields(fields)),
+    updateShippingAddress: (fields) => dispatch(updateShippingAddress(fields)),
 });
 
 /** @namespace Component/CheckoutShipping/Container */
@@ -235,6 +236,7 @@ CheckoutShippingContainerState
             updateShippingFields,
             addressLinesQty,
             selectedStoreAddress,
+            updateShippingAddress,
             customer: { default_shipping },
         } = this.props;
 
@@ -285,6 +287,17 @@ CheckoutShippingContainerState
         saveAddressInformation(data);
         const shipping_method = `${shipping_carrier_code}_${shipping_method_code}`;
         const { street = [] } = formattedFields;
+
+        updateShippingAddress({
+            ...(
+                street.length
+                || ('id' in data.shipping_address
+                && default_shipping
+                && parseInt(default_shipping, 10) === data.shipping_address.id)
+                    ? formattedFields : data.shipping_address
+            ),
+            shipping_method,
+        });
 
         updateShippingFields({
             ...(

--- a/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.type.ts
+++ b/packages/scandipwa/src/component/CheckoutShipping/CheckoutShipping.type.ts
@@ -29,6 +29,7 @@ export interface CheckoutShippingContainerMapStateProps {
 
 export interface CheckoutShippingContainerMapDispatchProps {
     updateShippingFields: (fields: Record<string, unknown>) => void;
+    updateShippingAddress: (fields: Record<string, unknown>) => void;
 }
 
 export interface CheckoutShippingContainerFunctions {

--- a/packages/scandipwa/src/query/Cart.type.ts
+++ b/packages/scandipwa/src/query/Cart.type.ts
@@ -72,7 +72,7 @@ export interface CartAddress {
     telephone: string;
     vat_id: string;
     email: string;
-    street: string;
+    street: Array<string>;
 }
 
 export interface SelectedShippingMethod {

--- a/packages/scandipwa/src/route/Checkout/Checkout.config.ts
+++ b/packages/scandipwa/src/route/Checkout/Checkout.config.ts
@@ -32,6 +32,7 @@ export enum CheckoutStepUrl {
 export const CHECKOUT_URL_REGEX = new RegExp(`^(${appendWithStoreCode('')})?${CheckoutStepUrl.CHECKOUT_URL}(/)?$`);
 
 export const PAYMENT_TOTALS = 'PAYMENT_TOTALS';
+export const SHIPPING_ADDRESS = 'shippingAddress';
 
 export const UPDATE_EMAIL_CHECK_FREQUENCY = 1500; // ms
 export const UPDATE_SHIPPING_COST_ESTIMATES_FREQUENCY = 800; // ms

--- a/packages/scandipwa/src/route/Checkout/Checkout.type.ts
+++ b/packages/scandipwa/src/route/Checkout/Checkout.type.ts
@@ -40,6 +40,7 @@ export interface CheckoutContainerMapStateProps {
     isSignedIn: boolean;
     isCartLoading: boolean;
     shippingFields: Record<string, unknown>;
+    formattedShippingAddress: Record<string, unknown>;
     minimumOrderAmount: MinimumOrderAmount | undefined;
 }
 

--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.ts
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.ts
@@ -113,14 +113,12 @@ export class CartDispatcher {
 
     prepareCheckoutAddressFormat(address: Partial<CartAddress>): CheckoutAddress {
         const {
-            street: addressStreet = '',
+            street = [],
             email,
             country: { code: country_id } = {},
             region,
             ...data
         } = address;
-
-        const street = addressStreet.split('\n');
 
         const street_index: Record<string, string> = {};
 
@@ -143,6 +141,8 @@ export class CartDispatcher {
             dispatch(updateIsLoadingCart(true));
 
             const quoteId = await this._getNewQuoteId();
+
+            dispatch(updateIsLoadingCart(false));
 
             setCartId(quoteId);
 

--- a/packages/scandipwa/src/store/Cart/Cart.dispatcher.ts
+++ b/packages/scandipwa/src/store/Cart/Cart.dispatcher.ts
@@ -142,8 +142,6 @@ export class CartDispatcher {
 
             const quoteId = await this._getNewQuoteId();
 
-            dispatch(updateIsLoadingCart(false));
-
             setCartId(quoteId);
 
             return quoteId;

--- a/packages/scandipwa/src/store/Checkout/Checkout.action.ts
+++ b/packages/scandipwa/src/store/Checkout/Checkout.action.ts
@@ -12,6 +12,7 @@ import {
     CheckoutActionType,
     UpdateEmailAction,
     UpdateEmailAvailableAction,
+    UpdateShippingAddressAction,
     UpdateShippingFieldsAction,
 } from './Checkout.type';
 
@@ -19,6 +20,12 @@ import {
 export const updateShippingFields = (shippingFields: Record<string, unknown>): UpdateShippingFieldsAction => ({
     type: CheckoutActionType.UPDATE_SHIPPING_FIELDS,
     shippingFields,
+});
+
+/** @namespace Store/Checkout/Action/updateShippingAddress */
+export const updateShippingAddress = (shippingAddress: Record<string, unknown>): UpdateShippingAddressAction => ({
+    type: CheckoutActionType.UPDATE_SHIPPING_ADDRESS,
+    shippingAddress,
 });
 
 /** @namespace Store/Checkout/Action/updateEmail */

--- a/packages/scandipwa/src/store/Checkout/Checkout.reducer.ts
+++ b/packages/scandipwa/src/store/Checkout/Checkout.reducer.ts
@@ -11,6 +11,9 @@
 
 import { Reducer } from 'redux';
 
+import { SHIPPING_ADDRESS } from 'Route/Checkout/Checkout.config';
+import BrowserDatabase from 'Util/BrowserDatabase';
+
 import {
     CheckoutAction,
     CheckoutActionType,
@@ -20,6 +23,7 @@ import {
 /** @namespace Store/Checkout/Reducer/getInitialState */
 export const getInitialState = (): CheckoutStore => ({
     shippingFields: {},
+    shippingAddress: BrowserDatabase.getItem(SHIPPING_ADDRESS) || {},
     email: '',
     isEmailAvailable: true,
 });
@@ -39,6 +43,19 @@ CheckoutAction
         return {
             ...state,
             shippingFields,
+        };
+
+    case CheckoutActionType.UPDATE_SHIPPING_ADDRESS:
+        const { shippingAddress } = action;
+
+        BrowserDatabase.setItem(
+            shippingAddress,
+            SHIPPING_ADDRESS,
+        );
+
+        return {
+            ...state,
+            shippingAddress,
         };
 
     case CheckoutActionType.UPDATE_EMAIL:

--- a/packages/scandipwa/src/store/Checkout/Checkout.type.ts
+++ b/packages/scandipwa/src/store/Checkout/Checkout.type.ts
@@ -12,6 +12,7 @@ import { AnyAction } from 'redux';
 
 export enum CheckoutActionType {
     UPDATE_SHIPPING_FIELDS = 'UPDATE_SHIPPING_FIELDS',
+    UPDATE_SHIPPING_ADDRESS = 'UPDATE_SHIPPING_ADDRESS',
     UPDATE_EMAIL = 'UPDATE_EMAIL',
     UPDATE_EMAIL_AVAILABLE = 'UPDATE_EMAIL_AVAILABLE',
 }
@@ -19,6 +20,10 @@ export enum CheckoutActionType {
 export interface UpdateShippingFieldsAction extends AnyAction {
     type: CheckoutActionType.UPDATE_SHIPPING_FIELDS;
     shippingFields: Record<string, unknown>;
+}
+export interface UpdateShippingAddressAction extends AnyAction {
+    type: CheckoutActionType.UPDATE_SHIPPING_ADDRESS;
+    shippingAddress: Record<string, unknown>;
 }
 export interface UpdateEmailAction extends AnyAction {
     type: CheckoutActionType.UPDATE_EMAIL;
@@ -30,11 +35,13 @@ export interface UpdateEmailAvailableAction extends AnyAction {
 }
 
 export type CheckoutAction = UpdateShippingFieldsAction
+| UpdateShippingAddressAction
 | UpdateEmailAction
 | UpdateEmailAvailableAction;
 
 export interface CheckoutStore {
     shippingFields: Record<string, unknown>;
+    shippingAddress: Record<string, unknown>;
     email: string;
     isEmailAvailable: boolean;
 }


### PR DESCRIPTION

**Related issue(s):**
* Fixes #5168
* Fixes #5438 

**Problem:**
1. User gets redirected to shipping step when refreshing the page on billing step
2. Endless Loader Spinning on checkout order summary after page reload in the billing step

**In this PR:**
Updated the code for #5399 
* A new persistent state called formattedShippingAddress has been added to CheckoutReducer with the help of localStorage. This state was created because it differs from the shippingFields state, which may contain many irrelevant fields and obstruct the process of placing an order. It made sense to add the shippingAddress state to CheckoutReducer as it is already present in Checkout.container
* A condition was added in Checkout.container to determine if the customer reloaded the page and, if so, then restore the shippingAddress state in Checkout.container with: this.saveShippingFieldsAsShippingAddress(formattedShippingAddress, !!is_virtual);
* Removing the split method that was generating the continuous loading on the order summary fixed the address split problem for streets.