### PR TITLE
fix html component issue with parsing `data-content-type`

### DIFF
--- a/packages/scandipwa/src/component/Html/Html.component.tsx
+++ b/packages/scandipwa/src/component/Html/Html.component.tsx
@@ -222,11 +222,23 @@ export class HtmlComponent extends PureComponent<HtmlComponentProps> {
     }
 
     replaceDiv({ attribs, children }: DomElement): JSX.Element {
-        return (
-            <div { ...attribs }>
-                { domToReact(children, this.parserOptions) }
-            </div>
-        );
+        const dataContentType = attribs['data-content-type'] || '';
+
+        switch (dataContentType) {
+        case 'html':
+            return (
+                <div>
+                    { children.length && children.map(({ data = '' }) => parser(data, this.parserOptions)) }
+                </div>
+            );
+
+        default:
+            return (
+                <div { ...attribs }>
+                    { domToReact(children, this.parserOptions) }
+                </div>
+            );
+        }
     }
 
     /**


### PR DESCRIPTION


**Problem:**
* Resolved an issue when HTML component unable to parser some CMS blocks when they are being sent as a value for `data-content-type=html`

**In this PR:**
* made a case to handle `data-content-type=html`
