### PR TITLE
TEAMS-860 - fixed issues with UrlRewrites initialization

### DIFF
--- a/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.tsx
+++ b/packages/scandipwa/src/route/UrlRewrites/UrlRewrites.container.tsx
@@ -16,6 +16,7 @@ import { Dispatch } from 'redux';
 import UrlRewritesDispatcher from 'Store/UrlRewrites/UrlRewrites.dispatcher';
 import { ReactElement } from 'Type/Common.type';
 import history from 'Util/History';
+import { waitForPriorityLoad } from 'Util/Request/LowPriorityLoad';
 import { RootState } from 'Util/Store/Store.type';
 
 import UrlRewrites from './UrlRewrites.component';
@@ -59,9 +60,10 @@ export class UrlRewritesContainer extends PureComponent<UrlRewritesContainerProp
     initialUrl = '';
 
     componentDidMount(): void {
-        if (this.getIsLoading()) {
-            this.requestUrlRewrite();
-        }
+        waitForPriorityLoad().then(
+            /** @namespace Route/UrlRewrites/Container/UrlRewritesContainer/componentDidMount/waitForPriorityLoad/then */
+            () => this.requestUrlRewrite(),
+        );
 
         this.initialUrl = location.pathname;
     }


### PR DESCRIPTION
**Related issue(s):**
* Fixes [[link for issue](https://scandiflow.atlassian.net/browse/TEAMS-860)]

**Problem:**
* "Products are loading..." label stays visible all the time although the products are loaded

**In this PR:**
* [Say what you changed]
