### PR TITLE
TEAMS-585 Canonicals for paginated pages to be self-referencing

### DIFF
--- a/packages/scandipwa/src/component/Router/Router.container.tsx
+++ b/packages/scandipwa/src/component/Router/Router.container.tsx
@@ -52,6 +52,7 @@ export const mapStateToProps = (state: RootState): RouterContainerMapStateProps 
     isBigOffline: state.OfflineReducer.isBig,
     status_code: state.MetaReducer.status_code,
     base_link_url: state.ConfigReducer.base_link_url,
+    canonical_url: state.MetaReducer.canonical_url,
 });
 
 /** @namespace Component/Router/Container/mapDispatchToProps */
@@ -139,6 +140,7 @@ export class RouterContainer extends PureComponent<RouterContainerProps, RouterC
                 title_suffix,
                 meta_title,
                 status_code,
+                canonical_url,
             } = this.props;
 
             updateMeta({
@@ -151,6 +153,7 @@ export class RouterContainer extends PureComponent<RouterContainerProps, RouterC
                 title_prefix,
                 title_suffix,
                 status_code,
+                canonical_url,
             });
         }
     }

--- a/packages/scandipwa/src/component/Router/Router.type.ts
+++ b/packages/scandipwa/src/component/Router/Router.type.ts
@@ -30,6 +30,7 @@ export interface RouterContainerMapStateProps {
     isBigOffline: boolean;
     status_code?: string;
     base_link_url: string;
+    canonical_url?: string;
 }
 
 export interface RouterContainerMapDispatchProps {

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.tsx
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.tsx
@@ -596,8 +596,29 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
         }
     }
 
+    getCanonicalWithPageNumber(canonical_url?: string) {
+        if (!canonical_url) {
+            return null;
+        }
+
+        const pageNumber = getQueryParam('page', history?.location);
+
+        if (pageNumber) {
+            return canonical_url.concat(`?page=${pageNumber}`);
+        }
+
+        return canonical_url;
+    }
+
     updateMeta(): void {
-        const { updateMetaFromCategory, category } = this.props;
+        const {
+            updateMetaFromCategory,
+            category,
+            category: {
+                canonical_url,
+            } = {},
+        } = this.props;
+
         const meta_robots = history.location.search
             ? ''
             : 'follow, index';
@@ -605,6 +626,7 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
         updateMetaFromCategory({
             ...category,
             meta_robots,
+            canonical_url: this.getCanonicalWithPageNumber(canonical_url),
         });
     }
 

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.tsx
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.tsx
@@ -231,6 +231,7 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
             },
             currentArgs: {
                 filter,
+                currentPage,
             } = {},
         } = this.props;
 
@@ -245,6 +246,7 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
             },
             currentArgs: {
                 filter: prevFilter,
+                currentPage: prevPage,
             } = {},
         } = prevProps;
 
@@ -280,7 +282,9 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
          * Or if the breadcrumbs were not yet updated after category request,
          * and the category ID expected to load was loaded, update data.
          */
-        const categoryChange = id !== prevId || (!breadcrumbsWereUpdated && id === categoryIds);
+        const categoryChange = id !== prevId
+            || (!breadcrumbsWereUpdated && id === categoryIds)
+            || currentPage !== prevPage;
 
         if (categoryChange) {
             this.checkIsActive();


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://scandiflow.atlassian.net/browse/TEAMS-585

**Problem:**
* Category pages with page URL parameters didn't have self-canonical URLs. This caused search engines to treat the paginated pages as duplicate pages.
* [Self-reported] Sometimes, canonical URLs get deleted if navigating page with refresh, because router update overrides it

**In this PR:**
* Made canonical URL include page parameter for categories.
* Fixed issue with canonical being deleted by router update
