### PR TITLE
TEAMS-587 storeswitcher links

### DIFF
--- a/packages/scandipwa/src/component/StoreItem/StoreItem.component.tsx
+++ b/packages/scandipwa/src/component/StoreItem/StoreItem.component.tsx
@@ -11,6 +11,7 @@
 
 import { PureComponent } from 'react';
 
+import Link from 'Component/Link';
 import { ReactElement } from 'Type/Common.type';
 
 import { StoreItemComponentProps } from './StoreItem.type';
@@ -21,18 +22,22 @@ import './StoreItem.style';
 export class StoreItemComponent extends PureComponent<StoreItemComponentProps> {
     render(): ReactElement {
         const {
-            item: { label },
-            getStoreCode,
+            item: {
+                label,
+                storeLinkUrl,
+            },
+            handleStoreItemClick,
         } = this.props;
 
         return (
-            <button
+            <Link
               block="StoreItem"
               elem="Item"
-              onClick={ getStoreCode }
+              onClick={ handleStoreItemClick }
+              to={ storeLinkUrl }
             >
                 { label }
-            </button>
+            </Link>
         );
     }
 }

--- a/packages/scandipwa/src/component/StoreItem/StoreItem.container.tsx
+++ b/packages/scandipwa/src/component/StoreItem/StoreItem.container.tsx
@@ -9,7 +9,7 @@
  * @link https://github.com/scandipwa/scandipwa
  */
 
-import { PureComponent } from 'react';
+import { MouseEvent, PureComponent } from 'react';
 
 import { ReactElement } from 'Type/Common.type';
 
@@ -23,7 +23,7 @@ import {
 /** @namespace Component/StoreItem/Container */
 export class StoreItemContainer extends PureComponent<StoreItemContainerProps> {
     containerFunctions: StoreItemContainerFunctions = {
-        getStoreCode: this.getStoreCode.bind(this),
+        handleStoreItemClick: this.handleStoreItemClick.bind(this),
     };
 
     containerProps(): Pick<StoreItemComponentProps, 'item'>{
@@ -32,7 +32,9 @@ export class StoreItemContainer extends PureComponent<StoreItemContainerProps> {
         return { item };
     }
 
-    getStoreCode(): void {
+    handleStoreItemClick(e: MouseEvent): void {
+        e.preventDefault();
+
         const { item: { value }, handleStoreSelect } = this.props;
 
         handleStoreSelect(value);

--- a/packages/scandipwa/src/component/StoreItem/StoreItem.style.scss
+++ b/packages/scandipwa/src/component/StoreItem/StoreItem.style.scss
@@ -16,6 +16,10 @@
         white-space: nowrap;
         width: 100%;
         cursor: pointer;
+        border-bottom: initial;
+        color: initial;
+        font-weight: initial;
+        display: inline-block;
 
         @include mobile {
             font-size: 14px;
@@ -23,6 +27,7 @@
 
         &:hover {
             background: var(--secondary-base-color);
+            color: initial;
         }
     }
 }

--- a/packages/scandipwa/src/component/StoreItem/StoreItem.type.ts
+++ b/packages/scandipwa/src/component/StoreItem/StoreItem.type.ts
@@ -9,10 +9,12 @@
  * @link https://github.com/scandipwa/scandipwa
  */
 
+import { MouseEvent } from 'react';
+
 import { FormattedStore } from 'Component/StoreSwitcher/StoreSwitcher.type';
 
 export interface StoreItemContainerFunctions {
-    getStoreCode: () => void;
+    handleStoreItemClick: (e: MouseEvent) => void;
 }
 
 export interface StoreItemContainerProps {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://scandiflow.atlassian.net/browse/TEAMS-587

**Problem:**
* Storeswitcher is using Buttons instead of Links, which causes issues with website crawling and doesnt allow bots to find other stores, the recurring issue is fixed on projects

**In this PR:**
* Replaced buttons with links in storeswitcher