### PR TITLE
TEAMS-578 fix flickering titles

### DIFF
--- a/packages/m2-theme/public/index.php
+++ b/packages/m2-theme/public/index.php
@@ -1,7 +1,6 @@
 <?php
 $colorConfig = $this->getThemeConfiguration('color_customization');
 $contentConfig = $this->getThemeConfiguration('content_customization');
-$title = $this->getThemeConfiguration('design/head/default_title');
 $description = $this->getThemeConfiguration('design/head/default_description');
 $themeColor = $this->getThemeConfiguration('webmanifest_customization/webmanifest/theme_color');
 $layoutDirection = $this->getThemeConfiguration('layout_direction_configuration/layout_direction_section/layout_direction') ?: 'ltr';
@@ -17,8 +16,6 @@ $icons = $this->getAppIconData();
     <!-- Muli font import from Abode
     <link rel="preload" href="https://use.typekit.net/fji5tuz.css" as="style"> -->
 
-    <title data-prerendered="1"><?= $title ?></title>
-    <meta name="description" content="<?= $description ?>" data-prerendered="1">
     <meta name="theme-color" content="#<?= $themeColor ?: 'ffffff' ?>">
 
     <script>

--- a/packages/scandipwa/public/index.html
+++ b/packages/scandipwa/public/index.html
@@ -7,10 +7,7 @@
     <!-- Muli font import from Abode -->
     <!-- <link rel="preload" href="https://use.typekit.net/fji5tuz.css" as="style"> -->
 
-    <!-- Default Meta -->
-    <title>ScandiPWA</title>
     <meta name="theme-color" content="#ffffff" />
-    <meta name="description" content="Web site created using create-scandipwa-app" />
 
     <!-- Default content-configurations -->
     <script>

--- a/packages/scandipwa/src/component/Meta/Meta.component.tsx
+++ b/packages/scandipwa/src/component/Meta/Meta.component.tsx
@@ -47,6 +47,10 @@ export class MetaComponent extends PureComponent<MetaComponentProps> {
         const titlePrefix = title_prefix ? `${ title_prefix } | ` : '';
         const titleSuffix = title_suffix ? ` | ${ title_suffix }` : '';
 
+        if (!title || !title?.length) {
+            return null;
+        }
+
         return (
             <title>
                 { `${ titlePrefix }${ title || default_title }${ titleSuffix }` }

--- a/packages/scandipwa/src/component/Router/Router.container.tsx
+++ b/packages/scandipwa/src/component/Router/Router.container.tsx
@@ -143,7 +143,7 @@ export class RouterContainer extends PureComponent<RouterContainerProps, RouterC
 
             updateMeta({
                 default_title,
-                title: meta_title || default_title,
+                title: meta_title,
                 default_description,
                 description: default_description,
                 default_keywords,


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://scandiflow.atlassian.net/browse/TEAMS-578

**Problem:**
* Flickering titles due to default titles being replaced with rendered titles. This caused double Titles registered and recurring SEO problems on projects.

**In this PR:**
* Default titles are removed, now only rendered titles will be used. Only one title will be rendered now.
