### PR TITLE
TEAMS-851 - removed redundant action on myAccountOverlay mounting

### DIFF
--- a/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.tsx
+++ b/packages/scandipwa/src/component/MyAccountOverlay/MyAccountOverlay.container.tsx
@@ -91,9 +91,7 @@ State extends MyAccountOverlayContainerState = MyAccountOverlayContainerState,
 
     __construct(props: MyAccountOverlayContainerProps): void {
         super.__construct?.(props);
-        const { showOverlay } = props;
 
-        showOverlay(CUSTOMER_ACCOUNT_OVERLAY_KEY);
         this.state = this.redirectOrGetState(props) as State;
     }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes [[link for issue](https://scandiflow.atlassian.net/browse/TEAMS-851)]

**Problem:**
* MyAccount icons doesn't open with first click

**In this PR:**
* removed the unnecessary toggle at component mounting
