### PR TITLE
TEAMS-586 render menu for bots

### DIFF
--- a/packages/scandipwa/src/component/Menu/Menu.component.tsx
+++ b/packages/scandipwa/src/component/Menu/Menu.component.tsx
@@ -18,6 +18,7 @@ import Link from 'Component/Link';
 import MenuItem from 'Component/MenuItem';
 import StoreSwitcher from 'Component/StoreSwitcher';
 import { ReactElement } from 'Type/Common.type';
+import { isCrawler } from 'Util/Browser';
 import { getSortedItems } from 'Util/Menu';
 import { FormattedMenuItem } from 'Util/Menu/Menu.type';
 import { debounce } from 'Util/Request/Debounce';
@@ -190,7 +191,8 @@ export class MenuComponent extends PureComponent<MenuComponentProps> {
         const { activeMenuItemsStack, closeMenu } = this.props;
         const isVisible = activeMenuItemsStack.includes(item_id);
 
-        if (!isVisible) {
+        // We need to render menu in DOM for Bots
+        if (!isCrawler() && !isVisible) {
             return null;
         }
 

--- a/packages/scandipwa/src/component/Menu/Menu.style.scss
+++ b/packages/scandipwa/src/component/Menu/Menu.style.scss
@@ -197,6 +197,14 @@
         }
     }
 
+    &-SubCategoriesWrapper {
+        display: none;
+
+        &_isVisible {
+            display: block;
+        }
+    }
+
     &-Sub {
         &ItemWrapper {
             > .Menu-Link {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://scandiflow.atlassian.net/browse/TEAMS-586

**Problem:**
* Menu subitems are not rendered for bots, thus not providing good data for crawling. The recurring issue has to be fixed on each project.

**In this PR:**
* Menu subitems will be rendered for bots (but invisible), for users it will not be rendered if not hovered.
