### PR TITLE
TEAMS-593 core, fixed breadcrumb content

### DIFF
--- a/packages/m2-theme/public/index.php
+++ b/packages/m2-theme/public/index.php
@@ -55,6 +55,7 @@ $icons = $this->getAppIconData();
         window.storeList = JSON.parse(`<?= $this->getStoreListJson() ?>`).sort().reverse();
         window.storeRegexText = `/(${window.storeList.join('|')})?`;
         window.website_code = '<?= $this->getWebsiteCode() ?>';
+        window.base_link_url = '<?= $this->getBaseLinkUrl() ?>';
         window.metaHtml = `
             <!-- Manifest -->
             <link rel="manifest" href="/media/webmanifest/manifest.json">

--- a/packages/scandipwa/src/component/Breadcrumbs/Breadcrumbs.component.tsx
+++ b/packages/scandipwa/src/component/Breadcrumbs/Breadcrumbs.component.tsx
@@ -54,13 +54,16 @@ export class BreadcrumbsComponent extends PureComponent<BreadcrumbsComponentProp
     }
 
     shouldHideBreadcrumbs(): boolean {
-        const { areBreadcrumbsVisible } = this.props;
-        const { pathname = appendWithStoreCode('/') } = location;
+        const {
+            areBreadcrumbsVisible,
+            baseUrl = window.base_link_url,
+        } = this.props;
+        const { pathname = appendWithStoreCode('/', baseUrl) } = location;
 
         return !!(
             !areBreadcrumbsVisible
-            || pathname.match(appendWithStoreCode(CheckoutStepUrl.CHECKOUT_URL))
-            || isHomePageUrl(pathname)
+            || pathname.match(appendWithStoreCode(CheckoutStepUrl.CHECKOUT_URL, baseUrl))
+            || isHomePageUrl(pathname, baseUrl)
         );
     }
 

--- a/packages/scandipwa/src/component/Breadcrumbs/Breadcrumbs.container.tsx
+++ b/packages/scandipwa/src/component/Breadcrumbs/Breadcrumbs.container.tsx
@@ -9,20 +9,56 @@
  * @link https://github.com/scandipwa/scandipwa
  */
 
+import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import { RootState } from 'Util/Store/Store.type';
 
-import Breadcrumbs from './Breadcrumbs.component';
-import { BreadcrumbsContainerMapDispatchProps, BreadcrumbsContainerMapStateProps } from './Breadcrumbs.type';
+import BreadcrumbsComponent from './Breadcrumbs.component';
+import {
+    BreadcrumbsComponentProps, BreadcrumbsContainerMapDispatchProps, BreadcrumbsContainerMapStateProps, BreadcrumbsContainerProps, BreadcrumbsContainerPropsKeys,
+} from './Breadcrumbs.type';
 
 /** @namespace Component/Breadcrumbs/Container/mapStateToProps */
 export const mapStateToProps = (state: RootState): BreadcrumbsContainerMapStateProps => ({
     breadcrumbs: state.BreadcrumbsReducer.breadcrumbs,
     areBreadcrumbsVisible: state.BreadcrumbsReducer.areBreadcrumbsVisible,
+    baseUrl: state.ConfigReducer.base_link_url,
 });
 
 /** @namespace Component/Breadcrumbs/Container/mapDispatchToProps */
 export const mapDispatchToProps = (): BreadcrumbsContainerMapDispatchProps => ({});
 
-export default connect(mapStateToProps, mapDispatchToProps)(Breadcrumbs);
+/**
+ * Breadcrumbs
+ * @class Breadcrumbs
+ * @namespace Component/Breadcrumbs/Container
+ */
+export class BreadcrumbsContainer extends PureComponent<BreadcrumbsContainerProps> {
+    containerFunctions = {};
+
+    containerProps(): Pick<BreadcrumbsComponentProps, BreadcrumbsContainerPropsKeys> {
+        const {
+            breadcrumbs,
+            areBreadcrumbsVisible,
+            baseUrl,
+        } = this.props;
+
+        return {
+            breadcrumbs,
+            areBreadcrumbsVisible,
+            baseUrl,
+        };
+    }
+
+    render() {
+        return (
+            <BreadcrumbsComponent
+              { ...this.containerProps() }
+              { ...this.containerFunctions }
+            />
+        );
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(BreadcrumbsContainer);

--- a/packages/scandipwa/src/component/Breadcrumbs/Breadcrumbs.type.ts
+++ b/packages/scandipwa/src/component/Breadcrumbs/Breadcrumbs.type.ts
@@ -14,9 +14,14 @@ import { Breadcrumb } from 'Store/Breadcrumbs/Breadcrumbs.type';
 export interface BreadcrumbsContainerMapStateProps {
     breadcrumbs: Breadcrumb[];
     areBreadcrumbsVisible: boolean;
+    baseUrl?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface BreadcrumbsContainerMapDispatchProps {}
 
 export type BreadcrumbsComponentProps = BreadcrumbsContainerMapStateProps & BreadcrumbsContainerMapDispatchProps;
+
+export type BreadcrumbsContainerProps = BreadcrumbsContainerMapStateProps & BreadcrumbsContainerMapDispatchProps;
+
+export type BreadcrumbsContainerPropsKeys = 'breadcrumbs' | 'areBreadcrumbsVisible' | 'baseUrl';

--- a/packages/scandipwa/src/type/Global.type.ts
+++ b/packages/scandipwa/src/type/Global.type.ts
@@ -46,6 +46,7 @@ declare global {
         contentConfiguration?: ContentConfiguration;
         prompt_event?: BeforeInstallPromptEvent;
         website_code: string;
+        base_link_url: string;
         storeCurrency: string;
         isPriorityLoaded: boolean;
         isPrefetchValueUsed?: boolean;

--- a/packages/scandipwa/src/util/Url/Url.ts
+++ b/packages/scandipwa/src/util/Url/Url.ts
@@ -87,8 +87,13 @@ export const replace = (regex: RegExp, path: string): string => {
  * @param {String} pathname the URL to append store code to
  * @namespace Util/Url/appendWithStoreCode
  */
-export const appendWithStoreCode = (pathname: string): string => {
-    const { ConfigReducer: { base_link_url = window.location.href } = {} } = getStoreState();
+export const appendWithStoreCode = (pathname: string, baseUrl?: string): string => {
+    const {
+        ConfigReducer: {
+            base_link_url = baseUrl || window.location.href,
+        } = {},
+    } = getStoreState();
+
     const { pathname: storePrefix } = new URL(base_link_url);
 
     if (!pathname) {
@@ -267,10 +272,10 @@ export const objectToUri = (keyValueObject: Record<string, string> = {}): string
 };
 
 /** @namespace Util/Url/isHomePageUrl */
-export const isHomePageUrl = (pathname: string): boolean => {
-    const isHomePage = pathname === appendWithStoreCode('/')
+export const isHomePageUrl = (pathname: string, baseUrl?: string): boolean => {
+    const isHomePage = pathname === appendWithStoreCode('/', baseUrl)
         || pathname === '/'
-        || pathname === appendWithStoreCode('')
+        || pathname === appendWithStoreCode('', baseUrl)
         || pathname === '';
 
     return isHomePage;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://scandiflow.atlassian.net/browse/TEAMS-593

**Problem:**
* On initial render, breadcrumbs might not have rendered, because URL check would fail due to not having base URL in props in time which was resolved from config request. 
* This was an issue, because site renderers like Prerender.io would capture page before breadcrumbs got chance to be rendered.

**In this PR:**
* Initial render condition for breadcrumbs component will be satisfied by having `base_link_url` fallback available in initially rendered page. This should make breadcrumb render as soon as possible and decrease possibility of not being captured on early page snapshots.

**Related PR;**
* https://github.com/scandipwa/customization/pull/35
