### PR TITLE
TEAMS-905: fix query parameter from url

### DIFF
--- a/packages/scandipwa/src/util/Url/Url.ts
+++ b/packages/scandipwa/src/util/Url/Url.ts
@@ -113,7 +113,7 @@ export const appendWithStoreCode = (pathname: string): string => {
  */
 export const getQueryParam = (variable: string, location: Location): string | false => {
     const query = decodeString(location.search.substring(1));
-    const vars = query.split('&');
+    const vars = query.split(/[?&]/);
 
     return vars.reduce((acc: string | false, item: string) => {
         const splitIdx = item.indexOf('=');


### PR DESCRIPTION
**Related issue(s):**
* Fixes [TEAMS-905](https://scandiflow.atlassian.net/browse/TEAMS-905)

**Problem:**
* PLP breaks when there are multiple parameters in the URL which start with "?"


[TEAMS-905]: https://scandiflow.atlassian.net/browse/TEAMS-905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ