### PR TITLE
TEAMS-772 - fixed Category info on selecting filters

### DIFF
--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.tsx
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.tsx
@@ -16,6 +16,7 @@ import { Dispatch } from 'redux';
 import UrlRewritesDispatcher from 'Store/UrlRewrites/UrlRewrites.dispatcher';
 import { ReactElement } from 'Type/Common.type';
 import history from 'Util/History';
+import { waitForPriorityLoad } from 'Util/Request/LowPriorityLoad';
 import { RootState } from 'Util/Store/Store.type';
 
 import UrlRewrites from './UrlRewrites.component';
@@ -59,9 +60,11 @@ export class UrlRewritesContainer extends PureComponent<UrlRewritesContainerProp
     initialUrl = '';
 
     componentDidMount(): void {
-        if (this.getIsLoading()) {
-            this.requestUrlRewrite();
-        }
+        waitForPriorityLoad().then(
+            /** @namespace Route/UrlRewrites/Container/UrlRewritesContainer/componentDidMount/waitForPriorityLoad/then */
+            () => this.requestUrlRewrite(),
+        );
+        this.initialUrl = location.pathname;
 
         this.initialUrl = location.pathname;
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes [[link for issue](https://scandiflow.atlassian.net/browse/TEAMS-772)]

**Problem:**
* when choosing filter from customer filter it cause infinite placeholders on PLP and this happens only if direct links

**In this PR:**
* the issue that i found is that on direct links UrlRewrites is intialized correctly on mounting with direct links so i removed the condition on it and low prioritize it 
