### PR TITLE
TEAMS-771 - remove blinking when navigation between categories

### DIFF
--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.tsx
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.tsx
@@ -103,8 +103,11 @@ export class UrlRewritesComponent extends PureComponent<UrlRewritesComponentProp
             categoryIds,
             displayMode,
             location,
-            sort_by,
+            // sort_by,
+            category_sort,
         } = props;
+
+        console.log('>>> sss', category_sort);
 
         return (
             <Suspense fallback={ this.renderDefaultPage() }>
@@ -113,7 +116,7 @@ export class UrlRewritesComponent extends PureComponent<UrlRewritesComponentProp
                   categoryIds={ categoryIds }
                   displayMode={ displayMode }
                   location={ location }
-                  categoryDefaultSortBy={ sort_by }
+                  categoryDefaultSortBy={ category_sort }
                 />
             </Suspense>
         );

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.tsx
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.component.tsx
@@ -103,11 +103,8 @@ export class UrlRewritesComponent extends PureComponent<UrlRewritesComponentProp
             categoryIds,
             displayMode,
             location,
-            // sort_by,
             category_sort,
         } = props;
-
-        console.log('>>> sss', category_sort);
 
         return (
             <Suspense fallback={ this.renderDefaultPage() }>

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.tsx
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.tsx
@@ -37,6 +37,7 @@ export const mapStateToProps = (state: RootState): UrlRewritesContainerMapStateP
     urlRewrite: state.UrlRewritesReducer.urlRewrite,
     isLoading: state.UrlRewritesReducer.isLoading,
     requestedUrl: state.UrlRewritesReducer.requestedUrl,
+    category_sort: state.ProductListReducer.currentArgs.sort?.sortKey,
 });
 
 /** @namespace Route/UrlRewrites/Container/mapDispatchToProps */
@@ -207,11 +208,13 @@ export class UrlRewritesContainer extends PureComponent<UrlRewritesContainerProp
         const {
             match,
             location,
+            category_sort,
         } = this.props;
 
         return {
             match,
             location,
+            category_sort,
             ...this.getTypeSpecificProps(),
         };
     }

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.type.ts
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.type.ts
@@ -20,7 +20,6 @@ export interface UrlRewritesContainerMapStateProps {
     isLoading: boolean;
     requestedUrl: string;
     category_sort?: string;
-
 }
 
 export interface UrlRewritesContainerMapDispatchProps {

--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.type.ts
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.type.ts
@@ -19,6 +19,8 @@ export interface UrlRewritesContainerMapStateProps {
     urlRewrite: UrlRewrite;
     isLoading: boolean;
     requestedUrl: string;
+    category_sort?: string;
+
 }
 
 export interface UrlRewritesContainerMapDispatchProps {
@@ -43,6 +45,7 @@ export type UrlRewritesContainerPropsKeys = 'type'
 export type UrlRewriteProps = Partial<UrlRewriteTypeSpecificProps> & {
     match: Match;
     location: Location<HistoryState>;
+    category_sort?: string;
 };
 
 export interface UrlRewriteTypeSpecificProps {

--- a/packages/scandipwa/src/store/ProductList/ProductList.dispatcher.ts
+++ b/packages/scandipwa/src/store/ProductList/ProductList.dispatcher.ts
@@ -62,8 +62,6 @@ ProductListDispatcherData
         const { args = {}, isNext } = options;
         const { currentPage = 0 } = args;
 
-        dispatch(updateLoadStatus(false));
-
         if (isNext) {
             return dispatch(
                 appendPage(


### PR DESCRIPTION
**Related issue(s):**
* Fixes [[link for issue](https://scandiflow.atlassian.net/browse/TEAMS-771)]

**Problem:**
* [product cards blinks when navigation between categories]

**In this PR:**
* [the issue was due to the sort_by value the has 2 possible values so instead of it used sort key coming from productList Reducer but this seems to fix the issue but not sure if this it provide the wanted value]
