### PR TITLE
Implemented the TS solution for breadcrumbs

### DIFF
--- a/packages/scandipwa/src/query/ProductList.query.ts
+++ b/packages/scandipwa/src/query/ProductList.query.ts
@@ -36,6 +36,7 @@ import {
     BundlePriceOption,
     BundleProductFragment,
     CategoryInterface,
+    CategoryTreeFragment,
     ComplexTextValue,
     ConfigurableCartProductFragment,
     ConfigurableProductFragment,
@@ -691,13 +692,19 @@ export class ProductListQuery {
     | Field<'name', string>
     | Field<'url', string>
     | Field<'breadcrumbs', Breadcrumb, true>
+    | InlineFragment<'CategoryTree', CategoryTreeFragment>
     > {
         return [
             new Field<'id', string>('id'),
             new Field<'name', string>('name'),
             new Field<'url', string>('url'),
+            this._getIsCategoryActive(),
             this._getBreadcrumbsField(),
         ];
+    }
+
+    _getIsCategoryActive(): InlineFragment<'CategoryTree', CategoryTreeFragment> {
+        return new InlineFragment<'CategoryTree', CategoryTreeFragment>('CategoryTree').addField('is_active');
     }
 
     _getCategoriesField(): Field<'categories', CategoryInterface, true> {

--- a/packages/scandipwa/src/query/ProductList.type.ts
+++ b/packages/scandipwa/src/query/ProductList.type.ts
@@ -379,12 +379,19 @@ export interface Breadcrumb {
     category_is_active: boolean;
 }
 
+export interface CategoryTreeFragment {
+    is_active: boolean;
+}
+
 export interface CategoryInterface {
     id: string;
     name: string;
     url: string;
     breadcrumbs: Breadcrumb[];
+    CategoryTree: CategoryTreeFragment;
 }
+
+export type Category = CategoryInterface & CategoryTreeFragment;
 
 export interface DownloadableProductSamples {
     title: string;
@@ -485,7 +492,7 @@ export interface BaseProductItem {
     meta_title: string;
     meta_keyword: string;
     meta_description: string;
-    categories: CategoryInterface[];
+    categories: Category[];
     reviews: ProductReviews;
     CustomizableProductInterface: {
         options: CustomizableProductFragmentOptions[];

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.tsx
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.tsx
@@ -615,6 +615,7 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
             url = '',
             name = '',
             breadcrumbs = [],
+            is_active = false,
         } = isUnmatchedCategory ? {} : category;
 
         updateBreadcrumbs({
@@ -622,6 +623,7 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
             url,
             name,
             breadcrumbs,
+            is_active,
         });
 
         this.setState({ breadcrumbsWereUpdated: true });

--- a/packages/scandipwa/src/route/SearchPage/SearchPage.container.tsx
+++ b/packages/scandipwa/src/route/SearchPage/SearchPage.container.tsx
@@ -83,6 +83,7 @@ SearchPageContainerState
             url: '',
             name: search,
             id: '',
+            is_active: true,
             breadcrumbs: [],
         });
     }

--- a/packages/scandipwa/src/store/Breadcrumbs/Breadcrumbs.dispatcher.ts
+++ b/packages/scandipwa/src/store/Breadcrumbs/Breadcrumbs.dispatcher.ts
@@ -55,8 +55,15 @@ export class BreadcrumbsDispatcher {
      * @param {Function} dispatch
      * @memberof BreadcrumbsDispatcher
      */
-    updateWithProduct(product: Product, prevCategoryId: number, dispatch: Dispatch): void {
-        const breadcrumbs = this._getProductBreadcrumbs(product, prevCategoryId);
+    updateWithProduct(
+        product: Product,
+        prevCategoryId: number,
+        dispatch: Dispatch,
+    ): void {
+        const breadcrumbs = this._getProductBreadcrumbs(
+            product,
+            prevCategoryId,
+        );
 
         dispatch(toggleBreadcrumbs(true));
         dispatch(updateBreadcrumbs(breadcrumbs));
@@ -93,7 +100,9 @@ export class BreadcrumbsDispatcher {
 
         if (breadcrumbs?.length) {
             breadcrumbs
-                .sort((a, b) => (a?.category_level || 0) - (b?.category_level || 0))
+                .sort(
+                    (a, b) => (a?.category_level || 0) - (b?.category_level || 0),
+                )
                 .forEach((crumb) => {
                     if (crumb) {
                         const {
@@ -121,44 +130,62 @@ export class BreadcrumbsDispatcher {
                 });
         }
 
-        return [
-            { url, name },
-            ...breadcrumbsList.reverse(),
-        ];
+        return [{ url, name }, ...breadcrumbsList.reverse()];
     }
 
-    findCategoryById(categories: Category[], categoryId: number): Category | undefined {
+    findCategoryById(
+        categories: Category[],
+        categoryId: number,
+    ): Category | undefined {
         return categories.find(({ id }) => id === categoryId);
     }
 
     findLongestBreadcrumbs(categories: Category[]): Partial<Category> {
-        const {
-            breadcrumbsCategory = {},
-        } = categories.reduce((acc, category) => {
-            const { longestBreadcrumbsLength } = acc;
-            const { breadcrumbs } = category;
-            const breadcrumbsLength = (breadcrumbs || []).length;
+        const { breadcrumbsCategory = {} } = categories.reduce(
+            (acc, category) => {
+                const { longestBreadcrumbsLength } = acc;
+                const breadcrumbs = category.breadcrumbs || [];
+                const { is_active } = category;
+                const breadcrumbsLength = breadcrumbs.length;
 
-            if (!breadcrumbsLength && longestBreadcrumbsLength !== 0) {
-                return acc;
-            }
+                if (!is_active) {
+                    return acc;
+                }
 
-            if (longestBreadcrumbsLength === 0) {
-                return { ...acc, breadcrumbsCategory: category };
-            }
+                if (!breadcrumbsLength && longestBreadcrumbsLength !== 0) {
+                    return acc;
+                }
 
-            if (breadcrumbsLength <= longestBreadcrumbsLength) {
-                return acc;
-            }
+                if (
+                    breadcrumbs.some(
+                        (breadcrumb) => !breadcrumb.category_is_active,
+                    )
+                ) {
+                    return acc;
+                }
 
-            return {
-                breadcrumbsCategory: category,
-                longestBreadcrumbsLength: breadcrumbsLength,
-            };
-        }, {
-            breadcrumbsCategory: {},
-            longestBreadcrumbsLength: 0,
-        });
+                if (longestBreadcrumbsLength === 0) {
+                    return {
+                        ...acc,
+                        breadcrumbsCategory: category,
+                        longestBreadcrumbsLength: breadcrumbsLength,
+                    };
+                }
+
+                if (breadcrumbsLength <= longestBreadcrumbsLength) {
+                    return acc;
+                }
+
+                return {
+                    breadcrumbsCategory: category,
+                    longestBreadcrumbsLength: breadcrumbsLength,
+                };
+            },
+            {
+                breadcrumbsCategory: {},
+                longestBreadcrumbsLength: 0,
+            },
+        );
 
         return breadcrumbsCategory;
     }
@@ -186,7 +213,7 @@ export class BreadcrumbsDispatcher {
             { url, name },
             ...this._getCategoryBreadcrumbs(
                 this.findCategoryById(categories, prevCategoryId || 0)
-                || this.findLongestBreadcrumbs(categories),
+                    || this.findLongestBreadcrumbs(categories),
             ),
         ];
     }

--- a/packages/scandipwa/src/store/Breadcrumbs/Breadcrumbs.type.ts
+++ b/packages/scandipwa/src/store/Breadcrumbs/Breadcrumbs.type.ts
@@ -29,6 +29,7 @@ export interface Category {
     url: string;
     name: string;
     breadcrumbs: CategoryBreadcrumb[];
+    is_active: boolean;
 }
 
 export interface Product {
@@ -52,7 +53,9 @@ export interface UpdateBreadcrumbsAction extends AnyAction {
     breadcrumbs?: Breadcrumb[];
 }
 
-export type BreadcrumbsAction = ToggleBreadcrumbsAction | UpdateBreadcrumbsAction;
+export type BreadcrumbsAction =
+    | ToggleBreadcrumbsAction
+    | UpdateBreadcrumbsAction;
 
 export interface BreadcrumbsStore {
     breadcrumbs: Breadcrumb[];


### PR DESCRIPTION
**Related issue(s):**
* Fixes #5451

**In this PR:**
* Added `is_active` to graphql request to ensure the category is active. Otherwise, clicking on a breadcrumb with a broken category would lead to a 404
* Fixed the longest breadcrumbs fn
