### PR TITLE
TEAMS-926 added head_scripts to index.php

### DIFF
--- a/packages/m2-theme/public/index.php
+++ b/packages/m2-theme/public/index.php
@@ -5,6 +5,7 @@ $description = $this->getThemeConfiguration('design/head/default_description');
 $themeColor = $this->getThemeConfiguration('webmanifest_customization/webmanifest/theme_color');
 $layoutDirection = $this->getThemeConfiguration('layout_direction_configuration/layout_direction_section/layout_direction') ?: 'ltr';
 $icons = $this->getAppIconData();
+$head_scripts = $this->getThemeConfiguration('design/head/includes');
 ?>
 <!DOCTYPE html>
 <html lang="<?= $this->getLanguageCode() ?>" dir="<?= $layoutDirection ?>">
@@ -17,7 +18,8 @@ $icons = $this->getAppIconData();
     <link rel="preload" href="https://use.typekit.net/fji5tuz.css" as="style"> -->
 
     <meta name="theme-color" content="#<?= $themeColor ?: 'ffffff' ?>">
-
+    <?= $head_scripts ?>
+    
     <script>
         (function() {
             if (typeof globalThis === 'object') return;


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://scandiflow.atlassian.net/browse/TEAMS-926

**Problem:**
* Including `head_scripts` into scandipwa is another recurrent task done by SEO team. `head_scripts` allows for inserting scripts from admin configuration.

**In this PR:**
* extended `index.php` from m2 theme to include `head_scripts`
