### PR TITLE
TEAMS-920 - fix unnecessary escape for "customFilters"

### DIFF
--- a/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.container.tsx
+++ b/packages/scandipwa/src/component/CategoryFilterOverlay/CategoryFilterOverlay.container.tsx
@@ -93,7 +93,7 @@ export class CategoryFilterOverlayContainer extends PureComponent<CategoryFilter
 
     _getSelectedFiltersFromUrl(): Record<string, string[]> {
         const { location } = history;
-        const selectedFiltersString = (getQueryParam('customFilters', location) || '').split(';');
+        const selectedFiltersString = (getQueryParam('customFilters', location, false) || '').split(';');
 
         return selectedFiltersString.reduce((acc, filter) => {
             if (!filter) {

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.tsx
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.container.tsx
@@ -456,7 +456,7 @@ S extends CategoryPageContainerState = CategoryPageContainerState,
 
     getSelectedFiltersFromUrl(): Record<string, string[]> {
         const { location } = history;
-        const selectedFiltersString = (getQueryParam('customFilters', location) || '').split(';');
+        const selectedFiltersString = (getQueryParam('customFilters', location, false) || '').split(';');
 
         return selectedFiltersString.reduce((acc, filter) => {
             if (!filter) {

--- a/packages/scandipwa/src/util/Preload/CategoryPreload.ts
+++ b/packages/scandipwa/src/util/Preload/CategoryPreload.ts
@@ -47,7 +47,7 @@ export class CategoryPreload {
 
     getSelectedFiltersFromUrl() {
         const { location } = history;
-        const selectedFiltersString = (getQueryParam('customFilters', location) || '').split(';');
+        const selectedFiltersString = (getQueryParam('customFilters', location, false) || '').split(';');
 
         return selectedFiltersString.reduce((acc, filter) => {
             if (!filter) {

--- a/packages/scandipwa/src/util/Url/Url.ts
+++ b/packages/scandipwa/src/util/Url/Url.ts
@@ -108,10 +108,15 @@ export const appendWithStoreCode = (pathname: string): string => {
  * Get query variable value (from react router)
  * @param {String} variable Variable from URL
  * @param {Object} location location object from react-router
+ * @param {Boolean} isReplaceEqual condition to replace equal sign
  * @return {String|false} Variable value
  * @namespace Util/Url/getQueryParam
  */
-export const getQueryParam = (variable: string, location: Location): string | false => {
+export const getQueryParam = (
+    variable: string,
+    location: Location,
+    isReplaceEqual: boolean = true,
+): string | false => {
     const query = decodeString(location.search.substring(1));
     const vars = query.split('&');
 
@@ -119,7 +124,11 @@ export const getQueryParam = (variable: string, location: Location): string | fa
         const splitIdx = item.indexOf('=');
         const [k, v] = [item.slice(0, splitIdx), item.slice(splitIdx + 1)];
 
-        return k === variable ? v.replace(/=/g, ':') : acc;
+        if (k !== variable) {
+            return acc;
+        }
+
+        return isReplaceEqual ? v.replace(/=/g, ':') : v;
     }, false);
 };
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes `category_uid` escape issue from the URL

**Problem:**
* `category_uid` can't be processed correctly because of incorrect escape of `=` signs.

**In this PR:**
* prevent the escape of `customFilters` param
