### PR TITLE
TEAMS-912 - disabled default scrollRestoration and modified current s…

### DIFF
--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.config.ts
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.config.ts
@@ -10,6 +10,7 @@
  */
 
 export const LOADING_TIME = 500;
+export const SCROLL_DEBOUNCE_TIME = 300;
 export const LAYOUT_KEY = 'layout';
 
 export enum CategoryDisplayMode {

--- a/packages/scandipwa/src/route/CategoryPage/CategoryPage.type.ts
+++ b/packages/scandipwa/src/route/CategoryPage/CategoryPage.type.ts
@@ -43,6 +43,7 @@ export interface CategoryPageContainerMapStateProps {
     totalItems: number;
     plpType: string;
     isMobile: boolean;
+    scrollPosition?: number;
 }
 
 export interface CategoryPageContainerMapDispatchProps {
@@ -57,6 +58,7 @@ export interface CategoryPageContainerMapDispatchProps {
     setBigOfflineNotice: (isBig: boolean) => void;
     updateMetaFromCategory: (category: MetaCategory) => void;
     clearCategory: () => void;
+    setScrollPosition: (scrollPosition: number) => void;
 }
 
 export interface CategoryPageContainerFunctions {

--- a/packages/scandipwa/src/store/Category/Category.action.ts
+++ b/packages/scandipwa/src/store/Category/Category.action.ts
@@ -14,6 +14,7 @@ import { Category } from 'Query/Category.type';
 
 import {
     CategoryActionType,
+    SetScrollPositionyAction,
     UpdateCurrentCategoryAction,
 } from './Category.type';
 
@@ -28,4 +29,10 @@ export const updateCurrentCategory = (
 ): UpdateCurrentCategoryAction => ({
     type: CategoryActionType.UPDATE_CURRENT_CATEGORY,
     category,
+});
+
+/** @namespace Store/Category/Action/setScrollPosition */
+export const setScrollPosition = (lastScrollPosition: number): SetScrollPositionyAction => ({
+    type: CategoryActionType.SET_SCROLL_POSITION,
+    payload: lastScrollPosition,
 });

--- a/packages/scandipwa/src/store/Category/Category.reducer.ts
+++ b/packages/scandipwa/src/store/Category/Category.reducer.ts
@@ -12,29 +12,36 @@
 import { Reducer } from 'redux';
 
 import {
+    CategoryAction,
     CategoryActionType,
     CategoryStore,
-    UpdateCurrentCategoryAction,
 } from './Category.type';
 
 /** @namespace Store/Category/Reducer/getInitialState */
 export const getInitialState = (): CategoryStore => ({
     category: {},
+    scrollPosition: 0,
 });
 
 /** @namespace Store/Category/Reducer/CategoryReducer */
 export const CategoryReducer: Reducer<
 CategoryStore,
-UpdateCurrentCategoryAction
+CategoryAction
 > = (
     state = getInitialState(),
-    { type, category },
+    action,
 ) => {
-    switch (type) {
+    switch (action.type) {
     case CategoryActionType.UPDATE_CURRENT_CATEGORY:
         return {
             ...state,
-            category: { ...category },
+            category: { ...action.category },
+        };
+
+    case CategoryActionType.SET_SCROLL_POSITION:
+        return {
+            ...state,
+            scrollPosition: action.payload,
         };
 
     default:

--- a/packages/scandipwa/src/store/Category/Category.type.ts
+++ b/packages/scandipwa/src/store/Category/Category.type.ts
@@ -14,6 +14,7 @@ import { Category } from 'Query/Category.type';
 
 export enum CategoryActionType {
     UPDATE_CURRENT_CATEGORY = 'UPDATE_CURRENT_CATEGORY',
+    SET_SCROLL_POSITION = 'SET_SCROLL_POSITION',
 }
 
 export interface UpdateCurrentCategoryAction extends AnyAction {
@@ -21,8 +22,16 @@ export interface UpdateCurrentCategoryAction extends AnyAction {
     category?: Partial<Category>;
 }
 
+export interface SetScrollPositionyAction extends AnyAction {
+    type: CategoryActionType.SET_SCROLL_POSITION;
+    payload: number;
+}
+
+export type CategoryAction = UpdateCurrentCategoryAction | SetScrollPositionyAction;
+
 export interface CategoryStore {
     category: Partial<Category>;
+    scrollPosition: number;
 }
 
 declare module 'Util/Store/Store.type' {


### PR DESCRIPTION
…croll logic on PLP

**Related issue(s):**
* Fixes [[912](https://scandiflow.atlassian.net/browse/TEAMS-912)]

**Problem:**
* [Describe the problem briefly]

**In this PR:**
* disabled default scroll restoration because it in some how buggy or maybe need some calculations and provided a smooth scroll restoration for PLP only (rest of pages have default scroll restoration)
