### PR TITLE
TEAMS-582 update highPrice and lowPrice logic

### DIFF
--- a/packages/scandipwa/src/component/Product/Product.component.tsx
+++ b/packages/scandipwa/src/component/Product/Product.component.tsx
@@ -421,7 +421,7 @@ export class ProductComponent<P extends ProductComponentProps = ProductComponent
         );
     }
 
-    renderPrice(isPreview = false): ReactElement {
+    renderPrice(isPreview = false, isSchemaRequired = false): ReactElement {
         const { getActiveProduct, productPrice } = this.props;
         const product = getActiveProduct();
 
@@ -444,6 +444,7 @@ export class ProductComponent<P extends ProductComponentProps = ProductComponent
                   priceType={ type as ProductType }
                   tierPrices={ priceTiers }
                   isPreview={ isPreview }
+                  isSchemaRequired={ isSchemaRequired }
                   mix={ { block: this.className, elem: 'Price' } }
                 />
             </div>

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.component.tsx
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.component.tsx
@@ -180,32 +180,44 @@ export class ProductActionsComponent extends ProductComponent<ProductActionsComp
         );
     }
 
-    renderPriceWithSchema(): ReactElement {
+    renderHighPrice() {
         const {
             productPrice,
+            offerCount,
         } = this.props;
 
         const {
-            originalPrice: {
-                minFinalPrice: {
-                    value: minFinalPrice = 0,
+            price: {
+                discount: {
+                    percentOff: discountPercentage = 0,
                 } = {},
-                maxFinalPrice: {
-                    value: maxFinalPrice = 0,
+                originalPrice: {
+                    value: originalPrice = 0,
                 } = {},
             } = {},
         } = productPrice;
 
+        // Render highPrice as originalPrice if there is discount or variants
+        if (discountPercentage !== 0 || offerCount > 1) {
+            return (
+                <meta
+                  itemProp="highPrice"
+                  content={ String(originalPrice) }
+                />
+            );
+        }
+
+        return null;
+    }
+
+    renderPriceWithSchema(): ReactElement {
         return (
             <div
               block="ProductActions"
               elem="PriceWrapper"
             >
                 { this.renderSchema() }
-                <meta
-                  itemProp="highPrice"
-                  content={ (minFinalPrice === maxFinalPrice) ? String(minFinalPrice) : String(maxFinalPrice) }
-                />
+                { this.renderHighPrice() }
                 { this.renderPrice() }
             </div>
         );
@@ -267,7 +279,10 @@ export class ProductActionsComponent extends ProductComponent<ProductActionsComp
             return null;
         }
 
-        return super.renderPrice(!inStock || notConfigured || isPricePreview);
+        return super.renderPrice(
+            !inStock || notConfigured || isPricePreview,
+            true,
+        );
     }
 
     renderTierPrices(): ReactElement {

--- a/packages/scandipwa/src/component/ProductActions/ProductActions.container.tsx
+++ b/packages/scandipwa/src/component/ProductActions/ProductActions.container.tsx
@@ -122,7 +122,7 @@ ProductActionsContainerState
     getOfferType(): string {
         const { product: { variants } } = this.props;
 
-        if (variants && variants.length >= 1) {
+        if (variants && variants.length > 1) {
             return 'https://schema.org/AggregateOffer';
         }
 

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.tsx
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.tsx
@@ -92,18 +92,20 @@ export class ProductPriceComponent extends PureComponent<ProductPriceComponentPr
             variantsCount,
             price: {
                 finalPrice: {
-                    value: contentPrice = 0,
+                    valueFormatted = '$0.00',
                 } = {},
             } = {},
             discountPercentage,
         } = this.props;
 
+        const priceRounded = parseFloat(valueFormatted.replace('$', ''));
+
         // Render lowPrice if there is variants or there is discount
         if (variantsCount > 1 || discountPercentage !== 0) {
-            return isSchemaRequired ? { itemProp: 'lowPrice', content: contentPrice } : {};
+            return isSchemaRequired ? { itemProp: 'lowPrice', content: priceRounded } : {};
         }
 
-        return isSchemaRequired ? { itemProp: 'price', content: contentPrice } : {};
+        return isSchemaRequired ? { itemProp: 'price', content: priceRounded } : {};
     }
 
     renderPrice(price: Partial<FormattedMoney>, label: string | ReactElement): ReactElement {
@@ -126,17 +128,20 @@ export class ProductPriceComponent extends PureComponent<ProductPriceComponentPr
         }
 
         return (
-            <PriceSemanticElementName block="ProductPrice" elem="Price">
-                { this.renderPriceBadge(label) }
-                <span
-                  itemScope
-                  block="ProductPrice"
-                  elem="PriceValue"
-                >
-                    <meta itemProp={ itemProp } content={ String(content) } />
-                    { priceFormatted }
-                </span>
-            </PriceSemanticElementName>
+            <>
+                { /** <meta itemprop isn't recognized inside <ins> tag */ }
+                <meta itemProp={ itemProp } content={ String(content) } />
+                <PriceSemanticElementName block="ProductPrice" elem="Price">
+                    { this.renderPriceBadge(label) }
+                    <span
+                      itemScope
+                      block="ProductPrice"
+                      elem="PriceValue"
+                    >
+                        { priceFormatted }
+                    </span>
+                </PriceSemanticElementName>
+            </>
         );
     }
 

--- a/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.tsx
+++ b/packages/scandipwa/src/component/ProductPrice/ProductPrice.component.tsx
@@ -95,9 +95,11 @@ export class ProductPriceComponent extends PureComponent<ProductPriceComponentPr
                     value: contentPrice = 0,
                 } = {},
             } = {},
+            discountPercentage,
         } = this.props;
 
-        if (variantsCount > 1) {
+        // Render lowPrice if there is variants or there is discount
+        if (variantsCount > 1 || discountPercentage !== 0) {
             return isSchemaRequired ? { itemProp: 'lowPrice', content: contentPrice } : {};
         }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://scandiflow.atlassian.net/browse/TEAMS-582

**Problem:**
1. (Self-reported) Meta content is undefined for price by default:
<img width="353" alt="image" src="https://github.com/scandipwa/scandipwa/assets/22796372/e8a24743-7de2-4915-a5d8-8782fab66ba7">

2. The discounted product should have schema:

lowPrice - Discounted price value

highPrice - Original price value

Currently, highPrice just uses final price of product

**In this PR:**
* meta content price is not undefined anymore
* highPrice displays final price if product has no discounts or variants
* highPrice displays Original price value if product has variants or has discount
* lowPrice displays minimum(final price) of product if product has variants or has discount
