### PR TITLE
TEAMS-773 - fixed PDP blinking when navigating from PLP to PDP

### DIFF
--- a/packages/scandipwa/src/component/ProductGallery/ProductGallery.component.tsx
+++ b/packages/scandipwa/src/component/ProductGallery/ProductGallery.component.tsx
@@ -414,6 +414,30 @@ export class ProductGalleryComponent extends PureComponent<ProductGalleryCompone
         return url;
     }
 
+    renderPlaceholderImage(): ReactElement {
+        const { activeImage } = this.props;
+
+        const {
+            state: {
+                state: {
+                    product: { small_image: { url } },
+                },
+            },
+        } = history;
+
+        return (
+            <Image
+              src={ url }
+              ratio={ ImageRatio.IMG_CUSTOM }
+              mix={ {
+                  block: 'ProductGallery',
+                  elem: 'SliderImage',
+                  mods: { isHidden: activeImage !== undefined },
+              } }
+            />
+        );
+    }
+
     renderSlider(): ReactElement {
         const {
             gallery,
@@ -451,6 +475,7 @@ export class ProductGalleryComponent extends PureComponent<ProductGalleryCompone
                   sliderHeight={ isImageZoomPopupActive ? '100%' : 0 }
                   isHeightTransitionDisabledOnMount
                 >
+                    { this.renderPlaceholderImage() }
                     { gallery.map(this.renderSlide) }
                 </Slider>
             </div>

--- a/packages/scandipwa/src/component/ProductGallery/ProductGallery.component.tsx
+++ b/packages/scandipwa/src/component/ProductGallery/ProductGallery.component.tsx
@@ -33,6 +33,7 @@ import VideoThumbnail from 'Component/VideoThumbnail';
 import { MediaGalleryEntry } from 'Query/ProductList.type';
 import { ReactElement } from 'Type/Common.type';
 import CSS from 'Util/CSS';
+import history from 'Util/History';
 import { setLoadedFlag } from 'Util/Request/LowPriorityLoad';
 import { lowPriorityLazy } from 'Util/Request/LowPriorityRender';
 
@@ -418,12 +419,12 @@ export class ProductGalleryComponent extends PureComponent<ProductGalleryCompone
         const { activeImage } = this.props;
 
         const {
-            state: {
+            location: {
                 state: {
-                    product: { small_image: { url } },
-                },
-            },
-        } = history;
+                    product: { small_image: { url = '' } = {} } = {},
+                } = {},
+            } = {},
+        } = history ?? {};
 
         return (
             <Image

--- a/packages/scandipwa/src/component/ProductGallery/ProductGallery.style.scss
+++ b/packages/scandipwa/src/component/ProductGallery/ProductGallery.style.scss
@@ -90,5 +90,10 @@
     &-SliderImage {
         height: 100%;
         width: 100%;
+
+        &_isHidden {
+            position: absolute;
+            z-index: -1100;
+        }
     }
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes [[link for issue](https://scandiflow.atlassian.net/browse/TEAMS-773)]

**Problem:**
* Product gallery blinks when going from PLP to PDP.

**In this PR:**
* Added an already loaded image from PLP until the product image loads in product Slider
