### PR TITLE
PERF-49 - added sharedTransition component and fixed sharedTransition…

### DIFF
--- a/packages/scandipwa/src/component/SharedTransition/SharedTransition.component.tsx
+++ b/packages/scandipwa/src/component/SharedTransition/SharedTransition.component.tsx
@@ -1,0 +1,125 @@
+// @ts-nocheck
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/scandipwa
+ * @link https://github.com/scandipwa/scandipwa
+ */
+
+import { createRef, PureComponent } from 'react';
+
+import { ReactElement } from 'Type/Common.type';
+
+import { SHARED_ELEMENT_TRANSITION } from './SharedTransition.config';
+import { SharedTransitionComponentProps } from './SharedTransition.type';
+
+import './SharedTransition.style';
+
+/** @namespace Component/SharedTransition/Component */
+export class SharedTransitionComponent extends PureComponent<SharedTransitionComponentProps> {
+    sharedContainer = createRef<HTMLDivElement>();
+
+    animationSpeed = SHARED_ELEMENT_TRANSITION;
+
+    transitionInAction = false;
+
+    setDestinationTransform = this.setTransform.bind(this, 'destinationPosition');
+
+    setStartingTransform = this.setTransform.bind(this, 'startingPosition');
+
+    __construct(props: SharedTransitionComponentProps): void {
+        super.__construct?.(props);
+
+        this.cleanUpTransition = this.cleanUpTransition.bind(this);
+    }
+
+    componentDidUpdate(): void {
+        if (this.transitionInAction) {
+            return;
+        }
+
+        this.updateSharedElement();
+    }
+
+    setTransform(key: 'startingPosition' | 'destinationPosition'): void {
+        const {
+            state: {
+                [key]: {
+                    width,
+                    height,
+                    left,
+                    top,
+                },
+            },
+        } = this.props;
+
+        if (this.sharedContainer.current) {
+            this.sharedContainer.current.style.cssText = `
+                --shared-element-width: ${width}px;
+                --shared-element-height: ${height}px;
+                --shared-element-top: ${top}px;
+                --shared-element-start: ${left}px;
+                --shared-element-animation-speed: ${this.animationSpeed}ms;
+            `;
+        }
+    }
+
+    cleanUpTransition(): void {
+        const { current: wrapper } = this.sharedContainer;
+        const { cleanUpTransition } = this.props;
+
+        if (wrapper) {
+            const range = document.createRange();
+
+            range.selectNodeContents(wrapper);
+            range.deleteContents();
+        }
+
+        this.transitionInAction = false;
+        cleanUpTransition();
+    }
+
+    updateSharedElement(): void {
+        const {
+            state: {
+                sharedElementDestination,
+                sharedElement,
+            },
+        } = this.props;
+
+        const { current: wrapper } = this.sharedContainer;
+
+        if (
+            !sharedElement
+            || !sharedElementDestination
+            || !wrapper
+        ) {
+            // this.cleanUpTransition();
+            return;
+        }
+
+        this.transitionInAction = true;
+        this.setStartingTransform();
+        wrapper.appendChild(sharedElement);
+        setTimeout(this.setDestinationTransform, 0);
+        setTimeout(this.cleanUpTransition, this.animationSpeed);
+    }
+
+    render(): ReactElement {
+        const { state: { sharedElement } } = this.props;
+
+        return (
+            <div
+              block="SharedTransition"
+              mods={ { isVisible: !!sharedElement } }
+              ref={ this.sharedContainer }
+            />
+        );
+    }
+}
+
+export default SharedTransitionComponent;

--- a/packages/scandipwa/src/component/SharedTransition/SharedTransition.config.ts
+++ b/packages/scandipwa/src/component/SharedTransition/SharedTransition.config.ts
@@ -1,0 +1,16 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/scandipwa
+ * @link https://github.com/scandipwa/scandipwa
+ */
+
+export const SHARED_ELEMENT_TRANSITION = 250;
+
+export const PRODUCT_GALLERY_SLIDER_CLASS_NAME = 'ProductGallery-SliderWrapper';
+
+export const HEADER_HEIGHT = 60;

--- a/packages/scandipwa/src/component/SharedTransition/SharedTransition.container.tsx
+++ b/packages/scandipwa/src/component/SharedTransition/SharedTransition.container.tsx
@@ -1,0 +1,36 @@
+// @ts-nocheck
+/* eslint-disable @scandipwa/scandipwa-guidelines/jsx-no-props-destruction */
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/scandipwa
+ * @link https://github.com/scandipwa/scandipwa
+ */
+
+// TODO: implement props passing
+
+import { Subscribe } from 'unstated-typescript';
+
+import SharedTransition from './SharedTransition.component';
+import SharedTransitionContainer from './SharedTransition.unstated';
+
+/** @namespace Component/SharedTransition/Container/SharedTransitionWrapper */
+export function SharedTransitionWrapper(props: Record<string, any>): JSX.Element {
+    return (
+        <Subscribe to={ [SharedTransitionContainer] }>
+            { (sharedTransition) => (
+                <SharedTransition
+                  { ...props }
+                  { ...sharedTransition }
+                />
+            ) }
+        </Subscribe>
+    );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default SharedTransitionWrapper;

--- a/packages/scandipwa/src/component/SharedTransition/SharedTransition.style.scss
+++ b/packages/scandipwa/src/component/SharedTransition/SharedTransition.style.scss
@@ -1,0 +1,58 @@
+/* stylelint-disable declaration-no-important */
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/scandipwa
+ * @link https://github.com/scandipwa/scandipwa
+ */
+
+.SharedTransition {
+    height: 100%;
+    width: 100%;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    position: fixed;
+    z-index: 75;
+    pointer-events: none;
+    opacity: 0;
+
+    &::after {
+        content: '';
+        position: absolute;
+        display: block;
+        height: calc(100vh - var(--header-height) - var(--navigation-tabs-height));
+        width: 100%;
+        inset-block-start: var(--header-total-height);
+        inset-inline-start: 0;
+    }
+
+    &_isVisible {
+        @include mobile {
+            pointer-events: all;
+            opacity: 1;
+            background: #fff;
+        }
+    }
+
+    > * {
+        padding: 0 !important;
+        margin: 0 !important;
+        inset-inline-start: 0 !important;
+        inset-block-start: 0 !important;
+        width: var(--shared-element-width, 0) !important;
+        height: var(--shared-element-height, 0) !important;
+        margin-block-start: var(--shared-element-top, 0) !important;
+        margin-inline-start: var(--shared-element-start, 0) !important;
+        will-change: width, height, margin-inline-start, margin-block-start;
+        transition-property: width, height, margin-inline-start, margin-block-start;
+        transition-timing-function: cubic-bezier(.215, .61, .355, 1);
+        transition-duration: var(--shared-element-animation-speed, 150ms);
+        backface-visibility: hidden;
+        transform: translate3d(0, 0, 0);
+        perspective: 1000px;
+    }
+}

--- a/packages/scandipwa/src/component/SharedTransition/SharedTransition.type.ts
+++ b/packages/scandipwa/src/component/SharedTransition/SharedTransition.type.ts
@@ -1,0 +1,29 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/scandipwa-theme
+ * @link https://github.com/scandipwa/scandipwa
+ */
+
+export interface SharedTransitionComponentProps {
+    state: SharedTransitionState;
+    cleanUpTransition: () => void;
+}
+
+export interface SharedTransitionState {
+    startingPosition: Partial<SharedTransitionPosition>;
+    destinationPosition: Partial<SharedTransitionPosition>;
+    sharedElementDestination: HTMLElement | null;
+    sharedElement: HTMLElement | null;
+}
+
+export interface SharedTransitionPosition {
+    width: number;
+    height: number;
+    left: number;
+    top: number;
+}

--- a/packages/scandipwa/src/component/SharedTransition/SharedTransition.unstated.ts
+++ b/packages/scandipwa/src/component/SharedTransition/SharedTransition.unstated.ts
@@ -1,0 +1,78 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/scandipwa
+ * @link https://github.com/scandipwa/scandipwa
+ */
+
+import { RefObject } from 'react';
+import { Container } from 'unstated-typescript';
+
+import { HEADER_HEIGHT, PRODUCT_GALLERY_SLIDER_CLASS_NAME } from './SharedTransition.config';
+import { SharedTransitionPosition, SharedTransitionState } from './SharedTransition.type';
+
+export const sharedTransitionInitialState: SharedTransitionState = {
+    sharedElementDestination: null,
+    sharedElement: null,
+    destinationPosition: {},
+    startingPosition: {},
+};
+
+/** @namespace Component/SharedTransition/Unstated */
+export class SharedTransitionUnstated extends Container<SharedTransitionState> {
+    state: SharedTransitionState = sharedTransitionInitialState;
+
+    __construct(): void {
+        this.registerSharedElementDestination = this.registerSharedElementDestination.bind(this);
+        this.registerSharedElement = this.registerSharedElement.bind(this);
+    }
+
+    _parseRectangle(val: DOMRect): SharedTransitionPosition {
+        return JSON.parse(JSON.stringify(val));
+    }
+
+    // eslint-disable-next-line @scandipwa/scandipwa-guidelines/no-arrow-functions-in-class
+    cleanUpTransition = (): void => {
+        this.setState(sharedTransitionInitialState);
+    };
+
+    registerSharedElementDestination({ current }: RefObject<HTMLElement>): void {
+        if (current) {
+            const isPdpDestination = current.classList.contains(PRODUCT_GALLERY_SLIDER_CLASS_NAME);
+
+            this.setState(({ sharedElementDestination }) => {
+                if (sharedElementDestination) {
+                    return {};
+                }
+
+                return {
+                    sharedElementDestination: current,
+                    destinationPosition: isPdpDestination ? {
+                        ...this._parseRectangle(current.getBoundingClientRect()),
+                        // to make sure animation will end at the correct position
+                        top: HEADER_HEIGHT,
+                    } : this._parseRectangle(current.getBoundingClientRect()),
+                };
+            });
+        }
+    }
+
+    registerSharedElement({ current }: RefObject<HTMLElement>): void {
+        if (current) {
+            const clone = current.cloneNode(true) as HTMLElement;
+
+            this.setState({
+                sharedElement: clone,
+                sharedElementDestination: null,
+                destinationPosition: {},
+                startingPosition: this._parseRectangle(current.getBoundingClientRect()),
+            });
+        }
+    }
+}
+
+export default new SharedTransitionUnstated();

--- a/packages/scandipwa/src/component/SharedTransition/index.ts
+++ b/packages/scandipwa/src/component/SharedTransition/index.ts
@@ -1,0 +1,12 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/scandipwa
+ * @link https://github.com/scandipwa/scandipwa
+ */
+
+export { default } from './SharedTransition.container';


### PR DESCRIPTION
**Related issue(s):**
* Fixes [[PERF-49](https://scandiflow.atlassian.net/browse/PERF-49)]

**Problem:**
* animation is busted when you try to go from PLP to PDP after scroll down due to wrong top property value

**In this PR:**
* added a top property with header height to final animation position

[PERF-49]: https://scandiflow.atlassian.net/browse/PERF-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ