### PR TITLE
TEAMS-584 Add alt to images for product gallery

### DIFF
--- a/packages/scandipwa/src/component/ProductGallery/ProductGallery.component.tsx
+++ b/packages/scandipwa/src/component/ProductGallery/ProductGallery.component.tsx
@@ -178,10 +178,13 @@ export class ProductGalleryComponent extends PureComponent<ProductGalleryCompone
     }
 
     renderAdditionalPicture(media: MediaGalleryEntry, index = 0): ReactElement {
+        const { productName } = this.props;
+
         return (
             <ProductGalleryThumbnailImage
               key={ index }
               media={ media }
+              productName={ productName }
             />
         );
     }
@@ -259,6 +262,7 @@ export class ProductGalleryComponent extends PureComponent<ProductGalleryCompone
             isMobile,
             isImageZoomPopupActive,
             showLoader,
+            productName,
         } = this.props;
         const { scrollEnabled } = this.state;
 
@@ -266,6 +270,7 @@ export class ProductGalleryComponent extends PureComponent<ProductGalleryCompone
             const {
                 base: { url: baseSrc } = {},
                 large: { url: largeSrc } = {},
+                label,
             } = mediaData;
 
             const style = isImageZoomPopupActive ? { height: 'auto' } : {};
@@ -281,6 +286,7 @@ export class ProductGalleryComponent extends PureComponent<ProductGalleryCompone
                       elem: 'SliderImage',
                       mods: { isPlaceholder: !src },
                   } }
+                  alt={ label || productName }
                   isPlaceholder={ !src }
                   style={ style }
                   showIsLoading={ showLoader }

--- a/packages/scandipwa/src/component/ProductGalleryThumbnailImage/ProductGalleryThumbnailImage.component.tsx
+++ b/packages/scandipwa/src/component/ProductGalleryThumbnailImage/ProductGalleryThumbnailImage.component.tsx
@@ -74,6 +74,7 @@ export class ProductGalleryThumbnailImageComponent extends PureComponent<Product
                 thumbnail: { url: thumbnailUrl } = {},
                 id,
             },
+            productName,
         } = this.props;
 
         // !FIXME: Possible dead code. Id is number and cannot be comparable to the 'thumbnail' value.
@@ -88,7 +89,7 @@ export class ProductGalleryThumbnailImageComponent extends PureComponent<Product
         return (
             <Image
               src={ src }
-              alt={ alt }
+              alt={ alt || productName }
               ratio={ ImageRatio.IMG_CUSTOM }
               mix={ { block: 'ProductGalleryThumbnailImage' } }
             />

--- a/packages/scandipwa/src/component/ProductGalleryThumbnailImage/ProductGalleryThumbnailImage.type.ts
+++ b/packages/scandipwa/src/component/ProductGalleryThumbnailImage/ProductGalleryThumbnailImage.type.ts
@@ -13,4 +13,5 @@ import { MediaGalleryEntry } from 'Query/ProductList.type';
 
 export interface ProductGalleryThumbnailImageComponentProps {
     media: MediaGalleryEntry;
+    productName: string;
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://scandiflow.atlassian.net/browse/TEAMS-584

**Problem:**
* Product Gallery component misses Alt for images, this caused SEO or even legal problems in some countries like US
* The recurring issue has to be fixed on each new project

**In this PR:**
* Product Gallery images will use Alt label or fallback to product name in case if alt is missing
